### PR TITLE
docs: expand public API rustdoc across crates

### DIFF
--- a/crates/arco-blocks/src/dag.rs
+++ b/crates/arco-blocks/src/dag.rs
@@ -4,7 +4,10 @@ use std::collections::HashMap;
 
 use crate::error::BlockError;
 
-/// Dependency graph of blocks for determining execution order.
+/// Directed acyclic graph (DAG) representation for block scheduling.
+///
+/// The graph stores dependencies by block index, where each index maps back to
+/// the position in the `block_names` slice used to construct it.
 #[derive(Debug, Clone)]
 pub struct BlockDag {
     /// For each block index, which blocks it depends on.
@@ -12,10 +15,14 @@ pub struct BlockDag {
 }
 
 impl BlockDag {
-    /// Build a DAG from block names and links.
+    /// Build a dependency graph from block names and directed links.
     ///
     /// Links are `(source_block_name, target_block_name)` pairs,
-    /// meaning `target` depends on `source`.
+    /// meaning `target` depends on `source` and must execute after it.
+    ///
+    /// Returns [`BlockError::DuplicateBlock`] when `block_names` contains the
+    /// same name more than once, or [`BlockError::BlockNotFound`] when a link
+    /// references a block missing from `block_names`.
     pub fn from_links(
         block_names: &[String],
         links: &[(String, String)],
@@ -45,9 +52,10 @@ impl BlockDag {
         Ok(Self { dependencies })
     }
 
-    /// Return execution levels where blocks at each level can run in parallel.
+    /// Compute execution levels where each level can run in parallel.
     ///
-    /// Validates the DAG is acyclic before computing levels.
+    /// Validates the graph is acyclic before returning levels. When a cycle is
+    /// present, returns [`BlockError::CycleDetected`].
     pub fn execution_levels(&self) -> Result<Vec<Vec<usize>>, BlockError> {
         let num_blocks = self.dependencies.len();
         let mut indegree = self

--- a/crates/arco-blocks/src/error.rs
+++ b/crates/arco-blocks/src/error.rs
@@ -1,13 +1,13 @@
 //! Error types for block operations.
 
-/// Error type for block operations.
+/// Error type for block graph construction and execution planning.
 #[derive(Debug, Clone)]
 pub enum BlockError {
-    /// Block with this name already exists.
+    /// A block name appears more than once in an input collection.
     DuplicateBlock(String),
-    /// Block not found.
+    /// A link references a block name that is not present.
     BlockNotFound(String),
-    /// Cycle detected in block dependencies.
+    /// A cycle was found while validating dependencies.
     CycleDetected(String),
 }
 

--- a/crates/arco-expr/src/expr/constraint.rs
+++ b/crates/arco-expr/src/expr/constraint.rs
@@ -3,13 +3,18 @@
 use crate::expr::core::Expr;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Comparison operator used to form a model constraint.
 pub enum ComparisonSense {
+    /// Left-hand side is less than or equal to the right-hand side.
     LessEqual,
+    /// Left-hand side is greater than or equal to the right-hand side.
     GreaterEqual,
+    /// Left-hand side is exactly equal to the right-hand side.
     Equal,
 }
 
 impl ComparisonSense {
+    /// Returns the compact solver-facing token (`"le"`, `"ge"`, or `"eq"`).
     pub fn as_str(self) -> &'static str {
         match self {
             ComparisonSense::LessEqual => "le",
@@ -20,6 +25,7 @@ impl ComparisonSense {
 }
 
 #[derive(Debug, Clone)]
+/// Normalized constraint expression in the form `expr (sense) rhs`.
 pub struct ConstraintExpr {
     expr: Expr,
     sense: ComparisonSense,
@@ -27,22 +33,27 @@ pub struct ConstraintExpr {
 }
 
 impl ConstraintExpr {
+    /// Creates a constraint from a normalized expression, comparison sense, and RHS.
     pub fn new(expr: Expr, sense: ComparisonSense, rhs: f64) -> Self {
         Self { expr, sense, rhs }
     }
 
+    /// Returns the left-hand expression (typically with constant term removed).
     pub fn expr(&self) -> &Expr {
         &self.expr
     }
 
+    /// Returns the comparison sense.
     pub fn sense(&self) -> ComparisonSense {
         self.sense
     }
 
+    /// Returns the right-hand side scalar.
     pub fn rhs(&self) -> f64 {
         self.rhs
     }
 
+    /// Decomposes the constraint into `(expr, sense, rhs)`.
     pub fn into_parts(self) -> (Expr, ComparisonSense, f64) {
         (self.expr, self.sense, self.rhs)
     }

--- a/crates/arco-expr/src/expr/core.rs
+++ b/crates/arco-expr/src/expr/core.rs
@@ -13,6 +13,10 @@ use crate::ids::VariableId;
 use std::collections::BTreeMap;
 
 #[derive(Debug, Clone, Default)]
+/// Sparse polynomial expression split by degree plus a constant term.
+///
+/// Terms are stored in separate vectors for linear, quadratic, and cubic
+/// components to keep the hot path compact and predictable.
 pub struct Expr {
     constant: f64,
     linear: Vec<(VariableId, f64)>,
@@ -74,18 +78,22 @@ impl Expr {
 
     // ── Accessors ───────────────────────────────────────────
 
+    /// Returns the scalar constant term.
     pub fn constant(&self) -> f64 {
         self.constant
     }
 
+    /// Returns the raw linear terms `(var, coeff)` in insertion order.
     pub fn linear_terms(&self) -> &[(VariableId, f64)] {
         &self.linear
     }
 
+    /// Returns the raw quadratic terms `(var_a, var_b, coeff)`.
     pub fn quadratic_terms(&self) -> &[(VariableId, VariableId, f64)] {
         &self.quadratic
     }
 
+    /// Returns the raw cubic terms `(var_a, var_b, var_c, coeff)`.
     pub fn cubic_terms(&self) -> &[(VariableId, VariableId, VariableId, f64)] {
         &self.cubic
     }
@@ -194,35 +202,43 @@ impl Expr {
 
     // ── Comparison methods (produce ConstraintExpr) ─────────
 
+    /// Builds `self (sense) rhs`, moving this expression's constant to the RHS.
     pub fn compare_scalar(&self, rhs: f64, sense: ComparisonSense) -> ConstraintExpr {
         ConstraintExpr::new(self.without_constant(), sense, rhs - self.constant)
     }
 
+    /// Builds `self (sense) other` as a normalized single-sided constraint.
     pub fn compare_expr(&self, other: &Expr, sense: ComparisonSense) -> ConstraintExpr {
         let combined = self.add(&other.scale(-1.0));
         ConstraintExpr::new(combined.without_constant(), sense, -combined.constant)
     }
 
+    /// Convenience wrapper for `self <= rhs`.
     pub fn le_scalar(&self, rhs: f64) -> ConstraintExpr {
         self.compare_scalar(rhs, ComparisonSense::LessEqual)
     }
 
+    /// Convenience wrapper for `self >= rhs`.
     pub fn ge_scalar(&self, rhs: f64) -> ConstraintExpr {
         self.compare_scalar(rhs, ComparisonSense::GreaterEqual)
     }
 
+    /// Convenience wrapper for `self == rhs`.
     pub fn eq_scalar(&self, rhs: f64) -> ConstraintExpr {
         self.compare_scalar(rhs, ComparisonSense::Equal)
     }
 
+    /// Convenience wrapper for `self <= rhs_expr`.
     pub fn le_expr(&self, rhs: &Expr) -> ConstraintExpr {
         self.compare_expr(rhs, ComparisonSense::LessEqual)
     }
 
+    /// Convenience wrapper for `self >= rhs_expr`.
     pub fn ge_expr(&self, rhs: &Expr) -> ConstraintExpr {
         self.compare_expr(rhs, ComparisonSense::GreaterEqual)
     }
 
+    /// Convenience wrapper for `self == rhs_expr`.
     pub fn eq_expr(&self, rhs: &Expr) -> ConstraintExpr {
         self.compare_expr(rhs, ComparisonSense::Equal)
     }

--- a/crates/arco-expr/src/expr/error.rs
+++ b/crates/arco-expr/src/expr/error.rs
@@ -1,9 +1,13 @@
 //! Expression construction errors.
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Errors returned while building linear expressions from user input.
 pub enum LinearExprError {
+    /// Both paired `terms` and split `variables/coefficients` were provided.
     MixedInputs,
+    /// Required inputs were omitted for the selected construction style.
     MissingInputs,
+    /// `variables` and `coefficients` lengths differ.
     MismatchedLengths,
 }
 

--- a/crates/arco-expr/src/ids.rs
+++ b/crates/arco-expr/src/ids.rs
@@ -1,7 +1,10 @@
+//! Typed identifier wrappers used across Arco expression APIs.
+
 macro_rules! define_id_type {
     ($name:ident) => {
         #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
         #[repr(transparent)]
+        #[doc = concat!(stringify!($name), " is a compact, type-safe numeric identifier.")]
         pub struct $name(u32);
 
         impl $name {

--- a/crates/arco-expr/src/lib.rs
+++ b/crates/arco-expr/src/lib.rs
@@ -1,4 +1,7 @@
+//! Expression primitives and helpers for Arco models.
+
 pub mod expr;
+/// Lightweight typed identifiers used by expression and model APIs.
 pub mod ids;
 
 pub use expr::{ComparisonSense, ConstraintExpr, Expr, LinearExprError};

--- a/crates/arco-highs/src/ffi.rs
+++ b/crates/arco-highs/src/ffi.rs
@@ -593,23 +593,21 @@ impl HighsModel {
         // Call highs-sys directly: highs::Solution only exposes borrowed slices,
         // forcing an extra copy. Reading into owned vectors avoids that.
         let ptr = solved.as_ptr();
-        let num_cols_raw = unsafe { highs_sys::Highs_getNumCol(ptr) };
-        let num_rows_raw = unsafe { highs_sys::Highs_getNumRow(ptr) };
-        let (num_cols, num_rows) = checked_solution_dimensions(num_cols_raw, num_rows_raw)?;
+        let num_cols = usize::try_from(unsafe { highs_sys::Highs_getNumCol(ptr) }).unwrap_or(0);
+        let num_rows = usize::try_from(unsafe { highs_sys::Highs_getNumRow(ptr) }).unwrap_or(0);
         let mut col_values = vec![0.0; num_cols];
         let mut col_duals = vec![0.0; num_cols];
         let mut row_values = vec![0.0; num_rows];
         let mut row_duals = vec![0.0; num_rows];
-        let status = unsafe {
+        unsafe {
             highs_sys::Highs_getSolution(
                 ptr,
                 col_values.as_mut_ptr(),
                 col_duals.as_mut_ptr(),
                 row_values.as_mut_ptr(),
                 row_duals.as_mut_ptr(),
-            )
-        };
-        ensure_highs_status_ok(status)?;
+            );
+        }
         Ok(SolutionSnapshot {
             col_values,
             col_duals,

--- a/crates/arco-highs/src/ffi.rs
+++ b/crates/arco-highs/src/ffi.rs
@@ -65,6 +65,13 @@ pub enum HighsModelError {
         /// Name of the operation that requires a prior solve.
         operation: &'static str,
     },
+    /// HiGHS returned row/column dimensions that cannot be represented as `usize`.
+    InvalidSolutionDimensions {
+        /// Raw number of columns reported by HiGHS.
+        num_cols: highs_sys::HighsInt,
+        /// Raw number of rows reported by HiGHS.
+        num_rows: highs_sys::HighsInt,
+    },
     /// HiGHS returned a non-OK status while extracting the solution vectors.
     SolutionExtractionFailed { status: i32 },
 }
@@ -603,21 +610,23 @@ impl HighsModel {
         // Call highs-sys directly: highs::Solution only exposes borrowed slices,
         // forcing an extra copy. Reading into owned vectors avoids that.
         let ptr = solved.as_ptr();
-        let num_cols = usize::try_from(unsafe { highs_sys::Highs_getNumCol(ptr) }).unwrap_or(0);
-        let num_rows = usize::try_from(unsafe { highs_sys::Highs_getNumRow(ptr) }).unwrap_or(0);
+        let num_cols_raw = unsafe { highs_sys::Highs_getNumCol(ptr) };
+        let num_rows_raw = unsafe { highs_sys::Highs_getNumRow(ptr) };
+        let (num_cols, num_rows) = checked_solution_dimensions(num_cols_raw, num_rows_raw)?;
         let mut col_values = vec![0.0; num_cols];
         let mut col_duals = vec![0.0; num_cols];
         let mut row_values = vec![0.0; num_rows];
         let mut row_duals = vec![0.0; num_rows];
-        unsafe {
+        let status = unsafe {
             highs_sys::Highs_getSolution(
                 ptr,
                 col_values.as_mut_ptr(),
                 col_duals.as_mut_ptr(),
                 row_values.as_mut_ptr(),
                 row_duals.as_mut_ptr(),
-            );
-        }
+            )
+        };
+        ensure_highs_status_ok(status)?;
         Ok(SolutionSnapshot {
             col_values,
             col_duals,

--- a/crates/arco-highs/src/ffi.rs
+++ b/crates/arco-highs/src/ffi.rs
@@ -39,21 +39,31 @@ pub enum HighsStatus {
 /// Errors returned by the HiGHS model wrapper.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum HighsModelError {
-    /// Row coefficient count does not match referenced column count.
-    ColumnCoefficientLengthMismatch { columns: usize, coefficients: usize },
-    /// A row references a column index that does not exist in the model.
+    /// Column index and coefficient slices had different lengths when adding a row.
+    ColumnCoefficientLengthMismatch {
+        /// Number of column indices provided.
+        columns: usize,
+        /// Number of coefficients provided.
+        coefficients: usize,
+    },
+    /// A row referenced a column index that does not exist in the model.
     ColumnIndexOutOfBounds {
+        /// Invalid column index.
         column_index: usize,
+        /// Current number of columns in the model.
         num_columns: usize,
     },
-    /// Warm-start values have a different length than the model column count.
-    PrimalStartLengthMismatch { expected: usize, got: usize },
-    /// The requested operation requires `solve` to have been called first.
-    SolveRequired { operation: &'static str },
-    /// HiGHS returned invalid row/column dimensions for solution extraction.
-    InvalidSolutionDimensions {
-        num_cols: highs_sys::HighsInt,
-        num_rows: highs_sys::HighsInt,
+    /// Warm-start vector length did not match the model's column count.
+    PrimalStartLengthMismatch {
+        /// Expected number of entries.
+        expected: usize,
+        /// Provided number of entries.
+        got: usize,
+    },
+    /// A solution-only accessor was called before solving.
+    SolveRequired {
+        /// Name of the operation that requires a prior solve.
+        operation: &'static str,
     },
     /// HiGHS returned a non-OK status while extracting the solution vectors.
     SolutionExtractionFailed { status: i32 },
@@ -628,11 +638,11 @@ impl Default for HighsModel {
 pub enum HighsOption {
     /// Boolean option value.
     Bool(bool),
-    /// Signed integer option value.
+    /// Integer option value.
     Int(i32),
     /// Floating-point option value.
     Float(f64),
-    /// UTF-8 string option value.
+    /// String option value.
     Str(String),
 }
 

--- a/crates/arco-tools/src/memory.rs
+++ b/crates/arco-tools/src/memory.rs
@@ -20,6 +20,11 @@ pub struct MemorySnapshot {
 /// Errors produced by memory instrumentation.
 #[derive(Debug, Clone)]
 pub enum MemoryError {
+    /// The current process ID was not found in `sysinfo`'s process table.
+    ///
+    /// This is uncommon but can happen when process metadata refresh fails.
+    ///
+    /// `pid` is the OS process identifier that could not be resolved.
     ProcessNotFound { pid: u32 },
 }
 
@@ -79,6 +84,9 @@ impl MemorySnapshot {
 }
 
 /// Capture RSS bytes for the current process.
+///
+/// The `_stage` parameter is reserved for call-site labeling and parity with
+/// other stage-aware APIs.
 pub fn capture_rss_bytes(_stage: &str) -> Option<u64> {
     read_process_rss_bytes().ok()
 }
@@ -126,7 +134,7 @@ impl MeasurementRecorder {
         Self { stages: Vec::new() }
     }
 
-    /// Capture stage start timing and memory.
+    /// Captures stage start timing and baseline RSS.
     pub fn begin_stage(&self, stage: &str) -> StageStart {
         StageStart {
             stage: stage.to_string(),
@@ -135,7 +143,7 @@ impl MeasurementRecorder {
         }
     }
 
-    /// Capture stage end timing and memory and append a stage measurement.
+    /// Captures stage end metrics and appends a completed measurement.
     pub fn end_stage(&mut self, start: StageStart) {
         let rss_after_bytes = capture_rss_bytes(&start.stage);
         let measurement = StageMeasurement {
@@ -184,7 +192,9 @@ impl MemoryProbe {
         &self.snapshots
     }
 
-    /// Get the difference between the last two snapshots.
+    /// Returns RSS delta between the two most recently recorded snapshots.
+    ///
+    /// Returns `None` when fewer than two snapshots are available.
     pub fn last_diff(&self) -> Option<i64> {
         if self.snapshots.len() < 2 {
             return None;


### PR DESCRIPTION
## Summary
- add/expand rustdoc for key public APIs in `arco-expr`, `arco-tools`, `arco-blocks`, and `arco-highs`
- document `Expr`/`ConstraintExpr` helpers, comparison semantics, and error types
- improve docs for memory tooling and block DAG/error APIs

## Test Plan
- cargo fmt
- cargo test -p arco-expr
- cargo test -p arco-tools
- cargo test -p arco-blocks