### PR TITLE
chore(ci): disable setup-uv internal cache cleanup failure

### DIFF
--- a/.github/actions/setup-build-env/action.yml
+++ b/.github/actions/setup-build-env/action.yml
@@ -45,9 +45,12 @@ runs:
     - name: Install uv
       if: ${{ inputs.install-uv == 'true' }}
       uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7
+      env:
+        UV_CACHE_DIR: ${{ github.workspace }}/.uv-cache
       with:
         version: ${{ inputs.uv-version }}
         python-version: ${{ inputs.python-version }}
+        enable-cache: false
 
     - name: Set up Rust
       uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable


### PR DESCRIPTION
## Summary
- disable `setup-uv` internal cache in the shared setup action
- set `UV_CACHE_DIR` to `${{ github.workspace }}/.uv-cache` for consistency
- keep existing explicit `actions/cache/restore` and `actions/cache/save` uv cache flow

## Why
Main CI and release workflows failed in post-job cleanup (not build/test) when `setup-uv` attempted to prune/save its own temp cache path and errored with:
- `No cache found at: .../setup-uv-cache`
- `Cache path .../setup-uv-cache does not exist on disk`

This change removes duplicate cache management and prevents that post-job failure path.

## Validation
- `just workflow-quality`
