### PR TITLE
chore(ci): build Linux wheels with manylinux tags for PyPI

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -63,7 +63,20 @@ jobs:
           uv-version: ${{ env.UV_VERSION }}
           just-version: ${{ env.JUST_VERSION }}
 
-      - name: Build wheel
+      - name: Build wheel (Linux, PyPI-compatible)
+        if: runner.os == 'Linux'
+        uses: PyO3/maturin-action@b1bd829e37fef14c63f19162034228a2f3dc1021 # v1
+        with:
+          target: x86_64
+          manylinux: auto
+          args: >-
+            --release
+            --manifest-path bindings/python/Cargo.toml
+            --out dist
+            -i python${{ matrix.python-version }}
+
+      - name: Build wheel (macOS/Windows)
+        if: runner.os != 'Linux'
         run: just py-build-ci
 
       - name: Smoke test wheel install and import


### PR DESCRIPTION
## Summary
- build Linux wheels in release workflow via  with 
- keep existing Running `maturin pep517 build-wheel -i /private/var/folders/vl/4yhzp91j2n38h_m2wvlhhrf80000gr/T/build-env-3bjjwecz/bin/python --compatibility off`
/Users/psanchez/dev/arco/target/wheels/arco-0.2.0-cp314-cp314-macosx_11_0_arm64.whl
Successfully built arco-0.2.0-cp314-cp314-macosx_11_0_arm64.whl path for macOS/Windows
- preserve downstream smoke test and artifact upload steps

## Why
PyPI rejects native  wheels generated by the current build path (). This change makes Linux wheels PyPI-compatible.

## Validation
- No findings to report. Good job! (4 suppressed) (passes)
- investigated failing run: https://github.com/NatLabRockies/arco/actions/runs/22408600859
