### PR TITLE
feat: adding ipopt support for non-linear stuff

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,7 +63,10 @@ jobs:
       matrix:
         solver:
           - package: arco-ipopt
-            apt-deps: coinor-libipopt-dev liblapack-dev gfortran
+            # Do NOT install coinor-libipopt-dev: Ubuntu 24.04 ships IPOPT 3.11.9
+            # which has a known memory corruption bug with MUMPS >= 5.1.0.
+            # ipopt-sys will build IPOPT 3.12.13 from source instead.
+            apt-deps: liblapack-dev gfortran
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -108,20 +111,17 @@ jobs:
       matrix:
         solver:
           - package: arco-ipopt
-            apt-deps: coinor-libipopt-dev liblapack-dev gfortran
+            # Do NOT install coinor-libipopt-dev: Ubuntu 24.04 ships IPOPT 3.11.9
+            # which has a known memory corruption bug with MUMPS >= 5.1.0.
+            # ipopt-sys will build IPOPT 3.12.13 from source instead.
+            apt-deps: liblapack-dev gfortran
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 
       - name: Install solver system dependencies
-        run: |
-          sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends ${{ matrix.solver.apt-deps }}
-          # Force dynamic linking: remove static libipopt.a so ipopt-sys
-          # does not set all transitive deps (including libm) to static.
-          # libm.a on Ubuntu 24.04 is a GNU linker script, not an archive,
-          # which Rust's archive reader cannot parse.
-          sudo find /usr -name 'libipopt.a' -delete
+        run: sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends ${{ matrix.solver.apt-deps }}
 
       - name: Set up build environment
         uses: ./.github/actions/setup-rust-validation-env

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,8 +37,8 @@ jobs:
       - name: Run workflow quality checks
         run: uvx zizmor .github
 
-  rust-clippy:
-    name: Rust clippy
+  rust-clippy-core:
+    name: Rust clippy (core)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -52,11 +52,38 @@ jobs:
           uv-version: ${{ env.UV_VERSION }}
           just-version: ${{ env.JUST_VERSION }}
 
-      - name: Run clippy
-        run: just clippy
+      - name: Run clippy (core)
+        run: just clippy-core
 
-  rust-test:
-    name: Rust tests
+  rust-clippy-solvers:
+    name: Rust clippy (${{ matrix.solver.package }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        solver:
+          - package: arco-ipopt
+            apt-deps: coinor-libipopt-dev
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Install solver system dependencies
+        run: sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends ${{ matrix.solver.apt-deps }}
+
+      - name: Set up build environment
+        uses: ./.github/actions/setup-rust-validation-env
+        with:
+          python-version: ${{ env.PYTHON_LATEST }}
+          uv-version: ${{ env.UV_VERSION }}
+          just-version: ${{ env.JUST_VERSION }}
+
+      - name: Run clippy (${{ matrix.solver.package }})
+        run: just clippy-solver ${{ matrix.solver.package }}
+
+  rust-test-core:
+    name: Rust tests (core)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -70,12 +97,39 @@ jobs:
           uv-version: ${{ env.UV_VERSION }}
           just-version: ${{ env.JUST_VERSION }}
 
-      - name: Run Rust tests
-        run: just test
+      - name: Run Rust tests (core)
+        run: just test-core
+
+  rust-test-solvers:
+    name: Rust tests (${{ matrix.solver.package }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        solver:
+          - package: arco-ipopt
+            apt-deps: coinor-libipopt-dev
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Install solver system dependencies
+        run: sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends ${{ matrix.solver.apt-deps }}
+
+      - name: Set up build environment
+        uses: ./.github/actions/setup-rust-validation-env
+        with:
+          python-version: ${{ env.PYTHON_LATEST }}
+          uv-version: ${{ env.UV_VERSION }}
+          just-version: ${{ env.JUST_VERSION }}
+
+      - name: Run Rust tests (${{ matrix.solver.package }})
+        run: just test-solver ${{ matrix.solver.package }}
 
   python-validation:
     name: Python validation (py${{ matrix.python-version }})
-    needs: [rust-test]
+    needs: [rust-test-core]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,7 +63,7 @@ jobs:
       matrix:
         solver:
           - package: arco-ipopt
-            apt-deps: coinor-libipopt-dev
+            apt-deps: coinor-libipopt-dev liblapack-dev gfortran
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -108,7 +108,7 @@ jobs:
       matrix:
         solver:
           - package: arco-ipopt
-            apt-deps: coinor-libipopt-dev
+            apt-deps: coinor-libipopt-dev liblapack-dev gfortran
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -115,7 +115,13 @@ jobs:
           persist-credentials: false
 
       - name: Install solver system dependencies
-        run: sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends ${{ matrix.solver.apt-deps }}
+        run: |
+          sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends ${{ matrix.solver.apt-deps }}
+          # Force dynamic linking: remove static libipopt.a so ipopt-sys
+          # does not set all transitive deps (including libm) to static.
+          # libm.a on Ubuntu 24.04 is a GNU linker script, not an archive,
+          # which Rust's archive reader cannot parse.
+          sudo find /usr -name 'libipopt.a' -delete
 
       - name: Set up build environment
         uses: ./.github/actions/setup-rust-validation-env
@@ -124,12 +130,8 @@ jobs:
           uv-version: ${{ env.UV_VERSION }}
           just-version: ${{ env.JUST_VERSION }}
 
-      # Use lld to avoid "Unsupported archive identifier" errors from
-      # thin archives (libm.a) on Ubuntu 24.04.
       - name: Run Rust tests (${{ matrix.solver.package }})
         run: just test-solver ${{ matrix.solver.package }}
-        env:
-          RUSTFLAGS: "-Clink-arg=-fuse-ld=lld"
 
   python-validation:
     name: Python validation (py${{ matrix.python-version }})

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -115,12 +115,7 @@ jobs:
           persist-credentials: false
 
       - name: Install solver system dependencies
-        run: |
-          sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends ${{ matrix.solver.apt-deps }}
-          # Remove static libipopt.a so ipopt-sys links dynamically.
-          # Static linking pulls in libm.a which is a thin archive on
-          # Ubuntu 24.04 and triggers "Unsupported archive identifier".
-          sudo rm -f /usr/lib/*/libipopt.a
+        run: sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends ${{ matrix.solver.apt-deps }}
 
       - name: Set up build environment
         uses: ./.github/actions/setup-rust-validation-env
@@ -129,8 +124,12 @@ jobs:
           uv-version: ${{ env.UV_VERSION }}
           just-version: ${{ env.JUST_VERSION }}
 
+      # Use lld to avoid "Unsupported archive identifier" errors from
+      # thin archives (libm.a) on Ubuntu 24.04.
       - name: Run Rust tests (${{ matrix.solver.package }})
         run: just test-solver ${{ matrix.solver.package }}
+        env:
+          RUSTFLAGS: "-Clink-arg=-fuse-ld=lld"
 
   python-validation:
     name: Python validation (py${{ matrix.python-version }})

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -84,6 +84,11 @@ jobs:
 
       - name: Run clippy (${{ matrix.solver.package }})
         run: just clippy-solver ${{ matrix.solver.package }}
+        env:
+          # MUMPS 4.10.0 (bundled by ipopt-sys) has Fortran type mismatches
+          # that GCC 14 on Ubuntu 24.04 rejects by default.
+          FFLAGS: "-fallow-argument-mismatch"
+          FCFLAGS: "-fallow-argument-mismatch"
 
   rust-test-core:
     name: Rust tests (core)
@@ -132,6 +137,11 @@ jobs:
 
       - name: Run Rust tests (${{ matrix.solver.package }})
         run: just test-solver ${{ matrix.solver.package }}
+        env:
+          # MUMPS 4.10.0 (bundled by ipopt-sys) has Fortran type mismatches
+          # that GCC 14 on Ubuntu 24.04 rejects by default.
+          FFLAGS: "-fallow-argument-mismatch"
+          FCFLAGS: "-fallow-argument-mismatch"
 
   python-validation:
     name: Python validation (py${{ matrix.python-version }})

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,7 +66,7 @@ jobs:
             # Do NOT install coinor-libipopt-dev: Ubuntu 24.04 ships IPOPT 3.11.9
             # which has a known memory corruption bug with MUMPS >= 5.1.0.
             # ipopt-sys will build IPOPT 3.12.13 from source instead.
-            apt-deps: liblapack-dev gfortran
+            apt-deps: liblapack-dev libopenblas-dev gfortran
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -114,7 +114,7 @@ jobs:
             # Do NOT install coinor-libipopt-dev: Ubuntu 24.04 ships IPOPT 3.11.9
             # which has a known memory corruption bug with MUMPS >= 5.1.0.
             # ipopt-sys will build IPOPT 3.12.13 from source instead.
-            apt-deps: liblapack-dev gfortran
+            apt-deps: liblapack-dev libopenblas-dev gfortran
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -115,7 +115,12 @@ jobs:
           persist-credentials: false
 
       - name: Install solver system dependencies
-        run: sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends ${{ matrix.solver.apt-deps }}
+        run: |
+          sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends ${{ matrix.solver.apt-deps }}
+          # Remove static libipopt.a so ipopt-sys links dynamically.
+          # Static linking pulls in libm.a which is a thin archive on
+          # Ubuntu 24.04 and triggers "Unsupported archive identifier".
+          sudo rm -f /usr/lib/*/libipopt.a
 
       - name: Set up build environment
         uses: ./.github/actions/setup-rust-validation-env

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,9 +63,8 @@ jobs:
       matrix:
         solver:
           - package: arco-ipopt
-            # Do NOT install coinor-libipopt-dev: Ubuntu 24.04 ships IPOPT 3.11.9
-            # which has a known memory corruption bug with MUMPS >= 5.1.0.
-            # ipopt-sys will build IPOPT 3.12.13 from source instead.
+            # Build IPOPT from source via ipopt-sys; the Ubuntu 24.04 system
+            # package (3.11.9) has a memory corruption bug with MUMPS >= 5.1.0.
             apt-deps: liblapack-dev libopenblas-dev gfortran
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -85,8 +84,8 @@ jobs:
       - name: Run clippy (${{ matrix.solver.package }})
         run: just clippy-solver ${{ matrix.solver.package }}
         env:
-          # MUMPS 4.10.0 (bundled by ipopt-sys) has Fortran type mismatches
-          # that GCC 14 on Ubuntu 24.04 rejects by default.
+          # MUMPS 4.10.0 (bundled by ipopt-sys) has type mismatches that
+          # GCC 14 rejects by default (-fallow-argument-mismatch).
           FFLAGS: "-fallow-argument-mismatch"
           FCFLAGS: "-fallow-argument-mismatch"
 
@@ -116,9 +115,8 @@ jobs:
       matrix:
         solver:
           - package: arco-ipopt
-            # Do NOT install coinor-libipopt-dev: Ubuntu 24.04 ships IPOPT 3.11.9
-            # which has a known memory corruption bug with MUMPS >= 5.1.0.
-            # ipopt-sys will build IPOPT 3.12.13 from source instead.
+            # Build IPOPT from source via ipopt-sys; the Ubuntu 24.04 system
+            # package (3.11.9) has a memory corruption bug with MUMPS >= 5.1.0.
             apt-deps: liblapack-dev libopenblas-dev gfortran
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -138,8 +136,8 @@ jobs:
       - name: Run Rust tests (${{ matrix.solver.package }})
         run: just test-solver ${{ matrix.solver.package }}
         env:
-          # MUMPS 4.10.0 (bundled by ipopt-sys) has Fortran type mismatches
-          # that GCC 14 on Ubuntu 24.04 rejects by default.
+          # MUMPS 4.10.0 (bundled by ipopt-sys) has type mismatches that
+          # GCC 14 rejects by default (-fallow-argument-mismatch).
           FFLAGS: "-fallow-argument-mismatch"
           FCFLAGS: "-fallow-argument-mismatch"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ arco-core = { path = "crates/arco-core" }
 arco-expr = { path = "crates/arco-expr" }
 arco-solver = { path = "crates/arco-solver" }
 arco-highs = { path = "crates/arco-highs" }
+arco-ipopt = { path = "crates/arco-ipopt" }
 arco-tools = { path = "crates/arco-tools" }
 arco-blocks = { path = "crates/arco-blocks" }
 

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -20,13 +20,16 @@ pyo3 = { workspace = true, features = ["extension-module"] }
 arco-core = { workspace = true }
 arco-expr = { workspace = true }
 arco-highs = { workspace = true }
+arco-solver = { workspace = true }
 arco-blocks = { workspace = true }
+arco-ipopt = { workspace = true, optional = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
 
 [features]
 default = []
+ipopt = ["arco-ipopt"]
 
 [lints]
 workspace = true

--- a/bindings/python/src/errors.rs
+++ b/bindings/python/src/errors.rs
@@ -306,26 +306,25 @@ pub fn model_error_to_py(e: arco_core::model::ModelError) -> PyErr {
     }
 }
 
-/// Convert a `arco_core::SolverError` into the appropriate ArcoError subclass.
-pub fn solver_error_to_py(e: arco_core::SolverError) -> PyErr {
+/// Convert a `arco_solver::SolverError` into the appropriate ArcoError subclass.
+pub fn generic_solver_error_to_py(e: arco_solver::SolverError) -> PyErr {
     let msg = e.to_string();
     match e {
-        arco_core::SolverError::EmptyModel => ModelEmptyError::new_err(msg),
-        arco_core::SolverError::NoObjective => ObjectiveMissingError::new_err(msg),
-        arco_core::SolverError::InvalidVariableId(_) => VariableInvalidIdError::new_err(msg),
-        arco_core::SolverError::SolveFailure { status } => {
-            use arco_core::solver::SolverStatus;
+        arco_solver::SolverError::EmptyModel => ModelEmptyError::new_err(msg),
+        arco_solver::SolverError::NoObjective => ObjectiveMissingError::new_err(msg),
+        arco_solver::SolverError::InvalidObjectiveSense => SolverInternalError::new_err(msg),
+        arco_solver::SolverError::InvalidVariableId(_) => VariableInvalidIdError::new_err(msg),
+        arco_solver::SolverError::InternalError(_) => SolverInternalError::new_err(msg),
+        arco_solver::SolverError::SolveFailure { status } => {
+            use arco_solver::SolverStatus;
             match status {
                 SolverStatus::Infeasible => SolverInfeasibleError::new_err(msg),
                 SolverStatus::Unbounded => SolverUnboundedError::new_err(msg),
-                SolverStatus::TimeLimit => SolverTimeLimitError::new_err(msg),
-                SolverStatus::IterationLimit => SolverIterationLimitError::new_err(msg),
+                SolverStatus::ReachedTimeLimit => SolverTimeLimitError::new_err(msg),
+                SolverStatus::ReachedIterationLimit => SolverIterationLimitError::new_err(msg),
                 _ => SolverInternalError::new_err(msg),
             }
         }
-        arco_core::SolverError::InvalidObjectiveSense
-        | arco_core::SolverError::SolverNotAvailable(_)
-        | arco_core::SolverError::SolverSpecific(_) => SolverInternalError::new_err(msg),
     }
 }
 

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -928,9 +928,9 @@ impl PyModel {
 
         let result = match backend.solve(&self.inner, &config, hints.as_deref()) {
             Ok(solution) => Ok(PySolveResult::new(solution)),
-            Err(arco_solver::SolverError::SolveFailure { status }) => {
-                Ok(PySolveResult::new(solve_failure_solution(status.to_core_status())))
-            }
+            Err(arco_solver::SolverError::SolveFailure { status }) => Ok(PySolveResult::new(
+                solve_failure_solution(status.to_core_status()),
+            )),
             Err(e) => Err(errors::generic_solver_error_to_py(e)),
         }?;
 

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -58,6 +58,8 @@ pub use model_blocks::{PyBlockHandle, PyBlockPorts, PyBlockResults};
 pub use slack_variable::PySlackVariable;
 pub use snapshot::{PyModelSnapshot, PySnapshotMetadata};
 pub use solution::{PySolutionStatus, PySolveResult};
+#[cfg(feature = "ipopt")]
+pub use solver::PyIpopt;
 pub use solver::{PyHiGHS, PySolver, PyXpress, SolveOverrides, SolverSettings};
 pub use variable::PyVariable;
 pub use views::{
@@ -69,7 +71,7 @@ pub use views::{
 pub struct PyModel {
     pub(crate) inner: Model,
     solver_settings: SolverSettings,
-    use_xpress: bool,
+    default_backend: String,
     last_solution: Option<Py<PySolveResult>>,
     /// Block definitions added via add_block()
     block_defs: Vec<model_blocks::BlockDef>,
@@ -305,12 +307,12 @@ impl PyModel {
         } else {
             Model::new()
         };
-        let use_xpress = solver.is_some_and(|s| s.cast::<PyXpress>().is_ok());
+        let default_backend = detect_default_backend(solver);
         let solver_settings = extract_solver_settings(solver)?;
         Ok(PyModel {
             inner,
             solver_settings,
-            use_xpress,
+            default_backend,
             last_solution: None,
             block_defs: Vec::new(),
             link_defs: Vec::new(),
@@ -368,7 +370,7 @@ impl PyModel {
         Ok(PyModel {
             inner,
             solver_settings: SolverSettings::default(),
-            use_xpress: false,
+            default_backend: "highs".to_string(),
             last_solution: None,
             block_defs: Vec::new(),
             link_defs: Vec::new(),
@@ -914,38 +916,22 @@ impl PyModel {
                 .collect()
         });
 
-        let solver_backend = if let Some(s) = solver {
-            resolve_solver_backend(Some(s))?
-        } else if self.use_xpress {
-            SolverBackend::Xpress(self.solver_settings.clone())
+        let effective_settings = if let Some(s) = solver {
+            extract_solver_settings(Some(s))?
         } else {
-            SolverBackend::HiGHS(self.solver_settings.clone())
+            self.solver_settings.clone()
         };
+        let effective_settings = effective_settings.with_overrides(overrides)?;
 
-        let result = match solver_backend {
-            SolverBackend::Xpress(_settings) => Err(errors::SolverInternalError::new_err(
-                "Xpress backend is not enabled in this build",
-            )),
-            SolverBackend::HiGHS(settings) => {
-                let settings = settings.with_overrides(overrides)?;
-                let mut highs = arco_highs::Solver::new(self.inner.clone())
-                    .map_err(errors::solver_error_to_py)?;
-                settings.apply_highs(&mut highs);
+        let backend = resolve_backend(solver, &self.default_backend)?;
+        let config = effective_settings.to_solver_config();
 
-                if let Some(ref hints) = hints {
-                    highs
-                        .set_primal_start(hints)
-                        .map_err(errors::solver_error_to_py)?;
-                }
-
-                match highs.solve() {
-                    Ok(solution) => Ok(PySolveResult::new(solution.into_core_solution())),
-                    Err(arco_core::SolverError::SolveFailure { status }) => {
-                        Ok(PySolveResult::new(solve_failure_solution(status)))
-                    }
-                    Err(e) => Err(errors::solver_error_to_py(e)),
-                }
+        let result = match backend.solve(&self.inner, &config, hints.as_deref()) {
+            Ok(solution) => Ok(PySolveResult::new(solution)),
+            Err(arco_solver::SolverError::SolveFailure { status }) => {
+                Ok(PySolveResult::new(solve_failure_solution(status.to_core_status())))
             }
+            Err(e) => Err(errors::generic_solver_error_to_py(e)),
         }?;
 
         let py_result = Py::new(py, result)?;
@@ -1393,19 +1379,32 @@ fn solve_failure_solution(status: arco_core::solver::SolverStatus) -> arco_core:
     }
 }
 
-/// Which solver backend to use when solving.
-enum SolverBackend {
-    HiGHS(SolverSettings),
-    Xpress(SolverSettings),
+/// Detect which backend name a solver object represents.
+fn detect_default_backend(solver: Option<&Bound<'_, PyAny>>) -> String {
+    let Some(solver) = solver else {
+        return "highs".to_string();
+    };
+    #[cfg(feature = "ipopt")]
+    if solver.cast::<PyIpopt>().is_ok() {
+        return "ipopt".to_string();
+    }
+    if solver.cast::<PyXpress>().is_ok() {
+        return "xpress".to_string();
+    }
+    "highs".to_string()
 }
 
-/// Extract `SolverSettings` from an optional Python solver object (`HiGHS`, `Xpress`, or `Solver`).
+/// Extract `SolverSettings` from an optional Python solver object (`HiGHS`, `Ipopt`, `Xpress`, or `Solver`).
 fn extract_solver_settings(solver: Option<&Bound<'_, PyAny>>) -> PyResult<SolverSettings> {
     let Some(solver) = solver else {
         return Ok(SolverSettings::default());
     };
     if let Ok(highs) = solver.cast::<PyHiGHS>() {
         return Ok(highs.borrow().into_super().settings.clone());
+    }
+    #[cfg(feature = "ipopt")]
+    if let Ok(ipopt) = solver.cast::<PyIpopt>() {
+        return Ok(ipopt.borrow().into_super().settings.clone());
     }
     if let Ok(xpress) = solver.cast::<PyXpress>() {
         return Ok(xpress.borrow().into_super().settings.clone());
@@ -1414,30 +1413,26 @@ fn extract_solver_settings(solver: Option<&Bound<'_, PyAny>>) -> PyResult<Solver
         return Ok(base.borrow().settings.clone());
     }
     Err(errors::SolverTypeError::new_err(
-        "solver must be a Solver, HiGHS, or Xpress instance",
+        "solver must be a Solver, HiGHS, Ipopt, or Xpress instance",
     ))
 }
 
-/// Determine the solver backend from the `solver` parameter passed to `solve()`.
-fn resolve_solver_backend(solver: Option<&Bound<'_, PyAny>>) -> PyResult<SolverBackend> {
-    let Some(solver) = solver else {
-        return Ok(SolverBackend::HiGHS(SolverSettings::default()));
-    };
-    if let Ok(xpress) = solver.cast::<PyXpress>() {
-        let settings = xpress.borrow().into_super().settings.clone();
-        return Ok(SolverBackend::Xpress(settings));
+/// Resolve which `SolverBackend` implementation to use.
+fn resolve_backend(
+    solver: Option<&Bound<'_, PyAny>>,
+    default_backend: &str,
+) -> PyResult<Box<dyn arco_solver::SolverBackend>> {
+    #[cfg(feature = "ipopt")]
+    if solver.is_some_and(|s| s.cast::<PyIpopt>().is_ok()) || default_backend == "ipopt" {
+        return Ok(Box::new(arco_ipopt::IpoptBackend));
     }
-    if let Ok(highs) = solver.cast::<PyHiGHS>() {
-        let settings = highs.borrow().into_super().settings.clone();
-        return Ok(SolverBackend::HiGHS(settings));
+    if solver.is_some_and(|s| s.cast::<PyXpress>().is_ok()) || default_backend == "xpress" {
+        return Err(errors::SolverInternalError::new_err(
+            "Xpress backend is not enabled in this build",
+        ));
     }
-    if let Ok(base) = solver.cast::<PySolver>() {
-        let settings = base.borrow().settings.clone();
-        return Ok(SolverBackend::HiGHS(settings));
-    }
-    Err(errors::SolverTypeError::new_err(
-        "solver must be a Solver, HiGHS, or Xpress instance",
-    ))
+    // Default: HiGHS
+    Ok(Box::new(arco_highs::HiGHSBackend))
 }
 
 /// Extract a `ConstraintId` from a Python object that may be a `PyConstraint` or `u32`.

--- a/bindings/python/src/solver.rs
+++ b/bindings/python/src/solver.rs
@@ -104,6 +104,33 @@ impl SolverSettings {
             solver.set_tolerance(tolerance);
         }
     }
+
+    /// Convert these settings into a generic `SolverConfig`.
+    pub fn to_solver_config(&self) -> arco_solver::SolverConfig {
+        let mut config = arco_solver::SolverConfig::new();
+        if let Some(presolve) = self.presolve {
+            config = config.with_presolve(presolve);
+        }
+        if let Some(threads) = self.threads {
+            config = config.with_threads(threads);
+        }
+        if let Some(tolerance) = self.tolerance {
+            config = config.with_tolerance(tolerance);
+        }
+        if let Some(time_limit) = self.time_limit {
+            config = config.with_time_limit(time_limit);
+        }
+        if let Some(mip_gap) = self.mip_gap {
+            config = config.with_mip_gap(mip_gap);
+        }
+        if let Some(verbosity) = self.verbosity {
+            config = config.with_verbosity(verbosity);
+        }
+        if let Some(log_to_console) = self.log_to_console {
+            config = config.with_log_to_console(log_to_console);
+        }
+        config
+    }
 }
 
 fn extract_optional<T: for<'a, 'py> FromPyObject<'a, 'py, Error = PyErr>>(
@@ -339,10 +366,62 @@ impl PyXpress {
     }
 }
 
+#[cfg(feature = "ipopt")]
+#[pyclass(from_py_object, extends = PySolver, name = "Ipopt")]
+#[derive(Debug, Clone)]
+pub struct PyIpopt;
+
+#[cfg(feature = "ipopt")]
+#[pymethods]
+impl PyIpopt {
+    #[new]
+    #[pyo3(
+        signature = (*, presolve=None, threads=None, tolerance=None, time_limit=None, mip_gap=None, verbosity=None, log_to_console=None)
+    )]
+    fn new(
+        presolve: Option<bool>,
+        threads: Option<u32>,
+        tolerance: Option<f64>,
+        time_limit: Option<f64>,
+        mip_gap: Option<f64>,
+        verbosity: Option<u32>,
+        log_to_console: Option<bool>,
+    ) -> PyResult<(Self, PySolver)> {
+        let settings = SolverSettings::new(
+            presolve,
+            threads,
+            tolerance,
+            time_limit,
+            mip_gap,
+            verbosity,
+            log_to_console,
+        )?;
+        Ok((PyIpopt, PySolver { settings }))
+    }
+
+    #[pyo3(signature = (*, update=None))]
+    fn copy(
+        slf: PyRef<'_, Self>,
+        py: Python<'_>,
+        update: Option<&Bound<'_, PyDict>>,
+    ) -> PyResult<Py<Self>> {
+        let base = slf.into_super();
+        let settings = apply_solver_updates(base.settings.clone(), update)?;
+        Py::new(py, (PyIpopt, PySolver { settings }))
+    }
+
+    fn __repr__(slf: PyRef<'_, Self>) -> String {
+        let base = slf.into_super();
+        solver_repr("Ipopt", &base.settings)
+    }
+}
+
 /// Register solver classes with the Python module.
 pub fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PySolver>()?;
     m.add_class::<PyHiGHS>()?;
     m.add_class::<PyXpress>()?;
+    #[cfg(feature = "ipopt")]
+    m.add_class::<PyIpopt>()?;
     Ok(())
 }

--- a/crates/arco-highs/src/lib.rs
+++ b/crates/arco-highs/src/lib.rs
@@ -22,4 +22,4 @@ pub use ffi::{
     highs_version,
 };
 pub use solution::Solution;
-pub use solver::{Solver, SolverError};
+pub use solver::{HiGHSBackend, Solver, SolverError};

--- a/crates/arco-highs/src/solver.rs
+++ b/crates/arco-highs/src/solver.rs
@@ -192,8 +192,7 @@ impl Solve for Solver {
     type Solution = Solution;
 
     fn solve(&mut self, config: &SolverConfig) -> Result<Self::Solution, GenericSolverError> {
-        self.solve_with_config(config)
-            .map_err(Into::into)
+        self.solve_with_config(config).map_err(Into::into)
     }
 }
 

--- a/crates/arco-highs/src/solver.rs
+++ b/crates/arco-highs/src/solver.rs
@@ -3,11 +3,11 @@
 use crate::async_matrix::{AsyncCrsBuilder, ConstraintEntries};
 use crate::ffi::{HighsModel, HighsModelError, HighsOption, HighsStatus, ObjectiveSense};
 use crate::solution::Solution;
-use crate::status::{core_to_generic_status, highs_has_solution, highs_to_core_status};
+use crate::status::{highs_has_solution, highs_to_core_status};
 use arco_core::solver::SolverError as CoreSolverError;
 use arco_core::{Model, Sense};
 use arco_expr::{ConstraintId, VariableId};
-use arco_solver::{Solve, SolverConfig, SolverError as GenericSolverError};
+use arco_solver::{Solve, SolverBackend, SolverConfig, SolverError as GenericSolverError};
 use arco_tools::memory::capture_rss_bytes;
 use std::collections::BTreeMap;
 use std::time::Instant;
@@ -19,21 +19,6 @@ pub type SolverError = CoreSolverError;
 /// Convert a HighsModelError into a SolverError.
 fn highs_model_error_to_solver_error(err: HighsModelError) -> SolverError {
     SolverError::SolverSpecific(err.to_string())
-}
-
-/// Convert a arco_core::SolverError to a arco_solver::SolverError.
-fn core_error_to_generic(err: CoreSolverError) -> GenericSolverError {
-    match err {
-        CoreSolverError::EmptyModel => GenericSolverError::EmptyModel,
-        CoreSolverError::NoObjective => GenericSolverError::NoObjective,
-        CoreSolverError::InvalidObjectiveSense => GenericSolverError::InvalidObjectiveSense,
-        CoreSolverError::InvalidVariableId(id) => GenericSolverError::InvalidVariableId(id),
-        CoreSolverError::SolverNotAvailable(msg) => GenericSolverError::InternalError(msg),
-        CoreSolverError::SolverSpecific(msg) => GenericSolverError::InternalError(msg),
-        CoreSolverError::SolveFailure { status } => GenericSolverError::SolveFailure {
-            status: core_to_generic_status(status),
-        },
-    }
 }
 
 /// Zero-copy bridge from arco-core::Model to HiGHS
@@ -208,7 +193,27 @@ impl Solve for Solver {
 
     fn solve(&mut self, config: &SolverConfig) -> Result<Self::Solution, GenericSolverError> {
         self.solve_with_config(config)
-            .map_err(core_error_to_generic)
+            .map_err(Into::into)
+    }
+}
+
+/// Zero-sized backend for trait-based dispatch from the Python bindings.
+pub struct HiGHSBackend;
+
+impl SolverBackend for HiGHSBackend {
+    fn solve(
+        &self,
+        model: &Model,
+        config: &SolverConfig,
+        primal_start: Option<&[(VariableId, f64)]>,
+    ) -> Result<arco_core::solver::Solution, GenericSolverError> {
+        solve_model(model, config, primal_start, false)
+            .map(|s| s.into_core_solution())
+            .map_err(Into::into)
+    }
+
+    fn name(&self) -> &'static str {
+        "HiGHS"
     }
 }
 

--- a/crates/arco-highs/src/status.rs
+++ b/crates/arco-highs/src/status.rs
@@ -16,19 +16,8 @@ pub(crate) fn highs_to_core_status(status: HighsStatus) -> CoreSolverStatus {
     }
 }
 
-pub(crate) fn core_to_generic_status(status: CoreSolverStatus) -> SolverStatus {
-    match status {
-        CoreSolverStatus::Optimal => SolverStatus::Optimal,
-        CoreSolverStatus::Infeasible => SolverStatus::Infeasible,
-        CoreSolverStatus::Unbounded => SolverStatus::Unbounded,
-        CoreSolverStatus::TimeLimit => SolverStatus::ReachedTimeLimit,
-        CoreSolverStatus::IterationLimit => SolverStatus::ReachedIterationLimit,
-        CoreSolverStatus::Unknown => SolverStatus::Unknown,
-    }
-}
-
 pub(crate) fn highs_to_generic_status(status: HighsStatus) -> SolverStatus {
-    core_to_generic_status(highs_to_core_status(status))
+    highs_to_core_status(status).into()
 }
 
 pub(crate) fn highs_status_string(status: HighsStatus) -> &'static str {
@@ -73,15 +62,15 @@ mod tests {
     #[test]
     fn test_core_to_generic_mapping() {
         assert_eq!(
-            core_to_generic_status(CoreSolverStatus::Optimal),
+            SolverStatus::from(CoreSolverStatus::Optimal),
             SolverStatus::Optimal
         );
         assert_eq!(
-            core_to_generic_status(CoreSolverStatus::TimeLimit),
+            SolverStatus::from(CoreSolverStatus::TimeLimit),
             SolverStatus::ReachedTimeLimit
         );
         assert_eq!(
-            core_to_generic_status(CoreSolverStatus::IterationLimit),
+            SolverStatus::from(CoreSolverStatus::IterationLimit),
             SolverStatus::ReachedIterationLimit
         );
     }

--- a/crates/arco-ipopt/Cargo.toml
+++ b/crates/arco-ipopt/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "arco-ipopt"
+version = { workspace = true }
+description = "IPOPT solver backend for Arco optimization"
+edition = { workspace = true }
+rust-version = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+authors = { workspace = true }
+license-file = { workspace = true }
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+arco-core = { workspace = true }
+arco-expr = { workspace = true }
+arco-solver = { workspace = true }
+ipopt = "0.5"
+tracing = { workspace = true }
+
+[dev-dependencies]
+tracing-subscriber = { workspace = true }

--- a/crates/arco-ipopt/src/lib.rs
+++ b/crates/arco-ipopt/src/lib.rs
@@ -1,0 +1,16 @@
+//! IPOPT solver backend for Arco optimization.
+//!
+//! This crate provides a bridge from `arco-core::Model` to the IPOPT nonlinear
+//! interior-point solver. It currently supports LP problems but is architecturally
+//! designed for future NLP extension.
+//!
+//! IPOPT is a continuous-only solver and will reject models with integer or
+//! binary variables.
+
+pub mod problem;
+pub mod solution;
+pub mod solver;
+mod status;
+
+pub use solution::Solution;
+pub use solver::{IpoptBackend, Solver, SolverError};

--- a/crates/arco-ipopt/src/problem.rs
+++ b/crates/arco-ipopt/src/problem.rs
@@ -326,7 +326,7 @@ mod tests {
         let problem = ArcoProblem::from_model(&model, None).unwrap();
         assert_eq!(problem.num_vars, 2);
         assert_eq!(problem.num_constraints, 1);
-        assert_eq!(problem.obj_sign, 1.0);
+        assert!((problem.obj_sign - 1.0).abs() < f64::EPSILON);
         assert_eq!(problem.jac_rows.len(), 2);
     }
 
@@ -345,7 +345,7 @@ mod tests {
             .unwrap();
 
         let problem = ArcoProblem::from_model(&model, None).unwrap();
-        assert_eq!(problem.obj_sign, -1.0);
+        assert!((problem.obj_sign - (-1.0)).abs() < f64::EPSILON);
         // Coefficient should be negated: -1 * 3.0 = -3.0
         assert!((problem.obj_coeffs[0] - (-3.0)).abs() < 1e-12);
     }

--- a/crates/arco-ipopt/src/problem.rs
+++ b/crates/arco-ipopt/src/problem.rs
@@ -1,7 +1,7 @@
 //! IPOPT problem adapter that maps an `arco_core::Model` to `ipopt::ConstrainedProblem`.
 
-use arco_core::solver::SolverError;
 use arco_core::Model;
+use arco_core::solver::SolverError;
 use arco_expr::{ConstraintId, VariableId};
 use ipopt::{BasicProblem, ConstrainedProblem, Index, Number};
 use std::collections::BTreeMap;

--- a/crates/arco-ipopt/src/problem.rs
+++ b/crates/arco-ipopt/src/problem.rs
@@ -1,0 +1,352 @@
+//! IPOPT problem adapter that maps an `arco_core::Model` to `ipopt::ConstrainedProblem`.
+
+use arco_core::solver::SolverError;
+use arco_core::Model;
+use arco_expr::{ConstraintId, VariableId};
+use ipopt::{BasicProblem, ConstrainedProblem, Index, Number};
+use std::collections::BTreeMap;
+
+/// Adapter that presents an `arco_core::Model` as an `ipopt::ConstrainedProblem`.
+///
+/// This struct holds pre-extracted data from the model in the format IPOPT expects.
+/// For LP problems, the Jacobian is constant and the Hessian is zero (we use
+/// IPOPT's limited-memory BFGS approximation instead).
+pub struct ArcoProblem {
+    // Variable data
+    pub(crate) num_vars: usize,
+    pub(crate) x_lower: Vec<f64>,
+    pub(crate) x_upper: Vec<f64>,
+    pub(crate) x_init: Vec<f64>,
+
+    // Objective: sign * c^T x
+    pub(crate) obj_coeffs: Vec<f64>,
+    pub(crate) obj_sign: f64, // +1 for minimize, -1 for maximize
+
+    // Constraint data
+    pub(crate) num_constraints: usize,
+    pub(crate) g_lower: Vec<f64>,
+    pub(crate) g_upper: Vec<f64>,
+
+    // Jacobian in COO format (constant for LP)
+    pub(crate) jac_rows: Vec<Index>,
+    pub(crate) jac_cols: Vec<Index>,
+    pub(crate) jac_vals: Vec<f64>,
+}
+
+/// IPOPT's conventional bounds for "infinity".
+const IPOPT_INF: f64 = 1e19;
+
+/// Clamp a bound value to IPOPT's finite range `[-IPOPT_INF, IPOPT_INF]`.
+fn clamp_bound(val: f64) -> f64 {
+    val.clamp(-IPOPT_INF, IPOPT_INF)
+}
+
+/// Pick a reasonable initial point: 0 when feasible, otherwise the nearest finite bound.
+fn default_primal_value(lower: f64, upper: f64) -> f64 {
+    if lower <= 0.0 && 0.0 <= upper {
+        0.0
+    } else if lower > 0.0 && lower.is_finite() {
+        lower
+    } else if upper < 0.0 && upper.is_finite() {
+        upper
+    } else {
+        0.0
+    }
+}
+
+impl ArcoProblem {
+    /// Build an `ArcoProblem` from an Arco model.
+    ///
+    /// Returns an error if the model contains integer variables (IPOPT is
+    /// continuous-only) or has no objective set.
+    pub fn from_model(
+        model: &Model,
+        primal_start: Option<&[(VariableId, f64)]>,
+    ) -> Result<Self, SolverError> {
+        let num_vars = model.num_variables();
+        if num_vars == 0 {
+            return Err(SolverError::EmptyModel);
+        }
+
+        let objective = model.objective();
+        let Some(sense) = objective.sense else {
+            return Err(SolverError::NoObjective);
+        };
+        let obj_sign = match sense {
+            arco_core::Sense::Minimize => 1.0,
+            arco_core::Sense::Maximize => -1.0,
+        };
+
+        // Collect variable data
+        let mut x_lower = Vec::with_capacity(num_vars);
+        let mut x_upper = Vec::with_capacity(num_vars);
+        let mut x_init = Vec::with_capacity(num_vars);
+        let mut var_id_to_col: BTreeMap<VariableId, usize> = BTreeMap::new();
+
+        for index in 0..num_vars {
+            let var_id = VariableId::new(index as u32);
+            let var = model
+                .get_variable(var_id)
+                .map_err(|_| SolverError::InvalidVariableId(var_id.inner()))?;
+
+            // IPOPT does not support integer variables
+            if var.is_integer {
+                return Err(SolverError::SolverSpecific(
+                    "IPOPT does not support integer variables".to_string(),
+                ));
+            }
+
+            let (lo, hi) = if var.is_active {
+                (var.bounds.lower, var.bounds.upper)
+            } else {
+                (0.0, 0.0) // fixed at zero
+            };
+
+            x_lower.push(clamp_bound(lo));
+            x_upper.push(clamp_bound(hi));
+            x_init.push(default_primal_value(lo, hi));
+            var_id_to_col.insert(var_id, index);
+        }
+
+        // Apply primal start hints
+        if let Some(hints) = primal_start {
+            for (var_id, value) in hints {
+                let Some(&col) = var_id_to_col.get(var_id) else {
+                    return Err(SolverError::InvalidVariableId(var_id.inner()));
+                };
+                x_init[col] = *value;
+            }
+        }
+
+        // Build dense objective coefficient vector
+        let mut obj_coeffs = vec![0.0; num_vars];
+        for (var_id, coeff) in &objective.terms {
+            let var = model
+                .get_variable(*var_id)
+                .map_err(|_| SolverError::InvalidVariableId(var_id.inner()))?;
+            if !var.is_active {
+                continue;
+            }
+            if let Some(&col) = var_id_to_col.get(var_id) {
+                obj_coeffs[col] += obj_sign * coeff;
+            }
+        }
+
+        // Collect constraint bounds and Jacobian in COO format
+        let num_constraints = model.num_constraints();
+        let mut g_lower = Vec::with_capacity(num_constraints);
+        let mut g_upper = Vec::with_capacity(num_constraints);
+        let mut jac_rows: Vec<Index> = Vec::new();
+        let mut jac_cols: Vec<Index> = Vec::new();
+        let mut jac_vals: Vec<f64> = Vec::new();
+
+        for con_index in 0..num_constraints {
+            let con_id = ConstraintId::new(con_index as u32);
+            let constraint = model.get_constraint(con_id).map_err(|_| {
+                SolverError::SolverSpecific(format!("constraint {} not found", con_index))
+            })?;
+            g_lower.push(clamp_bound(constraint.bounds.lower));
+            g_upper.push(clamp_bound(constraint.bounds.upper));
+        }
+
+        // Iterate columns (CSC) to build COO Jacobian
+        for (var_id, column) in model.columns() {
+            let var = match model.get_variable(var_id) {
+                Ok(v) => v,
+                Err(_) => continue,
+            };
+            if !var.is_active {
+                continue;
+            }
+            let Some(&col) = var_id_to_col.get(&var_id) else {
+                continue;
+            };
+            for (con_id, coeff) in column {
+                jac_rows.push(con_id.inner() as Index);
+                jac_cols.push(col as Index);
+                jac_vals.push(*coeff);
+            }
+        }
+
+        Ok(ArcoProblem {
+            num_vars,
+            x_lower,
+            x_upper,
+            x_init,
+            obj_coeffs,
+            obj_sign,
+            num_constraints,
+            g_lower,
+            g_upper,
+            jac_rows,
+            jac_cols,
+            jac_vals,
+        })
+    }
+}
+
+impl BasicProblem for ArcoProblem {
+    fn num_variables(&self) -> usize {
+        self.num_vars
+    }
+
+    fn bounds(&self, x_l: &mut [Number], x_u: &mut [Number]) -> bool {
+        x_l.copy_from_slice(&self.x_lower);
+        x_u.copy_from_slice(&self.x_upper);
+        true
+    }
+
+    fn initial_point(&self, x: &mut [Number]) -> bool {
+        x.copy_from_slice(&self.x_init);
+        true
+    }
+
+    fn objective(&self, x: &[Number], obj: &mut Number) -> bool {
+        // c^T x (coeffs already include obj_sign)
+        *obj = self.obj_coeffs.iter().zip(x).map(|(c, xi)| c * xi).sum();
+        true
+    }
+
+    fn objective_grad(&self, _x: &[Number], grad_f: &mut [Number]) -> bool {
+        // Constant gradient for LP (already includes obj_sign)
+        grad_f.copy_from_slice(&self.obj_coeffs);
+        true
+    }
+}
+
+impl ConstrainedProblem for ArcoProblem {
+    fn num_constraints(&self) -> usize {
+        self.num_constraints
+    }
+
+    fn num_constraint_jacobian_non_zeros(&self) -> usize {
+        self.jac_rows.len()
+    }
+
+    fn constraint(&self, x: &[Number], g: &mut [Number]) -> bool {
+        // g = A * x (sparse matrix-vector product via COO)
+        g.fill(0.0);
+        for ((&row, &col), &val) in self
+            .jac_rows
+            .iter()
+            .zip(self.jac_cols.iter())
+            .zip(self.jac_vals.iter())
+        {
+            g[row as usize] += val * x[col as usize];
+        }
+        true
+    }
+
+    fn constraint_bounds(&self, g_l: &mut [Number], g_u: &mut [Number]) -> bool {
+        g_l.copy_from_slice(&self.g_lower);
+        g_u.copy_from_slice(&self.g_upper);
+        true
+    }
+
+    fn constraint_jacobian_indices(&self, rows: &mut [Index], cols: &mut [Index]) -> bool {
+        rows.copy_from_slice(&self.jac_rows);
+        cols.copy_from_slice(&self.jac_cols);
+        true
+    }
+
+    fn constraint_jacobian_values(&self, _x: &[Number], vals: &mut [Number]) -> bool {
+        // Constant Jacobian for LP
+        vals.copy_from_slice(&self.jac_vals);
+        true
+    }
+
+    fn num_hessian_non_zeros(&self) -> usize {
+        // LP has zero Hessian; we use limited-memory BFGS approximation
+        0
+    }
+
+    fn hessian_indices(&self, _rows: &mut [Index], _cols: &mut [Index]) -> bool {
+        true
+    }
+
+    fn hessian_values(
+        &self,
+        _x: &[Number],
+        _obj_factor: Number,
+        _lambda: &[Number],
+        _vals: &mut [Number],
+    ) -> bool {
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arco_core::types::Bounds;
+    use arco_core::{Constraint, Objective, Sense, Variable};
+
+    #[test]
+    fn test_from_model_rejects_integer_variables() {
+        let mut model = Model::new();
+        let _x = model
+            .add_variable(Variable::integer(Bounds::new(0.0, 10.0)))
+            .unwrap();
+        model
+            .set_objective(Objective {
+                sense: Some(Sense::Minimize),
+                terms: vec![(_x, 1.0)],
+            })
+            .unwrap();
+
+        let result = ArcoProblem::from_model(&model, None);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_from_model_simple_lp() {
+        let mut model = Model::new();
+        let x = model
+            .add_variable(Variable::continuous(Bounds::new(0.0, f64::INFINITY)))
+            .unwrap();
+        let y = model
+            .add_variable(Variable::continuous(Bounds::new(0.0, f64::INFINITY)))
+            .unwrap();
+
+        let con = model
+            .add_constraint(Constraint {
+                bounds: Bounds::new(5.0, f64::INFINITY),
+            })
+            .unwrap();
+        model.set_coefficient(x, con, 1.0).unwrap();
+        model.set_coefficient(y, con, 1.0).unwrap();
+
+        model
+            .set_objective(Objective {
+                sense: Some(Sense::Minimize),
+                terms: vec![(x, 2.0), (y, 3.0)],
+            })
+            .unwrap();
+
+        let problem = ArcoProblem::from_model(&model, None).unwrap();
+        assert_eq!(problem.num_vars, 2);
+        assert_eq!(problem.num_constraints, 1);
+        assert_eq!(problem.obj_sign, 1.0);
+        assert_eq!(problem.jac_rows.len(), 2);
+    }
+
+    #[test]
+    fn test_maximize_negates_coefficients() {
+        let mut model = Model::new();
+        let x = model
+            .add_variable(Variable::continuous(Bounds::new(0.0, 10.0)))
+            .unwrap();
+
+        model
+            .set_objective(Objective {
+                sense: Some(Sense::Maximize),
+                terms: vec![(x, 3.0)],
+            })
+            .unwrap();
+
+        let problem = ArcoProblem::from_model(&model, None).unwrap();
+        assert_eq!(problem.obj_sign, -1.0);
+        // Coefficient should be negated: -1 * 3.0 = -3.0
+        assert!((problem.obj_coeffs[0] - (-3.0)).abs() < 1e-12);
+    }
+}

--- a/crates/arco-ipopt/src/solution.rs
+++ b/crates/arco-ipopt/src/solution.rs
@@ -1,0 +1,201 @@
+//! IPOPT solution type and trait implementations.
+
+use crate::problem::ArcoProblem;
+use crate::status::{
+    ipopt_has_solution, ipopt_status_string, ipopt_to_core_status, ipopt_to_generic_status,
+};
+use arco_core::solver::{Solution as CoreSolution, SolverStatus as CoreSolverStatus};
+use arco_solver::{SolutionView, SolverStatus};
+use ipopt::SolveStatus;
+use std::collections::BTreeMap;
+
+/// Solution from the IPOPT solver.
+#[derive(Debug, Clone)]
+pub struct Solution {
+    pub(crate) primal_values: Vec<f64>,
+    pub(crate) variable_duals: Vec<f64>,
+    pub(crate) constraint_duals: Vec<f64>,
+    pub(crate) row_values: Vec<f64>,
+    pub(crate) objective_value: f64,
+    pub(crate) status: SolveStatus,
+    pub(crate) solve_time_seconds: f64,
+}
+
+impl Solution {
+    /// Build a `Solution` from IPOPT's raw output.
+    ///
+    /// `obj_sign` is +1 for minimize, -1 for maximize. When maximizing, we
+    /// negate the objective and duals back to the user's convention.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn from_ipopt(
+        primal: &[f64],
+        lower_bound_mult: &[f64],
+        upper_bound_mult: &[f64],
+        constraint_mult: &[f64],
+        constraint_values: &[f64],
+        raw_objective: f64,
+        status: SolveStatus,
+        solve_time: f64,
+        problem: &ArcoProblem,
+    ) -> Self {
+        let obj_sign = problem.obj_sign;
+
+        // Variable duals = lower_bound_mult - upper_bound_mult
+        // For maximize, negate to match user convention.
+        let variable_duals: Vec<f64> = lower_bound_mult
+            .iter()
+            .zip(upper_bound_mult.iter())
+            .map(|(lo, hi)| obj_sign * (lo - hi))
+            .collect();
+
+        // Constraint duals: IPOPT gives multipliers for the Lagrangian.
+        // For maximize, negate to match user convention.
+        let constraint_duals: Vec<f64> = constraint_mult.iter().map(|&m| obj_sign * m).collect();
+
+        // Negate objective back for maximize
+        let objective_value = obj_sign * raw_objective;
+
+        Solution {
+            primal_values: primal.to_vec(),
+            variable_duals,
+            constraint_duals,
+            row_values: constraint_values.to_vec(),
+            objective_value,
+            status,
+            solve_time_seconds: solve_time,
+        }
+    }
+
+    /// Get the primal value of a variable at the given index.
+    pub fn get_primal(&self, index: usize) -> Option<f64> {
+        self.primal_values.get(index).copied()
+    }
+
+    /// Get the dual value (reduced cost) of a variable at the given index.
+    pub fn get_variable_dual(&self, index: usize) -> Option<f64> {
+        self.variable_duals.get(index).copied()
+    }
+
+    /// Get the dual value (shadow price) of a constraint at the given index.
+    pub fn get_constraint_dual(&self, index: usize) -> Option<f64> {
+        self.constraint_duals.get(index).copied()
+    }
+
+    /// Get the objective value.
+    pub fn objective_value(&self) -> f64 {
+        self.objective_value
+    }
+
+    /// Get the IPOPT-specific status.
+    pub fn ipopt_status(&self) -> SolveStatus {
+        self.status
+    }
+
+    /// Get all primal values.
+    pub fn primal_values(&self) -> &[f64] {
+        &self.primal_values
+    }
+
+    /// Get all variable dual values.
+    pub fn variable_duals(&self) -> &[f64] {
+        &self.variable_duals
+    }
+
+    /// Get all constraint dual values.
+    pub fn constraint_duals(&self) -> &[f64] {
+        &self.constraint_duals
+    }
+
+    /// Get solve time in seconds.
+    pub fn solve_time_seconds(&self) -> f64 {
+        self.solve_time_seconds
+    }
+
+    /// Check if solution is optimal.
+    pub fn is_optimal(&self) -> bool {
+        matches!(
+            self.status,
+            SolveStatus::SolveSucceeded | SolveStatus::SolvedToAcceptableLevel
+        )
+    }
+
+    /// Check if solution is feasible (includes optimal and limit-reached).
+    pub fn is_feasible(&self) -> bool {
+        ipopt_has_solution(self.status)
+    }
+
+    /// Check if solution is infeasible.
+    pub fn is_infeasible(&self) -> bool {
+        matches!(
+            self.status,
+            SolveStatus::InfeasibleProblemDetected | SolveStatus::RestorationFailed
+        )
+    }
+
+    /// Check if solution is unbounded.
+    pub fn is_unbounded(&self) -> bool {
+        matches!(self.status, SolveStatus::DivergingIterates)
+    }
+
+    /// Get solution status as a human-readable string.
+    pub fn status_string(&self) -> &'static str {
+        ipopt_status_string(self.status)
+    }
+
+    /// Convert the IPOPT status to an `arco_core::SolverStatus`.
+    pub fn core_status(&self) -> CoreSolverStatus {
+        ipopt_to_core_status(self.status)
+    }
+
+    /// Convert this IPOPT-specific solution into a solver-agnostic `arco_core::Solution`.
+    pub fn into_core_solution(self) -> CoreSolution {
+        CoreSolution {
+            primal_values: self.primal_values,
+            variable_duals: self.variable_duals,
+            constraint_duals: self.constraint_duals,
+            row_values: self.row_values,
+            objective_value: self.objective_value,
+            status: ipopt_to_core_status(self.status),
+            solve_time_seconds: self.solve_time_seconds,
+            metadata: BTreeMap::new(),
+        }
+    }
+}
+
+impl SolutionView for Solution {
+    fn objective_value(&self) -> f64 {
+        self.objective_value
+    }
+
+    fn status(&self) -> SolverStatus {
+        ipopt_to_generic_status(self.status)
+    }
+
+    fn get_primal(&self, index: usize) -> Option<f64> {
+        self.primal_values.get(index).copied()
+    }
+
+    fn get_variable_dual(&self, index: usize) -> Option<f64> {
+        self.variable_duals.get(index).copied()
+    }
+
+    fn get_constraint_dual(&self, index: usize) -> Option<f64> {
+        self.constraint_duals.get(index).copied()
+    }
+
+    fn primal_values(&self) -> &[f64] {
+        &self.primal_values
+    }
+
+    fn variable_duals(&self) -> &[f64] {
+        &self.variable_duals
+    }
+
+    fn constraint_duals(&self) -> &[f64] {
+        &self.constraint_duals
+    }
+
+    fn solve_time_seconds(&self) -> f64 {
+        self.solve_time_seconds
+    }
+}

--- a/crates/arco-ipopt/src/solver.rs
+++ b/crates/arco-ipopt/src/solver.rs
@@ -1,0 +1,309 @@
+//! IPOPT solver implementation.
+
+use crate::problem::ArcoProblem;
+use crate::solution::Solution;
+use crate::status::{ipopt_has_solution, ipopt_to_core_status};
+use arco_core::solver::SolverError as CoreSolverError;
+use arco_core::Model;
+use arco_expr::VariableId;
+use arco_solver::{Solve, SolverBackend, SolverConfig, SolverError as GenericSolverError};
+use ipopt::Ipopt;
+use std::time::Instant;
+use tracing::{debug, warn};
+
+/// Re-export of [`arco_core::solver::SolverError`] for backward compatibility.
+pub type SolverError = CoreSolverError;
+
+/// IPOPT solver wrapper.
+pub struct Solver {
+    model: Model,
+    config: SolverConfig,
+    primal_start: Option<Vec<(VariableId, f64)>>,
+}
+
+impl Solver {
+    /// Create a new IPOPT solver from a Model.
+    pub fn new(model: Model) -> Result<Self, SolverError> {
+        validate_model(&model)?;
+
+        debug!(
+            component = "solver",
+            operation = "init",
+            status = "success",
+            solver = "ipopt",
+            variables = model.num_variables() as u64,
+            constraints = model.num_constraints() as u64,
+            "Creating IPOPT solver from model"
+        );
+
+        Ok(Solver {
+            model,
+            config: SolverConfig::new(),
+            primal_start: None,
+        })
+    }
+
+    fn update_config(&mut self, update: impl FnOnce(SolverConfig) -> SolverConfig) {
+        self.config = update(std::mem::take(&mut self.config));
+    }
+
+    /// Enable or disable IPOPT logging to console for the next solve.
+    pub fn set_log_to_console(&mut self, enabled: bool) {
+        self.update_config(|config| config.with_log_to_console(enabled));
+    }
+
+    /// Set a time limit in seconds for the next solve.
+    pub fn set_time_limit(&mut self, seconds: f64) {
+        self.update_config(|config| config.with_time_limit(seconds));
+    }
+
+    /// Set verbosity level for the next solve.
+    pub fn set_verbosity(&mut self, level: u32) {
+        self.update_config(|config| config.with_verbosity(level));
+    }
+
+    /// Set feasibility tolerance for the next solve.
+    pub fn set_tolerance(&mut self, tolerance: f64) {
+        self.update_config(|config| config.with_tolerance(tolerance));
+    }
+
+    /// Set primal start values (warm-start hints).
+    pub fn set_primal_start(&mut self, hints: &[(VariableId, f64)]) -> Result<(), SolverError> {
+        for (var_id, _) in hints {
+            if self.model.get_variable(*var_id).is_err() {
+                return Err(SolverError::InvalidVariableId(var_id.inner()));
+            }
+        }
+        self.primal_start = Some(hints.to_vec());
+        debug!(
+            component = "solver",
+            operation = "set_primal_start",
+            status = "success",
+            num_hints = hints.len(),
+            "Stored warm-start hints"
+        );
+        Ok(())
+    }
+
+    /// Clear primal start hints.
+    pub fn clear_primal_start(&mut self) {
+        self.primal_start = None;
+    }
+
+    /// Get current primal start hints.
+    pub fn get_primal_start(&self) -> Option<&[(VariableId, f64)]> {
+        self.primal_start.as_deref()
+    }
+
+    /// Get access to the current solver configuration.
+    pub fn config(&self) -> &SolverConfig {
+        &self.config
+    }
+
+    /// Set the solver configuration.
+    pub fn set_config(&mut self, config: SolverConfig) {
+        self.config = config;
+    }
+
+    /// Solve the model and return the solution.
+    pub fn solve(&mut self) -> Result<Solution, SolverError> {
+        solve_model(&self.model, &self.config, self.primal_start.as_deref())
+    }
+
+    /// Solve the model with a specific configuration.
+    pub fn solve_with_config(&mut self, config: &SolverConfig) -> Result<Solution, SolverError> {
+        solve_model(&self.model, config, self.primal_start.as_deref())
+    }
+}
+
+impl Solve for Solver {
+    type Solution = Solution;
+
+    fn solve(&mut self, config: &SolverConfig) -> Result<Self::Solution, GenericSolverError> {
+        self.solve_with_config(config).map_err(Into::into)
+    }
+}
+
+/// Zero-sized backend for trait-based dispatch from the Python bindings.
+pub struct IpoptBackend;
+
+impl SolverBackend for IpoptBackend {
+    fn solve(
+        &self,
+        model: &Model,
+        config: &SolverConfig,
+        primal_start: Option<&[(VariableId, f64)]>,
+    ) -> Result<arco_core::solver::Solution, GenericSolverError> {
+        solve_model(model, config, primal_start)
+            .map(|s| s.into_core_solution())
+            .map_err(Into::into)
+    }
+
+    fn name(&self) -> &'static str {
+        "IPOPT"
+    }
+
+    fn supports_integer(&self) -> bool {
+        false
+    }
+}
+
+/// Validate that a model is ready for solving.
+fn validate_model(model: &Model) -> Result<(), SolverError> {
+    if model.num_variables() == 0 {
+        return Err(SolverError::EmptyModel);
+    }
+    Ok(())
+}
+
+/// Apply `SolverConfig` to an IPOPT solver instance.
+fn apply_ipopt_config<P: ipopt::ConstrainedProblem>(ipopt: &mut Ipopt<P>, config: &SolverConfig) {
+    // Always use limited-memory BFGS for LP (zero Hessian)
+    ipopt.set_option("hessian_approximation", "limited-memory");
+
+    // Suppress output by default; use level 5 when console logging is enabled
+    let log_enabled = config.log_to_console.unwrap_or(false);
+    let default_level = if log_enabled { 5 } else { 0 };
+    let print_level = config.verbosity.map_or(default_level, |v| v.min(12) as i32);
+    ipopt.set_option("print_level", print_level);
+
+    if let Some(limit) = config.time_limit {
+        ipopt.set_option("max_cpu_time", limit);
+    }
+    if let Some(tol) = config.tolerance {
+        ipopt.set_option("tol", tol);
+        ipopt.set_option("constr_viol_tol", tol);
+    }
+}
+
+/// Solve a model with the given config.
+fn solve_model(
+    model: &Model,
+    config: &SolverConfig,
+    primal_start: Option<&[(VariableId, f64)]>,
+) -> Result<Solution, SolverError> {
+    validate_model(model)?;
+
+    let solve_started = Instant::now();
+
+    debug!(
+        component = "solver",
+        operation = "solve",
+        solver = "ipopt",
+        variables = model.num_variables() as u64,
+        constraints = model.num_constraints() as u64,
+        "Starting IPOPT solve"
+    );
+
+    let problem = ArcoProblem::from_model(model, primal_start)?;
+
+    let mut ipopt = Ipopt::new(problem).map_err(|e| {
+        SolverError::SolverSpecific(format!("Failed to create IPOPT problem: {e:?}"))
+    })?;
+
+    apply_ipopt_config(&mut ipopt, config);
+
+    let result = ipopt.solve();
+    let solve_time = solve_started.elapsed().as_secs_f64();
+
+    let status = result.status;
+    let raw_objective = result.objective_value;
+
+    debug!(
+        component = "solver",
+        operation = "solve",
+        solver = "ipopt",
+        solver_status = ?status,
+        objective_value = raw_objective,
+        duration_ms = solve_time * 1000.0,
+        "IPOPT solve completed"
+    );
+
+    if !ipopt_has_solution(status) {
+        warn!(
+            component = "solver",
+            operation = "solve",
+            status = "warn",
+            solver = "ipopt",
+            solver_status = ?status,
+            duration_ms = solve_time * 1000.0,
+            "Solver did not find optimal solution"
+        );
+        return Err(SolverError::SolveFailure {
+            status: ipopt_to_core_status(status),
+        });
+    }
+
+    let sol = &result.solver_data.solution;
+
+    Ok(Solution::from_ipopt(
+        sol.primal_variables,
+        sol.lower_bound_multipliers,
+        sol.upper_bound_multipliers,
+        sol.constraint_multipliers,
+        result.constraint_values,
+        raw_objective,
+        status,
+        solve_time,
+        result.solver_data.problem,
+    ))
+}
+
+#[cfg(test)]
+#[allow(clippy::float_cmp)]
+mod tests {
+    use super::*;
+    use arco_core::types::Bounds;
+    use arco_core::{Objective, Sense, Variable};
+
+    #[test]
+    fn test_solver_new_rejects_empty_model() {
+        let model = Model::new();
+        assert!(matches!(
+            Solver::new(model),
+            Err(SolverError::EmptyModel)
+        ));
+    }
+
+    fn build_single_variable_model() -> Model {
+        let mut model = Model::new();
+        let x = model
+            .add_variable(Variable::continuous(Bounds::new(0.0, f64::INFINITY)))
+            .expect("variable");
+        model
+            .set_objective(Objective {
+                sense: Some(Sense::Minimize),
+                terms: vec![(x, 1.0)],
+            })
+            .expect("objective");
+        model
+    }
+
+    #[test]
+    fn test_primal_start_storage() {
+        let model = build_single_variable_model();
+        let mut solver = Solver::new(model).unwrap();
+        let hints = vec![(VariableId::new(0), 5.0)];
+        assert!(solver.set_primal_start(&hints).is_ok());
+        assert_eq!(solver.get_primal_start(), Some(hints.as_slice()));
+    }
+
+    #[test]
+    fn test_primal_start_validation() {
+        let model = build_single_variable_model();
+        let mut solver = Solver::new(model).unwrap();
+        let invalid_hints = vec![(VariableId::new(9999), 0.5)];
+        assert!(solver.set_primal_start(&invalid_hints).is_err());
+    }
+
+    #[test]
+    fn test_primal_start_clear() {
+        let model = build_single_variable_model();
+        let mut solver = Solver::new(model).unwrap();
+        let hints = vec![(VariableId::new(0), 5.0)];
+        solver.set_primal_start(&hints).unwrap();
+        assert!(solver.get_primal_start().is_some());
+        solver.clear_primal_start();
+        assert!(solver.get_primal_start().is_none());
+    }
+}

--- a/crates/arco-ipopt/src/solver.rs
+++ b/crates/arco-ipopt/src/solver.rs
@@ -3,8 +3,8 @@
 use crate::problem::ArcoProblem;
 use crate::solution::Solution;
 use crate::status::{ipopt_has_solution, ipopt_to_core_status};
-use arco_core::solver::SolverError as CoreSolverError;
 use arco_core::Model;
+use arco_core::solver::SolverError as CoreSolverError;
 use arco_expr::VariableId;
 use arco_solver::{Solve, SolverBackend, SolverConfig, SolverError as GenericSolverError};
 use ipopt::Ipopt;
@@ -259,10 +259,7 @@ mod tests {
     #[test]
     fn test_solver_new_rejects_empty_model() {
         let model = Model::new();
-        assert!(matches!(
-            Solver::new(model),
-            Err(SolverError::EmptyModel)
-        ));
+        assert!(matches!(Solver::new(model), Err(SolverError::EmptyModel)));
     }
 
     fn build_single_variable_model() -> Model {

--- a/crates/arco-ipopt/src/status.rs
+++ b/crates/arco-ipopt/src/status.rs
@@ -1,0 +1,96 @@
+//! IPOPT status to Arco status mapping.
+
+use arco_core::solver::SolverStatus as CoreSolverStatus;
+use arco_solver::SolverStatus;
+use ipopt::SolveStatus;
+
+pub(crate) fn ipopt_to_core_status(status: SolveStatus) -> CoreSolverStatus {
+    match status {
+        SolveStatus::SolveSucceeded | SolveStatus::SolvedToAcceptableLevel => {
+            CoreSolverStatus::Optimal
+        }
+        SolveStatus::InfeasibleProblemDetected | SolveStatus::RestorationFailed => {
+            CoreSolverStatus::Infeasible
+        }
+        SolveStatus::DivergingIterates => CoreSolverStatus::Unbounded,
+        SolveStatus::MaximumIterationsExceeded => CoreSolverStatus::IterationLimit,
+        SolveStatus::MaximumCpuTimeExceeded => CoreSolverStatus::TimeLimit,
+        _ => CoreSolverStatus::Unknown,
+    }
+}
+
+pub(crate) fn ipopt_to_generic_status(status: SolveStatus) -> SolverStatus {
+    ipopt_to_core_status(status).into()
+}
+
+pub(crate) fn ipopt_status_string(status: SolveStatus) -> &'static str {
+    match status {
+        SolveStatus::SolveSucceeded => "optimal",
+        SolveStatus::SolvedToAcceptableLevel => "acceptable",
+        SolveStatus::InfeasibleProblemDetected => "infeasible",
+        SolveStatus::DivergingIterates => "unbounded",
+        SolveStatus::MaximumIterationsExceeded => "iteration_limit",
+        SolveStatus::MaximumCpuTimeExceeded => "time_limit",
+        SolveStatus::RestorationFailed => "restoration_failed",
+        SolveStatus::UserRequestedStop => "user_stopped",
+        _ => "unknown",
+    }
+}
+
+pub(crate) fn ipopt_has_solution(status: SolveStatus) -> bool {
+    matches!(
+        status,
+        SolveStatus::SolveSucceeded
+            | SolveStatus::SolvedToAcceptableLevel
+            | SolveStatus::MaximumIterationsExceeded
+            | SolveStatus::MaximumCpuTimeExceeded
+            | SolveStatus::FeasiblePointFound
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ipopt_to_core_mapping() {
+        assert_eq!(
+            ipopt_to_core_status(SolveStatus::SolveSucceeded),
+            CoreSolverStatus::Optimal
+        );
+        assert_eq!(
+            ipopt_to_core_status(SolveStatus::SolvedToAcceptableLevel),
+            CoreSolverStatus::Optimal
+        );
+        assert_eq!(
+            ipopt_to_core_status(SolveStatus::InfeasibleProblemDetected),
+            CoreSolverStatus::Infeasible
+        );
+        assert_eq!(
+            ipopt_to_core_status(SolveStatus::DivergingIterates),
+            CoreSolverStatus::Unbounded
+        );
+        assert_eq!(
+            ipopt_to_core_status(SolveStatus::MaximumIterationsExceeded),
+            CoreSolverStatus::IterationLimit
+        );
+        assert_eq!(
+            ipopt_to_core_status(SolveStatus::MaximumCpuTimeExceeded),
+            CoreSolverStatus::TimeLimit
+        );
+    }
+
+    #[test]
+    fn test_status_helpers() {
+        assert!(ipopt_has_solution(SolveStatus::SolveSucceeded));
+        assert!(ipopt_has_solution(SolveStatus::SolvedToAcceptableLevel));
+        assert!(ipopt_has_solution(SolveStatus::MaximumIterationsExceeded));
+        assert!(!ipopt_has_solution(SolveStatus::InfeasibleProblemDetected));
+        assert!(!ipopt_has_solution(SolveStatus::DivergingIterates));
+        assert_eq!(ipopt_status_string(SolveStatus::SolveSucceeded), "optimal");
+        assert_eq!(
+            ipopt_status_string(SolveStatus::InfeasibleProblemDetected),
+            "infeasible"
+        );
+    }
+}

--- a/crates/arco-ipopt/tests/integration.rs
+++ b/crates/arco-ipopt/tests/integration.rs
@@ -1,0 +1,304 @@
+#![allow(clippy::float_cmp)]
+
+use arco_core::types::Bounds;
+use arco_core::{Constraint, Model, Objective, Sense, Variable};
+use arco_expr::VariableId;
+use arco_ipopt::Solver;
+
+/// Test: minimize 2x + 3y subject to x + y >= 5, x,y >= 0
+#[test]
+fn test_simple_lp() {
+    let mut model = Model::new();
+
+    let x = model
+        .add_variable(Variable::continuous(Bounds::new(0.0, f64::INFINITY)))
+        .unwrap();
+
+    let y = model
+        .add_variable(Variable::continuous(Bounds::new(0.0, f64::INFINITY)))
+        .unwrap();
+
+    let constraint = model
+        .add_constraint(Constraint {
+            bounds: Bounds::new(5.0, f64::INFINITY),
+        })
+        .unwrap();
+
+    model.set_coefficient(x, constraint, 1.0).unwrap();
+    model.set_coefficient(y, constraint, 1.0).unwrap();
+
+    let objective = Objective {
+        sense: Some(Sense::Minimize),
+        terms: vec![(x, 2.0), (y, 3.0)],
+    };
+    model.set_objective(objective).unwrap();
+
+    let mut solver = Solver::new(model).expect("Failed to create solver");
+    solver.set_log_to_console(false);
+    let solution = solver.solve().expect("Failed to solve");
+
+    assert!(
+        (solution.objective_value() - 10.0).abs() < 1e-4,
+        "Expected objective value 10.0, got {}",
+        solution.objective_value()
+    );
+}
+
+/// Test: maximize x subject to x <= 10
+#[test]
+fn test_maximize_lp() {
+    let mut model = Model::new();
+
+    let x = model
+        .add_variable(Variable::continuous(Bounds::new(0.0, f64::INFINITY)))
+        .unwrap();
+
+    let constraint = model
+        .add_constraint(Constraint {
+            bounds: Bounds::new(f64::NEG_INFINITY, 10.0),
+        })
+        .unwrap();
+
+    model.set_coefficient(x, constraint, 1.0).unwrap();
+
+    let objective = Objective {
+        sense: Some(Sense::Maximize),
+        terms: vec![(x, 1.0)],
+    };
+    model.set_objective(objective).unwrap();
+
+    let mut solver = Solver::new(model).expect("Failed to create solver");
+    solver.set_log_to_console(false);
+    let solution = solver.solve().expect("Failed to solve");
+
+    assert!(
+        (solution.objective_value() - 10.0).abs() < 1e-4,
+        "Expected objective value 10.0, got {}",
+        solution.objective_value()
+    );
+}
+
+/// Test: dual values have correct lengths and are finite
+#[test]
+fn test_dual_values() {
+    let mut model = Model::new();
+
+    let x = model
+        .add_variable(Variable::continuous(Bounds::new(0.0, 10.0)))
+        .unwrap();
+
+    let y = model
+        .add_variable(Variable::continuous(Bounds::new(0.0, 10.0)))
+        .unwrap();
+
+    let constraint = model
+        .add_constraint(Constraint {
+            bounds: Bounds::new(0.0, 5.0),
+        })
+        .unwrap();
+
+    model.set_coefficient(x, constraint, 1.0).unwrap();
+    model.set_coefficient(y, constraint, 1.0).unwrap();
+
+    let objective = Objective {
+        sense: Some(Sense::Minimize),
+        terms: vec![(x, 1.0), (y, 1.0)],
+    };
+    model.set_objective(objective).unwrap();
+
+    let num_variables = model.num_variables();
+    let num_constraints = model.num_constraints();
+
+    let mut solver = Solver::new(model).unwrap();
+    solver.set_log_to_console(false);
+    let solution = solver.solve().unwrap();
+
+    assert_eq!(solution.variable_duals().len(), num_variables);
+    assert_eq!(solution.constraint_duals().len(), num_constraints);
+    assert!(solution
+        .variable_duals()
+        .iter()
+        .all(|value| value.is_finite()));
+    assert!(solution
+        .constraint_duals()
+        .iter()
+        .all(|value| value.is_finite()));
+}
+
+/// Test: model with integer variable is rejected
+#[test]
+fn test_integer_rejection() {
+    let mut model = Model::new();
+
+    let x = model
+        .add_variable(Variable::integer(Bounds::new(0.0, 10.0)))
+        .unwrap();
+
+    let objective = Objective {
+        sense: Some(Sense::Minimize),
+        terms: vec![(x, 1.0)],
+    };
+    model.set_objective(objective).unwrap();
+
+    let mut solver = Solver::new(model).unwrap();
+    solver.set_log_to_console(false);
+    let result = solver.solve();
+    assert!(result.is_err(), "Should reject integer variables");
+}
+
+/// Test: infeasible model returns SolveFailure
+#[test]
+fn test_infeasible() {
+    let mut model = Model::new();
+
+    let x = model
+        .add_variable(Variable::continuous(Bounds::new(0.0, 10.0)))
+        .unwrap();
+
+    // x >= 20 AND x <= 10 (infeasible)
+    let constraint = model
+        .add_constraint(Constraint {
+            bounds: Bounds::new(20.0, f64::INFINITY),
+        })
+        .unwrap();
+    model.set_coefficient(x, constraint, 1.0).unwrap();
+
+    let objective = Objective {
+        sense: Some(Sense::Minimize),
+        terms: vec![(x, 1.0)],
+    };
+    model.set_objective(objective).unwrap();
+
+    let mut solver = Solver::new(model).unwrap();
+    solver.set_log_to_console(false);
+    let result = solver.solve();
+    assert!(result.is_err(), "Infeasible problem should fail to solve");
+}
+
+/// Test: primal start (warm-start hints) storage, validation, clear, solve
+#[test]
+fn test_primal_start() {
+    let mut model = Model::new();
+
+    let x = model
+        .add_variable(Variable::continuous(Bounds::new(0.0, 10.0)))
+        .unwrap();
+
+    let y = model
+        .add_variable(Variable::continuous(Bounds::new(0.0, 10.0)))
+        .unwrap();
+
+    let constraint = model
+        .add_constraint(Constraint {
+            bounds: Bounds::new(0.0, 5.0),
+        })
+        .unwrap();
+    model.set_coefficient(x, constraint, 1.0).unwrap();
+    model.set_coefficient(y, constraint, 1.0).unwrap();
+
+    let objective = Objective {
+        sense: Some(Sense::Minimize),
+        terms: vec![(x, 1.0), (y, 1.0)],
+    };
+    model.set_objective(objective).unwrap();
+
+    let mut solver = Solver::new(model).unwrap();
+    solver.set_log_to_console(false);
+
+    // Storage
+    let hints = vec![(VariableId::new(0), 2.0), (VariableId::new(1), 1.0)];
+    assert!(solver.set_primal_start(&hints).is_ok());
+    assert_eq!(solver.get_primal_start(), Some(hints.as_slice()));
+
+    // Validation
+    let bad_hints = vec![(VariableId::new(9999), 0.5)];
+    assert!(solver.set_primal_start(&bad_hints).is_err());
+
+    // Clear
+    solver.set_primal_start(&hints).unwrap();
+    solver.clear_primal_start();
+    assert!(solver.get_primal_start().is_none());
+
+    // Solve with hints
+    solver.set_primal_start(&hints).unwrap();
+    let solution = solver.solve().unwrap();
+    assert!(
+        (solution.objective_value() - 0.0).abs() < 1e-4,
+        "Expected objective value 0.0, got {}",
+        solution.objective_value()
+    );
+}
+
+/// Test: solution status methods
+#[test]
+fn test_solution_status_methods() {
+    let mut model = Model::new();
+
+    let x = model
+        .add_variable(Variable::continuous(Bounds::new(0.0, 10.0)))
+        .unwrap();
+
+    let constraint = model
+        .add_constraint(Constraint {
+            bounds: Bounds::new(0.0, 5.0),
+        })
+        .unwrap();
+    model.set_coefficient(x, constraint, 1.0).unwrap();
+
+    let objective = Objective {
+        sense: Some(Sense::Minimize),
+        terms: vec![(x, 1.0)],
+    };
+    model.set_objective(objective).unwrap();
+
+    let mut solver = Solver::new(model).unwrap();
+    solver.set_log_to_console(false);
+    let solution = solver.solve().unwrap();
+
+    assert!(solution.is_optimal(), "Solution should be optimal");
+    assert!(solution.is_feasible(), "Solution should be feasible");
+    assert!(
+        !solution.is_infeasible(),
+        "Solution should not be infeasible"
+    );
+    assert!(!solution.is_unbounded(), "Solution should not be unbounded");
+
+    let status_str = solution.status_string();
+    assert!(
+        status_str == "optimal" || status_str == "acceptable",
+        "Status string should be 'optimal' or 'acceptable', got '{}'",
+        status_str
+    );
+}
+
+/// Test: solution metadata (solve_time > 0)
+#[test]
+fn test_solution_metadata() {
+    let mut model = Model::new();
+
+    let x = model
+        .add_variable(Variable::continuous(Bounds::new(0.0, 10.0)))
+        .unwrap();
+
+    let constraint = model
+        .add_constraint(Constraint {
+            bounds: Bounds::new(0.0, 5.0),
+        })
+        .unwrap();
+    model.set_coefficient(x, constraint, 1.0).unwrap();
+
+    let objective = Objective {
+        sense: Some(Sense::Minimize),
+        terms: vec![(x, 1.0)],
+    };
+    model.set_objective(objective).unwrap();
+
+    let mut solver = Solver::new(model).unwrap();
+    solver.set_log_to_console(false);
+    let solution = solver.solve().unwrap();
+
+    assert!(
+        solution.solve_time_seconds() > 0.0,
+        "Solve time should be positive"
+    );
+}

--- a/crates/arco-ipopt/tests/integration.rs
+++ b/crates/arco-ipopt/tests/integration.rs
@@ -115,14 +115,18 @@ fn test_dual_values() {
 
     assert_eq!(solution.variable_duals().len(), num_variables);
     assert_eq!(solution.constraint_duals().len(), num_constraints);
-    assert!(solution
-        .variable_duals()
-        .iter()
-        .all(|value| value.is_finite()));
-    assert!(solution
-        .constraint_duals()
-        .iter()
-        .all(|value| value.is_finite()));
+    assert!(
+        solution
+            .variable_duals()
+            .iter()
+            .all(|value| value.is_finite())
+    );
+    assert!(
+        solution
+            .constraint_duals()
+            .iter()
+            .all(|value| value.is_finite())
+    );
 }
 
 /// Test: model with integer variable is rejected

--- a/crates/arco-solver/Cargo.toml
+++ b/crates/arco-solver/Cargo.toml
@@ -14,5 +14,7 @@ publish = false
 workspace = true
 
 [dependencies]
+arco-core = { workspace = true }
+arco-expr = { workspace = true }
 
 [dev-dependencies]

--- a/crates/arco-solver/src/backend.rs
+++ b/crates/arco-solver/src/backend.rs
@@ -1,0 +1,30 @@
+//! Solver backend trait for dispatching solves through a unified interface.
+
+use arco_core::Model;
+use arco_core::solver::Solution as CoreSolution;
+use arco_expr::VariableId;
+
+use crate::{SolverConfig, SolverError};
+
+/// A solver backend that can solve a model with a given configuration.
+///
+/// Each solver crate (e.g., `arco-highs`, `arco-ipopt`) exports a zero-sized
+/// struct implementing this trait. The Python bindings dispatch through
+/// `&dyn SolverBackend` instead of per-solver match arms.
+pub trait SolverBackend {
+    /// Solve the model and return a solver-agnostic solution.
+    fn solve(
+        &self,
+        model: &Model,
+        config: &SolverConfig,
+        primal_start: Option<&[(VariableId, f64)]>,
+    ) -> Result<CoreSolution, SolverError>;
+
+    /// Human-readable solver name (e.g., `"HiGHS"`, `"IPOPT"`).
+    fn name(&self) -> &'static str;
+
+    /// Whether this backend supports integer/binary variables.
+    fn supports_integer(&self) -> bool {
+        true
+    }
+}

--- a/crates/arco-solver/src/error.rs
+++ b/crates/arco-solver/src/error.rs
@@ -76,6 +76,24 @@ fn status_message(status: SolverStatus) -> &'static str {
 
 impl std::error::Error for SolverError {}
 
+impl From<arco_core::solver::SolverError> for SolverError {
+    fn from(err: arco_core::solver::SolverError) -> Self {
+        use arco_core::solver::SolverError as Core;
+        match err {
+            Core::EmptyModel => SolverError::EmptyModel,
+            Core::NoObjective => SolverError::NoObjective,
+            Core::InvalidObjectiveSense => SolverError::InvalidObjectiveSense,
+            Core::InvalidVariableId(id) => SolverError::InvalidVariableId(id),
+            Core::SolverNotAvailable(msg) | Core::SolverSpecific(msg) => {
+                SolverError::InternalError(msg)
+            }
+            Core::SolveFailure { status } => SolverError::SolveFailure {
+                status: status.into(),
+            },
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/arco-solver/src/lib.rs
+++ b/crates/arco-solver/src/lib.rs
@@ -11,11 +11,13 @@
 //! - [`Solve`]: Trait for solver implementations
 //! - [`SolutionView`]: Trait for accessing solution data
 
+mod backend;
 mod config;
 mod error;
 mod status;
 mod traits;
 
+pub use backend::SolverBackend;
 pub use config::SolverConfig;
 pub use error::SolverError;
 pub use status::SolverStatus;

--- a/crates/arco-solver/src/status.rs
+++ b/crates/arco-solver/src/status.rs
@@ -43,6 +43,19 @@ impl SolverStatus {
         matches!(self, SolverStatus::Unbounded)
     }
 
+    /// Convert to the corresponding [`arco_core::solver::SolverStatus`].
+    pub fn to_core_status(self) -> arco_core::solver::SolverStatus {
+        use arco_core::solver::SolverStatus as Core;
+        match self {
+            SolverStatus::Optimal => Core::Optimal,
+            SolverStatus::Infeasible => Core::Infeasible,
+            SolverStatus::Unbounded => Core::Unbounded,
+            SolverStatus::ReachedTimeLimit => Core::TimeLimit,
+            SolverStatus::ReachedIterationLimit => Core::IterationLimit,
+            SolverStatus::Unknown => Core::Unknown,
+        }
+    }
+
     /// Get a human-readable string representation.
     pub fn as_str(self) -> &'static str {
         match self {
@@ -59,6 +72,20 @@ impl SolverStatus {
 impl std::fmt::Display for SolverStatus {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.as_str())
+    }
+}
+
+impl From<arco_core::solver::SolverStatus> for SolverStatus {
+    fn from(status: arco_core::solver::SolverStatus) -> Self {
+        use arco_core::solver::SolverStatus as Core;
+        match status {
+            Core::Optimal => SolverStatus::Optimal,
+            Core::Infeasible => SolverStatus::Infeasible,
+            Core::Unbounded => SolverStatus::Unbounded,
+            Core::TimeLimit => SolverStatus::ReachedTimeLimit,
+            Core::IterationLimit => SolverStatus::ReachedIterationLimit,
+            Core::Unknown => SolverStatus::Unknown,
+        }
     }
 }
 

--- a/docs/how-to/configure-solver.md
+++ b/docs/how-to/configure-solver.md
@@ -120,6 +120,54 @@ This is equivalent to constructing an `arco.HiGHS(...)` and passing it via the
 > pass the same settings and use `solver=arco.Xpress(threads=4)` in the solve
 > call.
 
+## IPOPT (nonlinear / continuous solver)
+
+The IPOPT backend is available when Arco is built with the `ipopt` feature flag.
+IPOPT is a continuous-only solver -- it does **not** support integer or binary
+variables. Passing a model that contains integer variables will raise an error.
+
+> [!IMPORTANT]
+> Building with IPOPT requires the IPOPT C library to be installed on the
+> system. See the [IPOPT installation guide](https://coin-or.github.io/Ipopt/INSTALL.html)
+> for platform-specific instructions.
+
+### Build with IPOPT support
+
+```bash
+# Rust crate
+cargo build --features ipopt
+
+# Python wheel (maturin)
+maturin develop --features ipopt
+```
+
+### Usage
+
+```python
+import arco
+
+solver = arco.Ipopt(tolerance=1e-8, log_to_console=False)
+model = arco.Model()
+x = model.add_variable(bounds=arco.Bounds(lower=0.0, upper=10.0))
+model.minimize(x)
+solution = model.solve(solver=solver)
+```
+
+### Settings mapping
+
+The following table shows how `SolverSettings` map to IPOPT options. Settings
+that do not apply to IPOPT are silently ignored.
+
+| Setting          | IPOPT option                  | Notes                         |
+| ---------------- | ----------------------------- | ----------------------------- |
+| `time_limit`     | `max_cpu_time`                |                               |
+| `tolerance`      | `tol` + `constr_viol_tol`     |                               |
+| `verbosity`      | `print_level`                 | Clamped to 0--12              |
+| `log_to_console` | `print_level` (0 when false)  |                               |
+| `presolve`       | --                            | Ignored                       |
+| `threads`        | --                            | Ignored                       |
+| `mip_gap`        | --                            | Ignored (continuous only)     |
+
 ---
 
 [How-to Guides](./) | [Docs home](../)

--- a/justfile
+++ b/justfile
@@ -51,6 +51,7 @@ test:
 test-core:
     PYO3_PYTHON=${PYO3_PYTHON:-python3} cargo test {{ core-packages }} --all-features
 
+# Run single-threaded: MUMPS (IPOPT's linear solver) uses non-thread-safe global state
 test-solver package:
     cargo test -p {{ package }} --all-features -- --test-threads=1
 

--- a/justfile
+++ b/justfile
@@ -19,6 +19,9 @@ export UV_CACHE_DIR := justfile_directory() / ".uv-cache"
 
 maturin := "uv run --with maturin maturin"
 
+# Core crates that do not require system solver libraries
+core-packages := "-p arco-core -p arco-expr -p arco-solver -p arco-tools -p arco-blocks -p arco-highs -p arco-bench"
+
 default: check
 
 fmt:
@@ -36,8 +39,20 @@ check-lib:
 clippy:
     cargo clippy --all --benches --tests --examples --all-features -- -D warnings
 
+clippy-core:
+    cargo clippy {{ core-packages }} --benches --tests --examples --all-features -- -D warnings
+
+clippy-solver package:
+    cargo clippy -p {{ package }} --benches --tests --examples --all-features -- -D warnings
+
 test:
     PYO3_PYTHON=${PYO3_PYTHON:-python3} cargo test --workspace --all-features --exclude arco-python
+
+test-core:
+    PYO3_PYTHON=${PYO3_PYTHON:-python3} cargo test {{ core-packages }} --all-features
+
+test-solver package:
+    cargo test -p {{ package }} --all-features
 
 doc:
     cargo doc --workspace --no-deps

--- a/justfile
+++ b/justfile
@@ -52,7 +52,7 @@ test-core:
     PYO3_PYTHON=${PYO3_PYTHON:-python3} cargo test {{ core-packages }} --all-features
 
 test-solver package:
-    cargo test -p {{ package }} --all-features
+    cargo test -p {{ package }} --all-features -- --test-threads=1
 
 doc:
     cargo doc --workspace --no-deps


### PR DESCRIPTION
## Summary

- Add `core-packages` variable and `clippy-core`, `test-core`, `clippy-solver`, `test-solver` recipes to the justfile so CI can validate core crates independently from solver backends
- Split monolithic `rust-clippy` and `rust-test` CI jobs into core and solver-specific variants using a matrix strategy — adding a new solver backend is a single matrix entry
- Update `python-validation` to depend on `rust-test-core` since the Python wheel does not enable solver-specific features

## Test plan

- [x] `just clippy-core` passes locally without IPOPT installed
- [x] `just test-core` passes locally (206 tests)
- [x] `just test-solver arco-ipopt` passes locally (17 tests)
- [x] `just clippy-solver arco-ipopt` runs correctly (found pre-existing float-cmp lint)
- [x] Existing `just test` and `just clippy` recipes unchanged
- [ ] All 4 Rust CI jobs pass in GitHub Actions
- [ ] Python validation passes in GitHub Actions