### PR TITLE
fix(xpress): update FFI bindings and licensing for Xpress SDK 9+

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,18 @@
 [workspace]
 members = ["crates/*", "bindings/python"]
-exclude=["scripts"]
+exclude = ["scripts"]
+default-members = [
+    "crates/arco-bench",
+    "crates/arco-blocks",
+    "crates/arco-cli",
+    "crates/arco-core",
+    "crates/arco-expr",
+    "crates/arco-highs",
+    "crates/arco-kdl",
+    "crates/arco-solver",
+    "crates/arco-tools",
+    "crates/arco-xpress",
+]
 resolver = "3"
 
 [workspace.dependencies]
@@ -18,6 +30,8 @@ arco-ipopt = { path = "crates/arco-ipopt" }
 arco-xpress = { path = "crates/arco-xpress" }
 arco-tools = { path = "crates/arco-tools" }
 arco-blocks = { path = "crates/arco-blocks" }
+arco-kdl = { path = "crates/arco-kdl" }
+arco-cli = { path = "crates/arco-cli" }
 
 [workspace.package]
 version = "0.2.0"

--- a/crates/arco-cli/Cargo.toml
+++ b/crates/arco-cli/Cargo.toml
@@ -1,0 +1,41 @@
+[package]
+name = "arco-cli"
+version = { workspace = true }
+description = "CLI compiler and solver for KDL optimization models"
+edition = { workspace = true }
+rust-version = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+authors = { workspace = true }
+license-file = { workspace = true }
+publish = false
+autobins = false
+default-run = "arco"
+
+[[bin]]
+name = "arco"
+path = "src/main.rs"
+
+[lints]
+workspace = true
+
+[dependencies]
+arco-kdl = { workspace = true }
+arco-core = { workspace = true }
+arco-highs = { workspace = true }
+arco-xpress = { workspace = true, optional = true }
+clap = { version = "4", features = ["derive"] }
+miette = { version = "7", features = ["fancy"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = { workspace = true }
+sysinfo = { workspace = true }
+thiserror = "2.0"
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
+
+[dev-dependencies]
+csv = "1.4"
+
+[features]
+default = []
+xpress = ["dep:arco-xpress"]

--- a/crates/arco-cli/build.rs
+++ b/crates/arco-cli/build.rs
@@ -1,0 +1,24 @@
+fn main() {
+    // When the xpress feature is enabled, embed an rpath so the final binary
+    // can locate libxprs.dylib at runtime without requiring DYLD_LIBRARY_PATH.
+    #[cfg(feature = "xpress")]
+    {
+        println!("cargo:rerun-if-env-changed=XPRESSDIR");
+
+        let xpress_dir = std::env::var("XPRESSDIR").ok().or_else(|| {
+            for path in &["/opt/xpressmp", "/Library/xpressmp", "C:\\xpressmp"] {
+                if std::path::Path::new(path).exists() {
+                    return Some(path.to_string());
+                }
+            }
+            None
+        });
+
+        if let Some(dir) = xpress_dir {
+            let lib_dir = format!("{dir}/lib");
+            if cfg!(unix) {
+                println!("cargo:rustc-link-arg-bins=-Wl,-rpath,{lib_dir}");
+            }
+        }
+    }
+}

--- a/crates/arco-cli/src/benchmark.rs
+++ b/crates/arco-cli/src/benchmark.rs
@@ -1,0 +1,245 @@
+use crate::execution::{ExecutionError, RustArcoAdapter, SolveStatus, execute_problem};
+use arco_kdl::pipeline::{PipelineError, compile_file};
+use arco_kdl::semantic::SemanticProgram;
+use serde::Deserialize;
+use std::fs;
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum BenchmarkError {
+    #[error("failed to read {path}: {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("failed to parse json {path}: {source}")]
+    Json {
+        path: PathBuf,
+        #[source]
+        source: serde_json::Error,
+    },
+    #[error(transparent)]
+    Pipeline(#[from] PipelineError),
+    #[error(transparent)]
+    Execution(#[from] ExecutionError),
+    #[error("missing required node `{name}` in {path}")]
+    MissingNode { name: &'static str, path: PathBuf },
+    #[error("semantic program mismatch for case `{case_id}`")]
+    SemanticMismatch { case_id: String },
+    #[error("e2e summary mismatch for case `{case_id}`")]
+    E2eSummaryMismatch { case_id: String },
+}
+
+#[derive(Debug, Deserialize)]
+pub struct BenchmarkManifest {
+    pub version: u32,
+    pub cases: Vec<BenchmarkCaseDefinition>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct BenchmarkCaseDefinition {
+    pub id: String,
+    pub description: String,
+    pub entrypoint: String,
+    pub expected_semantic_program: String,
+    pub expected_e2e_summary: String,
+    pub solvable: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct SemanticProgramExpectation {
+    pub case_id: String,
+    pub active_scenario: String,
+    pub sets: ExpectedSets,
+    #[serde(default)]
+    pub parameters: ExpectedParameters,
+    #[serde(default)]
+    pub variable_families: Vec<String>,
+    #[serde(default)]
+    pub chronology: ExpectedChronology,
+    #[serde(default)]
+    pub lowering_rules: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct ExpectedSets {
+    pub assets: Vec<String>,
+    #[serde(default)]
+    pub candidate_assets: Vec<String>,
+    pub time: ExpectedTimeSet,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct ExpectedTimeSet {
+    pub steps: usize,
+    pub resolution: String,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+pub struct ExpectedParameters {
+    #[serde(default)]
+    pub series: Vec<String>,
+    #[serde(default)]
+    pub indexed: Vec<String>,
+    #[serde(default)]
+    pub asset: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+pub struct ExpectedChronology {
+    #[serde(default)]
+    pub initial_boundary: Option<String>,
+    #[serde(default)]
+    pub terminal_boundary: Option<String>,
+    #[serde(default)]
+    pub initial_commitment_boundary: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct ExpectedE2eSummary {
+    pub case_id: String,
+    pub expect_parse_success: bool,
+    pub expect_semantic_validation_success: bool,
+    pub expect_lowering_success: bool,
+    pub expect_solve_success: bool,
+    #[serde(default)]
+    pub objective: Option<ExpectedObjective>,
+    #[serde(default)]
+    pub reports: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct ExpectedObjective {
+    pub name: String,
+    pub sense: String,
+}
+
+#[derive(Debug)]
+pub struct CaseOutcome {
+    pub case_id: String,
+    pub actual_semantic_program: SemanticProgramExpectation,
+    pub actual_e2e_summary: ExpectedE2eSummary,
+}
+
+pub fn load_manifest(path: &Path) -> Result<BenchmarkManifest, BenchmarkError> {
+    read_json(path)
+}
+
+pub fn evaluate_manifest(path: &Path) -> Result<Vec<CaseOutcome>, BenchmarkError> {
+    let manifest = load_manifest(path)?;
+    let repo_root = path
+        .parent()
+        .and_then(Path::parent)
+        .and_then(Path::parent)
+        .ok_or_else(|| BenchmarkError::MissingNode {
+            name: "manifest parent",
+            path: path.to_path_buf(),
+        })?;
+
+    manifest
+        .cases
+        .iter()
+        .map(|case| evaluate_case(repo_root, case))
+        .collect()
+}
+
+fn evaluate_case(
+    repo_root: &Path,
+    case: &BenchmarkCaseDefinition,
+) -> Result<CaseOutcome, BenchmarkError> {
+    let entrypoint = repo_root.join(&case.entrypoint);
+    let compiled = compile_file(&entrypoint)?;
+    let execution_result = execute_problem(&compiled.lowered_problem, &RustArcoAdapter::new())?;
+
+    let actual_semantic_program = to_semantic_expectation(case, &compiled.semantic_program);
+    let actual_e2e_summary = to_e2e_summary(case, &execution_result);
+    let expected_semantic_program = read_json(&repo_root.join(&case.expected_semantic_program))?;
+    let expected_e2e_summary = read_json(&repo_root.join(&case.expected_e2e_summary))?;
+
+    if actual_semantic_program != expected_semantic_program {
+        return Err(BenchmarkError::SemanticMismatch {
+            case_id: case.id.clone(),
+        });
+    }
+
+    if actual_e2e_summary != expected_e2e_summary {
+        return Err(BenchmarkError::E2eSummaryMismatch {
+            case_id: case.id.clone(),
+        });
+    }
+
+    Ok(CaseOutcome {
+        case_id: case.id.clone(),
+        actual_semantic_program,
+        actual_e2e_summary,
+    })
+}
+
+fn to_semantic_expectation(
+    case: &BenchmarkCaseDefinition,
+    program: &SemanticProgram,
+) -> SemanticProgramExpectation {
+    SemanticProgramExpectation {
+        case_id: case.id.clone(),
+        active_scenario: program.active_scenario.clone(),
+        sets: ExpectedSets {
+            assets: program.sets.assets.clone(),
+            candidate_assets: program.sets.candidate_assets.clone(),
+            time: ExpectedTimeSet {
+                steps: program.sets.time.steps,
+                resolution: program.sets.time.resolution.clone(),
+            },
+        },
+        parameters: ExpectedParameters {
+            series: program.parameters.series.clone(),
+            indexed: program.parameters.indexed.clone(),
+            asset: program.parameters.asset.clone(),
+        },
+        variable_families: program
+            .variable_families
+            .iter()
+            .map(|f| f.render())
+            .collect(),
+        chronology: ExpectedChronology {
+            initial_boundary: program.chronology.initial_boundary.clone(),
+            terminal_boundary: program.chronology.terminal_boundary.clone(),
+            initial_commitment_boundary: program.chronology.initial_commitment_boundary.clone(),
+        },
+        lowering_rules: program.lowering_rules.clone(),
+    }
+}
+
+fn to_e2e_summary(
+    case: &BenchmarkCaseDefinition,
+    execution_result: &crate::execution::ExecutionResult,
+) -> ExpectedE2eSummary {
+    ExpectedE2eSummary {
+        case_id: case.id.clone(),
+        expect_parse_success: true,
+        expect_semantic_validation_success: true,
+        expect_lowering_success: true,
+        expect_solve_success: case.solvable && execution_result.status == SolveStatus::Optimal,
+        objective: Some(ExpectedObjective {
+            name: execution_result.objective.dsl_name.clone(),
+            sense: execution_result.objective_sense.clone(),
+        }),
+        reports: execution_result
+            .reports
+            .iter()
+            .map(|report| report.dsl_name.clone())
+            .collect(),
+    }
+}
+
+fn read_json<T: for<'de> Deserialize<'de>>(path: &Path) -> Result<T, BenchmarkError> {
+    let text = fs::read_to_string(path).map_err(|source| BenchmarkError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    serde_json::from_str(&text).map_err(|source| BenchmarkError::Json {
+        path: path.to_path_buf(),
+        source,
+    })
+}

--- a/crates/arco-cli/src/cli_io.rs
+++ b/crates/arco-cli/src/cli_io.rs
@@ -1,0 +1,83 @@
+use std::io::{self, Write};
+
+pub fn write_all_ignoring_broken_pipe<W: Write>(writer: &mut W, bytes: &[u8]) -> io::Result<()> {
+    ignore_broken_pipe(writer.write_all(bytes))?;
+    ignore_broken_pipe(writer.flush())
+}
+
+fn ignore_broken_pipe(result: io::Result<()>) -> io::Result<()> {
+    match result {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::BrokenPipe => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+pub fn write_stdout(bytes: &[u8]) -> io::Result<()> {
+    let stdout = io::stdout();
+    let mut handle = stdout.lock();
+    write_all_ignoring_broken_pipe(&mut handle, bytes)
+}
+
+pub fn write_stdout_line(line: &str) -> io::Result<()> {
+    let stdout = io::stdout();
+    let mut handle = stdout.lock();
+    write_all_ignoring_broken_pipe(&mut handle, line.as_bytes())?;
+    write_all_ignoring_broken_pipe(&mut handle, b"\n")
+}
+
+pub fn should_log_solver_to_console(verbose: u8, stdout_is_terminal: bool) -> bool {
+    verbose >= 2 && stdout_is_terminal
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::cli_io::{should_log_solver_to_console, write_all_ignoring_broken_pipe};
+    use std::io::{self, Write};
+
+    struct BrokenPipeWriter;
+
+    impl Write for BrokenPipeWriter {
+        fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
+            Err(io::Error::new(io::ErrorKind::BrokenPipe, "broken pipe"))
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Err(io::Error::new(io::ErrorKind::BrokenPipe, "broken pipe"))
+        }
+    }
+
+    struct FailingWriter;
+
+    impl Write for FailingWriter {
+        fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
+            Err(io::Error::other("disk full"))
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn ignores_broken_pipe_errors() -> Result<(), Box<dyn std::error::Error>> {
+        let mut writer = BrokenPipeWriter;
+        write_all_ignoring_broken_pipe(&mut writer, b"hello")?;
+        Ok(())
+    }
+
+    #[test]
+    fn returns_other_io_errors() {
+        let mut writer = FailingWriter;
+        let error = write_all_ignoring_broken_pipe(&mut writer, b"hello")
+            .expect_err("non-broken-pipe errors should be returned");
+        assert_eq!(error.kind(), io::ErrorKind::Other);
+    }
+
+    #[test]
+    fn only_enables_solver_console_logging_for_double_verbose_terminals() {
+        assert!(should_log_solver_to_console(2, true));
+        assert!(!should_log_solver_to_console(1, true));
+        assert!(!should_log_solver_to_console(2, false));
+    }
+}

--- a/crates/arco-cli/src/config.rs
+++ b/crates/arco-cli/src/config.rs
@@ -1,0 +1,137 @@
+// thiserror's Display derive triggers unused_assignments in edition 2024
+// because derive-generated code no longer inherits item-level #[allow].
+#![allow(unused_assignments)]
+
+use miette::Diagnostic;
+use serde::{Deserialize, Serialize};
+use std::env;
+use std::path::PathBuf;
+use thiserror::Error;
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SolverBackend {
+    #[default]
+    Highs,
+    Xpress,
+}
+
+impl SolverBackend {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Highs => "highs",
+            Self::Xpress => "xpress",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SolverConfig {
+    pub backend: SolverBackend,
+}
+
+#[derive(Debug, Error, Diagnostic)]
+pub enum ConfigError {
+    #[error("could not determine an arco config directory")]
+    #[diagnostic(
+        code(arco::config::missing_directory),
+        help("set ARCO_CONFIG_DIR, XDG_CONFIG_HOME, HOME, or APPDATA before running the command")
+    )]
+    MissingConfigDirectory,
+    #[error("failed to read solver config {path}: {source}")]
+    #[diagnostic(
+        code(arco::config::io),
+        help("verify the config path exists and is readable")
+    )]
+    Read {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("failed to write solver config {path}: {source}")]
+    #[diagnostic(
+        code(arco::config::io),
+        help("verify the config directory is writable")
+    )]
+    Write {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("failed to parse solver config {path}: {source}")]
+    #[diagnostic(
+        code(arco::config::json),
+        help("delete or repair the solver config file and retry")
+    )]
+    Parse {
+        path: PathBuf,
+        #[source]
+        source: serde_json::Error,
+    },
+    #[error("failed to serialize solver config for {path}: {source}")]
+    #[diagnostic(
+        code(arco::config::json),
+        help("inspect the solver configuration payload for unsupported values")
+    )]
+    Serialize {
+        path: PathBuf,
+        #[source]
+        source: serde_json::Error,
+    },
+}
+
+pub fn load_solver_config() -> Result<SolverConfig, ConfigError> {
+    let path = solver_config_path()?;
+    match std::fs::read_to_string(&path) {
+        Ok(text) => {
+            serde_json::from_str(&text).map_err(|source| ConfigError::Parse { path, source })
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(SolverConfig::default()),
+        Err(source) => Err(ConfigError::Read { path, source }),
+    }
+}
+
+pub fn save_solver_config(config: &SolverConfig) -> Result<PathBuf, ConfigError> {
+    let path = solver_config_path()?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|source| ConfigError::Write {
+            path: parent.to_path_buf(),
+            source,
+        })?;
+    }
+
+    let text = serde_json::to_string_pretty(config).map_err(|source| ConfigError::Serialize {
+        path: path.clone(),
+        source,
+    })?;
+    std::fs::write(&path, text).map_err(|source| ConfigError::Write {
+        path: path.clone(),
+        source,
+    })?;
+
+    Ok(path)
+}
+
+pub fn solver_config_path() -> Result<PathBuf, ConfigError> {
+    Ok(config_dir()?.join("solver.json"))
+}
+
+fn config_dir() -> Result<PathBuf, ConfigError> {
+    if let Some(path) = env::var_os("ARCO_CONFIG_DIR") {
+        return Ok(PathBuf::from(path));
+    }
+    if let Some(path) = env::var_os("XDG_CONFIG_HOME") {
+        return Ok(PathBuf::from(path).join("arco"));
+    }
+    if cfg!(windows) {
+        return env::var_os("APPDATA")
+            .map(PathBuf::from)
+            .map(|path| path.join("arco"))
+            .ok_or(ConfigError::MissingConfigDirectory);
+    }
+
+    env::var_os("HOME")
+        .map(PathBuf::from)
+        .map(|path| path.join(".config").join("arco"))
+        .ok_or(ConfigError::MissingConfigDirectory)
+}

--- a/crates/arco-cli/src/debug.rs
+++ b/crates/arco-cli/src/debug.rs
@@ -1,0 +1,460 @@
+use arco_kdl::lowering::{AlgebraicProblem, ConstraintSense, ObjectiveSense, VariableKind};
+use arco_kdl::pipeline::compile_file;
+use miette::{IntoDiagnostic, Result, miette};
+use std::collections::BTreeMap;
+use std::fs::{File, remove_file};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const ARCO_PYTHON_BINDINGS_SPEC: &str = "arco";
+
+pub fn launch_ipython(path: &Path) -> Result<()> {
+    let compiled = compile_file(path)?;
+    let model_data = build_python_model_data(&compiled.lowered_problem.algebra)?;
+    let script = build_ipython_script(path, &model_data);
+    let bootstrap = DebugBootstrapScript::create(&script)?;
+
+    let status = Command::new("uvx")
+        .arg("--with")
+        .arg(ARCO_PYTHON_BINDINGS_SPEC)
+        .arg("ipython")
+        .arg("--no-banner")
+        .arg("-i")
+        .arg(bootstrap.path())
+        .status();
+
+    let status = match status {
+        Ok(status) => status,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Err(miette!(
+                "failed to start uvx (uv is not installed). Install uv first: https://docs.astral.sh/uv/getting-started/installation/"
+            ));
+        }
+        Err(error) => return Err(error).into_diagnostic(),
+    };
+
+    if status.success() {
+        Ok(())
+    } else {
+        Err(miette!(
+            "uvx ipython exited with status {}",
+            status
+                .code()
+                .map_or_else(|| "signal".to_string(), |code| code.to_string())
+        ))
+    }
+}
+
+#[derive(Debug, PartialEq)]
+struct PythonModelData {
+    col_ptrs: Vec<usize>,
+    row_indices: Vec<usize>,
+    values: Vec<f64>,
+    var_lower: Vec<f64>,
+    var_upper: Vec<f64>,
+    con_lower: Vec<f64>,
+    con_upper: Vec<f64>,
+    is_integer: Vec<bool>,
+    variable_names: Vec<String>,
+    constraint_names: Vec<String>,
+    objective_sense: ObjectiveSense,
+    objective_name: String,
+    objective_constant: f64,
+    objective_terms: Vec<(usize, f64)>,
+}
+
+fn build_python_model_data(problem: &AlgebraicProblem) -> Result<PythonModelData> {
+    let variable_indices = problem
+        .variable_instances
+        .iter()
+        .enumerate()
+        .map(|(index, variable)| (variable.name.clone(), index))
+        .collect::<BTreeMap<_, _>>();
+
+    let mut columns = vec![Vec::new(); problem.variable_instances.len()];
+    for (row_index, constraint) in problem.constraints.iter().enumerate() {
+        for term in &constraint.terms {
+            let column_index = lookup_variable_index(
+                &variable_indices,
+                &term.variable_name,
+                "debug bootstrap references unknown lowered variable",
+            )?;
+            columns[column_index].push((row_index, term.coefficient));
+        }
+    }
+
+    let mut col_ptrs = Vec::with_capacity(problem.variable_instances.len() + 1);
+    let mut row_indices = Vec::new();
+    let mut values = Vec::new();
+    col_ptrs.push(0);
+    for column in columns {
+        for (row_index, value) in column {
+            row_indices.push(row_index);
+            values.push(value);
+        }
+        col_ptrs.push(row_indices.len());
+    }
+
+    let var_lower = problem
+        .variable_instances
+        .iter()
+        .map(|variable| variable.lower)
+        .collect();
+    let var_upper = problem
+        .variable_instances
+        .iter()
+        .map(|variable| variable.upper.unwrap_or(f64::INFINITY))
+        .collect();
+    let con_lower = problem
+        .constraints
+        .iter()
+        .map(|constraint| match constraint.sense {
+            ConstraintSense::GreaterEqual | ConstraintSense::Equal => constraint.rhs,
+            ConstraintSense::LessEqual => f64::NEG_INFINITY,
+        })
+        .collect();
+    let con_upper = problem
+        .constraints
+        .iter()
+        .map(|constraint| match constraint.sense {
+            ConstraintSense::LessEqual | ConstraintSense::Equal => constraint.rhs,
+            ConstraintSense::GreaterEqual => f64::INFINITY,
+        })
+        .collect();
+    let is_integer = problem
+        .variable_instances
+        .iter()
+        .map(|variable| matches!(variable.kind, VariableKind::Integer | VariableKind::Binary))
+        .collect();
+    let variable_names = problem
+        .variable_instances
+        .iter()
+        .map(|variable| variable.name.clone())
+        .collect();
+    let constraint_names = problem
+        .constraints
+        .iter()
+        .map(|constraint| constraint.name.clone())
+        .collect();
+    let objective_terms = problem
+        .objective
+        .terms
+        .iter()
+        .map(|term| {
+            let index = lookup_variable_index(
+                &variable_indices,
+                &term.variable_name,
+                "debug bootstrap objective references unknown lowered variable",
+            )?;
+            Ok((index, term.coefficient))
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    Ok(PythonModelData {
+        col_ptrs,
+        row_indices,
+        values,
+        var_lower,
+        var_upper,
+        con_lower,
+        con_upper,
+        is_integer,
+        variable_names,
+        constraint_names,
+        objective_sense: problem.objective.sense,
+        objective_name: problem.objective.name.clone(),
+        objective_constant: problem.objective.constant,
+        objective_terms,
+    })
+}
+
+fn lookup_variable_index(
+    variable_indices: &BTreeMap<String, usize>,
+    variable_name: &str,
+    context: &str,
+) -> Result<usize> {
+    variable_indices
+        .get(variable_name)
+        .copied()
+        .ok_or_else(|| miette!("{context} `{variable_name}`"))
+}
+
+fn build_ipython_script(path: &Path, model: &PythonModelData) -> String {
+    format!(
+        "from pathlib import Path\n\nimport arco\n\nmodel_path = Path(r{path})\nmodel = arco.Model.from_csc(\n    num_constraints={num_constraints},\n    num_variables={num_variables},\n    col_ptrs={col_ptrs},\n    row_indices={row_indices},\n    values={values},\n    var_lower={var_lower},\n    var_upper={var_upper},\n    con_lower={con_lower},\n    con_upper={con_upper},\n    is_integer={is_integer},\n)\nfor index, name in enumerate({variable_names}):\n    model.set_variable_name(index, name=name)\nfor index, name in enumerate({constraint_names}):\n    model.set_constraint_name(index, name=name)\nmodel.set_objective(\n    arco.Sense.{objective_sense},\n    {objective_terms},\n    name={objective_name},\n)\nobjective_constant = {objective_constant}\n",
+        path = format_python_string(&path.display().to_string()),
+        num_constraints = model.constraint_names.len(),
+        num_variables = model.variable_names.len(),
+        col_ptrs = format_python_usize_list(&model.col_ptrs),
+        row_indices = format_python_usize_list(&model.row_indices),
+        values = format_python_f64_list(&model.values),
+        var_lower = format_python_f64_list(&model.var_lower),
+        var_upper = format_python_f64_list(&model.var_upper),
+        con_lower = format_python_f64_list(&model.con_lower),
+        con_upper = format_python_f64_list(&model.con_upper),
+        is_integer = format_python_bool_list(&model.is_integer),
+        variable_names = format_python_string_list(&model.variable_names),
+        constraint_names = format_python_string_list(&model.constraint_names),
+        objective_sense = match model.objective_sense {
+            ObjectiveSense::Minimize => "MINIMIZE",
+            ObjectiveSense::Maximize => "MAXIMIZE",
+        },
+        objective_terms = format_python_tuple_list(&model.objective_terms),
+        objective_name = format_python_string(&model.objective_name),
+        objective_constant = format_python_f64(model.objective_constant),
+    )
+}
+
+fn format_python_string(value: &str) -> String {
+    // Hand-rolled to avoid expect/unwrap on serde_json::to_string.
+    let mut encoded = String::with_capacity(value.len() + 2);
+    encoded.push('"');
+    for character in value.chars() {
+        match character {
+            '\\' => encoded.push_str("\\\\"),
+            '"' => encoded.push_str("\\\""),
+            '\n' => encoded.push_str("\\n"),
+            '\r' => encoded.push_str("\\r"),
+            '\t' => encoded.push_str("\\t"),
+            _ => encoded.push(character),
+        }
+    }
+    encoded.push('"');
+    encoded
+}
+
+fn format_python_string_list(values: &[String]) -> String {
+    format_python_list(values, |value| format_python_string(value))
+}
+
+fn format_python_usize_list(values: &[usize]) -> String {
+    format_python_list(values, |value| value.to_string())
+}
+
+fn format_python_f64_list(values: &[f64]) -> String {
+    format_python_list(values, |value| format_python_f64(*value))
+}
+
+fn format_python_bool_list(values: &[bool]) -> String {
+    format_python_list(values, |value| {
+        (if *value { "True" } else { "False" }).to_string()
+    })
+}
+
+fn format_python_tuple_list(values: &[(usize, f64)]) -> String {
+    format_python_list(values, |(index, coefficient)| {
+        format!("({}, {})", index, format_python_f64(*coefficient))
+    })
+}
+
+fn format_python_list<T>(values: &[T], format_item: impl Fn(&T) -> String) -> String {
+    format!(
+        "[{}]",
+        values
+            .iter()
+            .map(format_item)
+            .collect::<Vec<_>>()
+            .join(", ")
+    )
+}
+
+fn format_python_f64(value: f64) -> String {
+    if value == f64::INFINITY {
+        "float(\"inf\")".to_string()
+    } else if value == f64::NEG_INFINITY {
+        "float(\"-inf\")".to_string()
+    } else {
+        value.to_string()
+    }
+}
+
+struct DebugBootstrapScript {
+    path: PathBuf,
+}
+
+impl DebugBootstrapScript {
+    fn create(contents: &str) -> Result<Self> {
+        let base_name = format!(
+            "arco-debug-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .into_diagnostic()?
+                .as_nanos()
+        );
+
+        for attempt in 0..16 {
+            let path = std::env::temp_dir().join(format!("{base_name}-{attempt}.py"));
+            match File::options().write(true).create_new(true).open(&path) {
+                Ok(mut file) => {
+                    file.write_all(contents.as_bytes()).into_diagnostic()?;
+                    return Ok(Self { path });
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
+                Err(error) => return Err(error).into_diagnostic(),
+            }
+        }
+
+        Err(miette!("failed to create temporary debug bootstrap script"))
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for DebugBootstrapScript {
+    fn drop(&mut self) {
+        let _ = remove_file(&self.path);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::debug::{PythonModelData, build_ipython_script, build_python_model_data};
+    use arco_kdl::lowering::{
+        AlgebraicProblem, ConstraintSense, LinearConstraint, LinearObjective, LinearTerm,
+        ObjectiveSense, VariableInstance, VariableKind,
+    };
+    use std::path::Path;
+
+    #[test]
+    fn python_model_data_uses_csc_layout_and_bounds() {
+        let problem = AlgebraicProblem {
+            variable_instances: vec![
+                VariableInstance {
+                    name: "x".to_string(),
+                    family: "x".to_string(),
+                    lower: 0.0,
+                    upper: Some(4.0),
+                    kind: VariableKind::Continuous,
+                },
+                VariableInstance {
+                    name: "y".to_string(),
+                    family: "y".to_string(),
+                    lower: 0.0,
+                    upper: Some(1.0),
+                    kind: VariableKind::Binary,
+                },
+            ],
+            constraints: vec![
+                LinearConstraint {
+                    name: "c1".to_string(),
+                    sense: ConstraintSense::LessEqual,
+                    rhs: 5.0,
+                    terms: vec![
+                        LinearTerm {
+                            variable_name: "x".to_string(),
+                            coefficient: 2.0,
+                        },
+                        LinearTerm {
+                            variable_name: "y".to_string(),
+                            coefficient: 3.0,
+                        },
+                    ],
+                },
+                LinearConstraint {
+                    name: "c2".to_string(),
+                    sense: ConstraintSense::GreaterEqual,
+                    rhs: 1.0,
+                    terms: vec![LinearTerm {
+                        variable_name: "y".to_string(),
+                        coefficient: 4.0,
+                    }],
+                },
+            ],
+            objective: LinearObjective {
+                name: "profit".to_string(),
+                sense: ObjectiveSense::Maximize,
+                constant: 7.5,
+                terms: vec![
+                    LinearTerm {
+                        variable_name: "x".to_string(),
+                        coefficient: 1.0,
+                    },
+                    LinearTerm {
+                        variable_name: "y".to_string(),
+                        coefficient: 9.0,
+                    },
+                ],
+            },
+            reports: Vec::new(),
+        };
+
+        let model = build_python_model_data(&problem).expect("model data should build");
+
+        assert_eq!(
+            model,
+            PythonModelData {
+                col_ptrs: vec![0, 1, 3],
+                row_indices: vec![0, 0, 1],
+                values: vec![2.0, 3.0, 4.0],
+                var_lower: vec![0.0, 0.0],
+                var_upper: vec![4.0, 1.0],
+                con_lower: vec![f64::NEG_INFINITY, 1.0],
+                con_upper: vec![5.0, f64::INFINITY],
+                is_integer: vec![false, true],
+                variable_names: vec!["x".to_string(), "y".to_string()],
+                constraint_names: vec!["c1".to_string(), "c2".to_string()],
+                objective_sense: ObjectiveSense::Maximize,
+                objective_name: "profit".to_string(),
+                objective_constant: 7.5,
+                objective_terms: vec![(0, 1.0), (1, 9.0)],
+            }
+        );
+    }
+
+    #[test]
+    fn ipython_script_preloads_arco_and_model() {
+        let model = PythonModelData {
+            col_ptrs: vec![0, 1],
+            row_indices: vec![0],
+            values: vec![1.0],
+            var_lower: vec![0.0],
+            var_upper: vec![f64::INFINITY],
+            con_lower: vec![f64::NEG_INFINITY],
+            con_upper: vec![2.0],
+            is_integer: vec![false],
+            variable_names: vec!["dispatch[Battery1,1]".to_string()],
+            constraint_names: vec!["limit[Battery1,1]".to_string()],
+            objective_sense: ObjectiveSense::Minimize,
+            objective_name: "cost".to_string(),
+            objective_constant: 0.0,
+            objective_terms: vec![(0, 1.0)],
+        };
+
+        let script =
+            build_ipython_script(Path::new("tests/e2e/price-taker-battery/input.kdl"), &model);
+
+        assert!(script.contains("import arco"));
+        // The model path is embedded as a raw string literal.
+        assert!(
+            script.contains(r#"model_path = Path(r"tests/e2e/price-taker-battery/input.kdl")"#)
+        );
+        // CSC matrix data: col_ptrs, row_indices, values from the test model.
+        // Note: Rust's f64::to_string() omits the trailing .0 for whole numbers.
+        assert!(script.contains("col_ptrs=[0, 1]"));
+        assert!(script.contains("row_indices=[0]"));
+        assert!(script.contains("values=[1]"));
+        // Variable bounds: lower=0.0 (serialized as "0"), upper=inf.
+        assert!(script.contains("var_lower=[0]"));
+        assert!(script.contains("var_upper=[float(\"inf\")]"));
+        // Constraint bounds: lower=-inf (no lower bound), upper=2.0 (serialized as "2").
+        assert!(script.contains("con_lower=[float(\"-inf\")]"));
+        assert!(script.contains("con_upper=[2]"));
+        // Integer flags: the single variable is continuous.
+        assert!(script.contains("is_integer=[False]"));
+        // Variable name is embedded in the enumerate call.
+        assert!(script.contains(r#"["dispatch[Battery1,1]"]"#));
+        // Constraint name is embedded in the enumerate call.
+        assert!(script.contains(r#"["limit[Battery1,1]"]"#));
+        // Objective sense and term: MINIMIZE with coefficient 1.0 on variable 0.
+        // Rust serializes 1.0f64 as "1" via to_string().
+        assert!(script.contains("arco.Sense.MINIMIZE"));
+        assert!(script.contains("[(0, 1)]"));
+        assert!(script.contains(r#"name="cost""#));
+        assert!(script.contains("objective_constant = 0"));
+    }
+}

--- a/crates/arco-cli/src/driver.rs
+++ b/crates/arco-cli/src/driver.rs
@@ -1,0 +1,380 @@
+use crate::config::SolverBackend;
+#[cfg(feature = "xpress")]
+use crate::execution::XpressArcoAdapter;
+use crate::execution::{
+    ExecutionError, RustArcoAdapter, SolveStatus, execute_problem_with_options,
+    render_problem_model,
+};
+use arco_kdl::pipeline::{PipelineError, compile_file, validate_file};
+use miette::Diagnostic;
+use serde::Serialize;
+use std::fmt::Display;
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+use thiserror::Error;
+
+const DEFAULT_BACKEND: SolverBackend = SolverBackend::Highs;
+
+#[derive(Debug, Clone, Default)]
+pub struct RunOptions {
+    pub compact: bool,
+    pub filter_variable: Option<String>,
+    pub filter_asset: Option<String>,
+    pub solver_log: bool,
+}
+
+#[derive(Debug, Serialize, PartialEq)]
+pub struct RunSummary {
+    pub entrypoint: String,
+    pub backend: &'static str,
+    pub solve_status: &'static str,
+    pub active_scenario: String,
+    pub objective: ObjectiveSummary,
+    pub reports: Vec<ReportSummary>,
+    pub variables: Vec<VariableSummary>,
+    pub counts: ProblemCounts,
+    pub timing: TimingSummary,
+}
+
+#[derive(Debug, Serialize, PartialEq)]
+pub struct ObjectiveSummary {
+    pub name: String,
+    pub sense: String,
+    pub value: f64,
+}
+
+#[derive(Debug, Serialize, PartialEq)]
+pub struct ReportSummary {
+    pub name: String,
+    pub value: f64,
+}
+
+#[derive(Debug, Serialize, PartialEq)]
+pub struct VariableSummary {
+    pub name: String,
+    pub representative_value: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub values: Option<Vec<VariableValueSummary>>,
+}
+
+#[derive(Debug, Serialize, PartialEq)]
+pub struct VariableValueSummary {
+    pub name: String,
+    pub value: f64,
+}
+
+#[derive(Debug, Serialize, PartialEq)]
+pub struct ProblemCounts {
+    pub parameters: usize,
+    pub variables: usize,
+    pub constraints: usize,
+}
+
+#[derive(Debug, Serialize, PartialEq)]
+pub struct TimingSummary {
+    pub parse_ms: f64,
+    pub validate_ms: f64,
+    pub lower_ms: f64,
+    pub solve_ms: f64,
+    pub total_ms: f64,
+    pub peak_memory_bytes: Option<u64>,
+}
+
+#[derive(Debug, Error)]
+pub enum DriverError {
+    #[error(transparent)]
+    Pipeline(#[from] PipelineError),
+    #[error(transparent)]
+    Execution(#[from] ExecutionError),
+    #[error("failed to serialize run summary for {path}: {source}")]
+    Json {
+        path: PathBuf,
+        #[source]
+        source: serde_json::Error,
+    },
+    #[error("{message}")]
+    BackendNotAvailable { message: String },
+}
+
+impl Diagnostic for DriverError {
+    fn code<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
+        match self {
+            Self::Json { .. } => Some(Box::new("arco::driver::json")),
+            Self::BackendNotAvailable { .. } => {
+                Some(Box::new("arco::driver::backend_not_available"))
+            }
+            Self::Pipeline { .. } | Self::Execution { .. } => None,
+        }
+    }
+
+    fn help<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
+        match self {
+            Self::Json { .. } => Some(Box::new(
+                "inspect the summary payload for non-finite values that cannot be serialized",
+            )),
+            Self::BackendNotAvailable { .. } => Some(Box::new(
+                "To enable Xpress support, rebuild arco with the xpress feature:\n\n\
+                 \x20   cargo install --path . --features xpress\n\n\
+                 This requires the FICO Xpress SDK installed and XPRESSDIR set.\n\n\
+                 On macOS (DMG install):\n\
+                 \x20   export XPRESSDIR=\"/Applications/FICO Xpress/xpressmp\"\n\n\
+                 On Linux:\n\
+                 \x20   export XPRESSDIR=\"/opt/xpressmp\"\n\n\
+                 To switch back to HiGHS (no extra dependencies):\n\
+                 \x20   arco solver set highs",
+            )),
+            Self::Pipeline { .. } | Self::Execution { .. } => None,
+        }
+    }
+
+    fn diagnostic_source(&self) -> Option<&dyn Diagnostic> {
+        match self {
+            Self::Pipeline(error) => Some(error),
+            Self::Execution(_) | Self::Json { .. } | Self::BackendNotAvailable { .. } => None,
+        }
+    }
+}
+
+pub fn run_file(path: &Path) -> Result<RunSummary, DriverError> {
+    run_file_with_options_and_backend(path, &RunOptions::default(), DEFAULT_BACKEND)
+}
+
+pub fn run_file_with_options(path: &Path, options: &RunOptions) -> Result<RunSummary, DriverError> {
+    run_file_with_options_and_backend(path, options, DEFAULT_BACKEND)
+}
+
+pub fn run_file_with_options_and_backend(
+    path: &Path,
+    options: &RunOptions,
+    backend: SolverBackend,
+) -> Result<RunSummary, DriverError> {
+    let total_start = Instant::now();
+    let compiled = compile_file(path)?;
+
+    let solve_start = Instant::now();
+    let include_variable_values = !(options.compact && options.filter_asset.is_none());
+    let execution_result = match backend {
+        SolverBackend::Highs => execute_problem_with_options(
+            &compiled.lowered_problem,
+            &RustArcoAdapter::with_console_log(options.solver_log),
+            include_variable_values,
+        )?,
+        #[cfg(feature = "xpress")]
+        SolverBackend::Xpress => execute_problem_with_options(
+            &compiled.lowered_problem,
+            &XpressArcoAdapter::with_console_log(options.solver_log),
+            include_variable_values,
+        )?,
+        #[cfg(not(feature = "xpress"))]
+        SolverBackend::Xpress => {
+            return Err(DriverError::BackendNotAvailable {
+                message: "Xpress solver backend is not available in this build".to_string(),
+            });
+        }
+    };
+    let solve = solve_start.elapsed();
+    let total = total_start.elapsed();
+
+    let variables = summarize_variables(&execution_result.variables, options);
+
+    Ok(RunSummary {
+        entrypoint: compiled.entrypoint.display().to_string(),
+        backend: execution_result.backend,
+        solve_status: solve_status_name(execution_result.status),
+        active_scenario: compiled.semantic_program.active_scenario,
+        objective: ObjectiveSummary {
+            name: execution_result.objective.dsl_name,
+            sense: execution_result.objective_sense,
+            value: execution_result.objective.value,
+        },
+        reports: execution_result
+            .reports
+            .into_iter()
+            .map(|report| ReportSummary {
+                name: report.dsl_name,
+                value: report.value,
+            })
+            .collect(),
+        variables,
+        counts: ProblemCounts {
+            parameters: compiled.lowered_problem.parameters.len(),
+            variables: compiled.lowered_problem.variables.len(),
+            constraints: compiled.lowered_problem.constraints.len(),
+        },
+        timing: TimingSummary {
+            parse_ms: compiled.timing.parse.as_secs_f64() * 1000.0,
+            validate_ms: compiled.timing.validate.as_secs_f64() * 1000.0,
+            lower_ms: compiled.timing.lower.as_secs_f64() * 1000.0,
+            solve_ms: solve.as_secs_f64() * 1000.0,
+            total_ms: total.as_secs_f64() * 1000.0,
+            peak_memory_bytes: peak_rss_bytes(),
+        },
+    })
+}
+
+pub fn run_file_json(path: &Path) -> Result<String, DriverError> {
+    run_file_json_with_options_and_backend(path, &RunOptions::default(), DEFAULT_BACKEND)
+}
+
+pub fn run_file_json_with_options(
+    path: &Path,
+    options: &RunOptions,
+) -> Result<String, DriverError> {
+    run_file_json_with_options_and_backend(path, options, DEFAULT_BACKEND)
+}
+
+pub fn run_file_json_with_options_and_backend(
+    path: &Path,
+    options: &RunOptions,
+    backend: SolverBackend,
+) -> Result<String, DriverError> {
+    let summary = run_file_with_options_and_backend(path, options, backend)?;
+    serde_json::to_string(&summary).map_err(|source| DriverError::Json {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+pub fn print_file_model(path: &Path) -> Result<String, DriverError> {
+    let compiled = compile_file(path)?;
+    render_problem_model(&compiled.lowered_problem).map_err(DriverError::from)
+}
+
+pub fn validate_file_report(path: &Path) -> Result<String, DriverError> {
+    let validated = validate_file(path)?;
+    Ok(format!(
+        "Validation succeeded\nentrypoint: {}\nscenario: {}\nassets: {}\nconstraints: {}",
+        validated.entrypoint.display(),
+        validated.semantic_program.active_scenario,
+        validated.semantic_program.sets.assets.len(),
+        validated.semantic_program.active_constraints.len()
+    ))
+}
+
+fn summarize_variables(
+    variables: &[crate::execution::MappedVariableResult],
+    options: &RunOptions,
+) -> Vec<VariableSummary> {
+    variables
+        .iter()
+        .filter(|variable| {
+            options
+                .filter_variable
+                .as_deref()
+                .is_none_or(|pattern| wildcard_match(pattern, &variable.dsl_name))
+        })
+        .filter_map(|variable| {
+            let filtered_values = variable
+                .values
+                .iter()
+                .filter(|value| {
+                    options.filter_asset.as_deref().is_none_or(|pattern| {
+                        extract_asset_name(&value.lowered_name)
+                            .is_some_and(|asset| wildcard_match(pattern, asset))
+                    })
+                })
+                .map(|value| VariableValueSummary {
+                    name: trim_family_prefix(&variable.dsl_name, &value.lowered_name),
+                    value: value.value,
+                })
+                .collect::<Vec<_>>();
+
+            if options.filter_asset.is_some() && filtered_values.is_empty() {
+                return None;
+            }
+
+            let representative_value = filtered_values
+                .first()
+                .map_or(variable.representative_value, |value| value.value);
+            let values = if options.compact || values_are_redundant(&filtered_values) {
+                None
+            } else {
+                Some(filtered_values)
+            };
+
+            Some(VariableSummary {
+                name: variable.dsl_name.clone(),
+                representative_value,
+                values,
+            })
+        })
+        .collect()
+}
+
+fn values_are_redundant(values: &[VariableValueSummary]) -> bool {
+    match values.first() {
+        Some(first) => values
+            .iter()
+            .all(|value| (value.value - first.value).abs() < f64::EPSILON),
+        None => true,
+    }
+}
+
+fn trim_family_prefix(family_name: &str, value_name: &str) -> String {
+    let prefix = family_name.split('[').next().unwrap_or(family_name);
+    value_name
+        .strip_prefix(prefix)
+        .map_or_else(|| value_name.to_string(), ToString::to_string)
+}
+
+fn extract_asset_name(value_name: &str) -> Option<&str> {
+    let start = value_name.find('[')? + 1;
+    let remainder = &value_name[start..];
+    let end = remainder.find([',', ']'])?;
+    let asset = &remainder[..end];
+    if asset.is_empty() || asset.chars().all(|character| character.is_ascii_digit()) {
+        None
+    } else {
+        Some(asset)
+    }
+}
+
+fn wildcard_match(pattern: &str, value: &str) -> bool {
+    let pattern = pattern.as_bytes();
+    let value = value.as_bytes();
+    let mut pattern_index = 0usize;
+    let mut value_index = 0usize;
+    let mut star_index = None;
+    let mut match_index = 0usize;
+
+    while value_index < value.len() {
+        if pattern_index < pattern.len()
+            && (pattern[pattern_index] == b'?' || pattern[pattern_index] == value[value_index])
+        {
+            pattern_index += 1;
+            value_index += 1;
+        } else if pattern_index < pattern.len() && pattern[pattern_index] == b'*' {
+            star_index = Some(pattern_index);
+            match_index = value_index;
+            pattern_index += 1;
+        } else if let Some(star) = star_index {
+            pattern_index = star + 1;
+            match_index += 1;
+            value_index = match_index;
+        } else {
+            return false;
+        }
+    }
+
+    while pattern_index < pattern.len() && pattern[pattern_index] == b'*' {
+        pattern_index += 1;
+    }
+
+    pattern_index == pattern.len()
+}
+
+fn solve_status_name(status: SolveStatus) -> &'static str {
+    match status {
+        SolveStatus::Optimal => "optimal",
+        SolveStatus::Infeasible => "infeasible",
+        SolveStatus::Failed => "failed",
+    }
+}
+
+fn peak_rss_bytes() -> Option<u64> {
+    use sysinfo::{Pid, System};
+    let pid = Pid::from_u32(std::process::id());
+    let mut system = System::new();
+    system.refresh_processes(sysinfo::ProcessesToUpdate::Some(&[pid]), true);
+    system.process(pid).map(|p| p.memory())
+}

--- a/crates/arco-cli/src/execution.rs
+++ b/crates/arco-cli/src/execution.rs
@@ -1,0 +1,851 @@
+use arco_core::{
+    Bounds, Constraint, Model, ModelError as ArcoModelError, Objective, PrettyPrintOptions, Sense,
+    SolverError as ArcoSolverError, SolverStatus as ArcoSolverStatus, Variable,
+};
+use arco_highs::Solver as HighsSolver;
+use arco_kdl::lowering::{
+    ConstraintSense, LinearReport, LinearTerm, LoweredProblem, ObjectiveSense, VariableKind,
+};
+#[cfg(feature = "xpress")]
+use arco_xpress::Solver as XpressSolver;
+use std::collections::BTreeMap;
+use thiserror::Error;
+use tracing::info;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct AdapterSolveOutput {
+    pub status: SolveStatus,
+    pub objective_value: ScalarArtifactValue,
+    pub report_values: Vec<ScalarArtifactValue>,
+    pub variable_values: Vec<VariableArtifactValue>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SolveStatus {
+    Optimal,
+    Infeasible,
+    Failed,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ScalarArtifactValue {
+    pub lowered_name: String,
+    pub value: f64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct VariableArtifactValue {
+    pub lowered_name: String,
+    pub representative_value: f64,
+    pub values: Vec<VariableInstanceArtifactValue>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct VariableInstanceArtifactValue {
+    pub lowered_name: String,
+    pub value: f64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ExecutionResult {
+    pub backend: &'static str,
+    pub status: SolveStatus,
+    pub objective_sense: String,
+    pub objective: MappedScalarResult,
+    pub reports: Vec<MappedScalarResult>,
+    pub variables: Vec<MappedVariableResult>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct MappedScalarResult {
+    pub dsl_name: String,
+    pub lowered_name: String,
+    pub value: f64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct MappedVariableResult {
+    pub dsl_name: String,
+    pub lowered_name: String,
+    pub representative_value: f64,
+    pub values: Vec<MappedVariableValue>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct MappedVariableValue {
+    pub dsl_name: String,
+    pub lowered_name: String,
+    pub value: f64,
+}
+
+pub trait OptimizationAdapter {
+    fn backend_name(&self) -> &'static str;
+
+    fn solve(
+        &self,
+        problem: &LoweredProblem,
+        include_variable_values: bool,
+    ) -> Result<AdapterSolveOutput, ExecutionError>;
+}
+
+#[derive(Debug, Default)]
+pub struct MockArcoAdapter;
+
+#[derive(Debug, Default)]
+pub struct RustArcoAdapter {
+    log_to_console: bool,
+}
+
+#[cfg(feature = "xpress")]
+#[derive(Debug, Default)]
+pub struct XpressArcoAdapter {
+    log_to_console: bool,
+}
+
+#[derive(Debug, Error)]
+pub enum ExecutionError {
+    #[error("adapter backend `{backend}` failed to add variable `{lowered_name}`: {source}")]
+    AddVariable {
+        backend: String,
+        lowered_name: String,
+        #[source]
+        source: ArcoModelError,
+    },
+    #[error("adapter backend `{backend}` failed to name variable `{lowered_name}`: {source}")]
+    NameVariable {
+        backend: String,
+        lowered_name: String,
+        #[source]
+        source: ArcoModelError,
+    },
+    #[error("adapter backend `{backend}` failed to add constraint `{lowered_name}`: {source}")]
+    AddConstraint {
+        backend: String,
+        lowered_name: String,
+        #[source]
+        source: ArcoModelError,
+    },
+    #[error("adapter backend `{backend}` failed to name constraint `{lowered_name}`: {source}")]
+    NameConstraint {
+        backend: String,
+        lowered_name: String,
+        #[source]
+        source: ArcoModelError,
+    },
+    #[error("adapter backend `{backend}` references unknown lowered variable `{lowered_name}`")]
+    UnknownLoweredVariable {
+        backend: String,
+        lowered_name: String,
+    },
+    #[error(
+        "adapter backend `{backend}` failed to set coefficient for `{constraint_name}`: {source}"
+    )]
+    SetCoefficient {
+        backend: String,
+        constraint_name: String,
+        #[source]
+        source: ArcoModelError,
+    },
+    #[error("adapter backend `{backend}` failed to set objective `{lowered_name}`: {source}")]
+    SetObjective {
+        backend: String,
+        lowered_name: String,
+        #[source]
+        source: ArcoModelError,
+    },
+    #[error("adapter backend `{backend}` failed to name objective `{lowered_name}`: {source}")]
+    NameObjective {
+        backend: String,
+        lowered_name: String,
+        #[source]
+        source: ArcoModelError,
+    },
+    #[error("adapter backend `{backend}` failed to initialize solver: {source}")]
+    SolverInitialization {
+        backend: String,
+        #[source]
+        source: ArcoSolverError,
+    },
+    #[error("adapter backend `{backend}` failed to solve model: {source}")]
+    Solve {
+        backend: String,
+        #[source]
+        source: ArcoSolverError,
+    },
+    #[error(
+        "adapter backend `{backend}` produced no usable primal solution because status was `{status}`"
+    )]
+    NoFeasibleSolution { backend: String, status: String },
+    #[error("adapter backend `{backend}` did not return objective `{lowered_name}`")]
+    MissingObjectiveValue {
+        backend: String,
+        lowered_name: String,
+    },
+    #[error("adapter backend `{backend}` did not return report `{lowered_name}`")]
+    MissingReportValue {
+        backend: String,
+        lowered_name: String,
+    },
+    #[error("adapter backend `{backend}` did not return variable `{lowered_name}`")]
+    MissingVariableValue {
+        backend: String,
+        lowered_name: String,
+    },
+}
+
+impl MockArcoAdapter {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl RustArcoAdapter {
+    pub fn new() -> Self {
+        Self {
+            log_to_console: false,
+        }
+    }
+
+    pub fn with_console_log(log_to_console: bool) -> Self {
+        Self { log_to_console }
+    }
+}
+
+impl OptimizationAdapter for MockArcoAdapter {
+    fn backend_name(&self) -> &'static str {
+        "mock-arco"
+    }
+
+    fn solve(
+        &self,
+        problem: &LoweredProblem,
+        include_variable_values: bool,
+    ) -> Result<AdapterSolveOutput, ExecutionError> {
+        Ok(AdapterSolveOutput {
+            status: SolveStatus::Optimal,
+            objective_value: ScalarArtifactValue {
+                lowered_name: problem.objective.name.clone(),
+                value: 0.0,
+            },
+            report_values: problem
+                .reports
+                .iter()
+                .map(|report| ScalarArtifactValue {
+                    lowered_name: report.name.clone(),
+                    value: 0.0,
+                })
+                .collect(),
+            variable_values: problem
+                .variables
+                .iter()
+                .map(|variable| VariableArtifactValue {
+                    lowered_name: variable.family.clone(),
+                    representative_value: 0.0,
+                    values: if include_variable_values {
+                        problem
+                            .algebra
+                            .variable_instances
+                            .iter()
+                            .filter(|instance| instance.family == variable.family)
+                            .map(|instance| VariableInstanceArtifactValue {
+                                lowered_name: instance.name.clone(),
+                                value: 0.0,
+                            })
+                            .collect()
+                    } else {
+                        Vec::new()
+                    },
+                })
+                .collect(),
+        })
+    }
+}
+
+impl OptimizationAdapter for RustArcoAdapter {
+    fn backend_name(&self) -> &'static str {
+        "arco-rust-highs"
+    }
+
+    fn solve(
+        &self,
+        problem: &LoweredProblem,
+        include_variable_values: bool,
+    ) -> Result<AdapterSolveOutput, ExecutionError> {
+        let backend = self.backend_name().to_string();
+        info!("solving with {}", backend);
+        let BuiltModel {
+            model,
+            variable_indices,
+        } = build_model(problem, &backend)?;
+        let mut solver =
+            HighsSolver::new(model).map_err(|source| ExecutionError::SolverInitialization {
+                backend: backend.clone(),
+                source,
+            })?;
+        solver.set_log_to_console(self.log_to_console);
+
+        let solution = solver.solve().map_err(|source| ExecutionError::Solve {
+            backend: backend.clone(),
+            source,
+        })?;
+        info!("solve status: {}", solution.status_string());
+        if !solution.is_feasible() {
+            return Err(ExecutionError::NoFeasibleSolution {
+                backend,
+                status: solution.status_string().to_string(),
+            });
+        }
+
+        let objective_value = problem.algebra.objective.constant + solution.objective_value();
+        let report_values = problem
+            .algebra
+            .reports
+            .iter()
+            .map(|report| {
+                Ok(ScalarArtifactValue {
+                    lowered_name: report.name.clone(),
+                    value: evaluate_linear_report(
+                        &backend,
+                        report,
+                        &variable_indices,
+                        solution.primal_values(),
+                    )?,
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let variable_values = problem
+            .variables
+            .iter()
+            .map(|variable| {
+                let representative_value = problem
+                    .algebra
+                    .variable_instances
+                    .iter()
+                    .find(|instance| instance.family == variable.family)
+                    .map(|instance| {
+                        lookup_primal_value(
+                            &backend,
+                            &instance.name,
+                            &variable_indices,
+                            solution.primal_values(),
+                        )
+                    })
+                    .transpose()?
+                    .unwrap_or(0.0);
+                let values = if include_variable_values {
+                    problem
+                        .algebra
+                        .variable_instances
+                        .iter()
+                        .filter(|instance| instance.family == variable.family)
+                        .map(|instance| {
+                            Ok(VariableInstanceArtifactValue {
+                                lowered_name: instance.name.clone(),
+                                value: lookup_primal_value(
+                                    &backend,
+                                    &instance.name,
+                                    &variable_indices,
+                                    solution.primal_values(),
+                                )?,
+                            })
+                        })
+                        .collect::<Result<Vec<_>, _>>()?
+                } else {
+                    Vec::new()
+                };
+
+                Ok(VariableArtifactValue {
+                    lowered_name: variable.family.clone(),
+                    representative_value,
+                    values,
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(AdapterSolveOutput {
+            status: map_solver_status(solution.core_status()),
+            objective_value: ScalarArtifactValue {
+                lowered_name: problem.objective.name.clone(),
+                value: objective_value,
+            },
+            report_values,
+            variable_values,
+        })
+    }
+}
+
+#[cfg(feature = "xpress")]
+impl XpressArcoAdapter {
+    pub fn new() -> Self {
+        Self {
+            log_to_console: false,
+        }
+    }
+
+    pub fn with_console_log(log_to_console: bool) -> Self {
+        Self { log_to_console }
+    }
+}
+
+#[cfg(feature = "xpress")]
+impl OptimizationAdapter for XpressArcoAdapter {
+    fn backend_name(&self) -> &'static str {
+        "arco-rust-xpress"
+    }
+
+    fn solve(
+        &self,
+        problem: &LoweredProblem,
+        include_variable_values: bool,
+    ) -> Result<AdapterSolveOutput, ExecutionError> {
+        let backend = self.backend_name().to_string();
+        info!("solving with {}", backend);
+        let BuiltModel {
+            model,
+            variable_indices,
+        } = build_model(problem, &backend)?;
+        let mut solver =
+            XpressSolver::new(model).map_err(|source| ExecutionError::SolverInitialization {
+                backend: backend.clone(),
+                source,
+            })?;
+        solver.set_log_to_console(self.log_to_console);
+
+        let solution = solver.solve().map_err(|source| ExecutionError::Solve {
+            backend: backend.clone(),
+            source,
+        })?;
+        info!("solve status: {:?}", solution.core_status());
+        if !solution.is_feasible() {
+            return Err(ExecutionError::NoFeasibleSolution {
+                backend,
+                status: format!("{:?}", solution.core_status()),
+            });
+        }
+
+        let objective_value = problem.algebra.objective.constant + solution.objective_value();
+        let report_values = problem
+            .algebra
+            .reports
+            .iter()
+            .map(|report| {
+                Ok(ScalarArtifactValue {
+                    lowered_name: report.name.clone(),
+                    value: evaluate_linear_report(
+                        &backend,
+                        report,
+                        &variable_indices,
+                        solution.primal_values(),
+                    )?,
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let variable_values = problem
+            .variables
+            .iter()
+            .map(|variable| {
+                let representative_value = problem
+                    .algebra
+                    .variable_instances
+                    .iter()
+                    .find(|instance| instance.family == variable.family)
+                    .map(|instance| {
+                        lookup_primal_value(
+                            &backend,
+                            &instance.name,
+                            &variable_indices,
+                            solution.primal_values(),
+                        )
+                    })
+                    .transpose()?
+                    .unwrap_or(0.0);
+                let values = if include_variable_values {
+                    problem
+                        .algebra
+                        .variable_instances
+                        .iter()
+                        .filter(|instance| instance.family == variable.family)
+                        .map(|instance| {
+                            Ok(VariableInstanceArtifactValue {
+                                lowered_name: instance.name.clone(),
+                                value: lookup_primal_value(
+                                    &backend,
+                                    &instance.name,
+                                    &variable_indices,
+                                    solution.primal_values(),
+                                )?,
+                            })
+                        })
+                        .collect::<Result<Vec<_>, _>>()?
+                } else {
+                    Vec::new()
+                };
+
+                Ok(VariableArtifactValue {
+                    lowered_name: variable.family.clone(),
+                    representative_value,
+                    values,
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(AdapterSolveOutput {
+            status: map_solver_status(solution.core_status()),
+            objective_value: ScalarArtifactValue {
+                lowered_name: problem.objective.name.clone(),
+                value: objective_value,
+            },
+            report_values,
+            variable_values,
+        })
+    }
+}
+
+pub fn execute_problem(
+    problem: &LoweredProblem,
+    adapter: &dyn OptimizationAdapter,
+) -> Result<ExecutionResult, ExecutionError> {
+    execute_problem_with_options(problem, adapter, true)
+}
+
+pub fn execute_problem_with_options(
+    problem: &LoweredProblem,
+    adapter: &dyn OptimizationAdapter,
+    include_variable_values: bool,
+) -> Result<ExecutionResult, ExecutionError> {
+    let solve_output = adapter.solve(problem, include_variable_values)?;
+    let backend = adapter.backend_name();
+
+    let objective = if solve_output.objective_value.lowered_name == problem.objective.name {
+        MappedScalarResult {
+            dsl_name: problem.objective.name.clone(),
+            lowered_name: solve_output.objective_value.lowered_name.clone(),
+            value: solve_output.objective_value.value,
+        }
+    } else {
+        return Err(ExecutionError::MissingObjectiveValue {
+            backend: backend.to_string(),
+            lowered_name: problem.objective.name.clone(),
+        });
+    };
+
+    let report_values = solve_output
+        .report_values
+        .iter()
+        .map(|report| (report.lowered_name.clone(), report.value))
+        .collect::<BTreeMap<_, _>>();
+    let variable_values = solve_output
+        .variable_values
+        .iter()
+        .map(|variable| (variable.lowered_name.clone(), variable))
+        .collect::<BTreeMap<_, _>>();
+
+    let reports = problem
+        .reports
+        .iter()
+        .map(|report| {
+            let value = report_values.get(&report.name).copied().ok_or_else(|| {
+                ExecutionError::MissingReportValue {
+                    backend: backend.to_string(),
+                    lowered_name: report.name.clone(),
+                }
+            })?;
+            Ok(MappedScalarResult {
+                dsl_name: report.name.clone(),
+                lowered_name: report.name.clone(),
+                value,
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let variables = problem
+        .variables
+        .iter()
+        .map(|variable| {
+            let solved_variable =
+                variable_values
+                    .get(&variable.family)
+                    .copied()
+                    .ok_or_else(|| ExecutionError::MissingVariableValue {
+                        backend: backend.to_string(),
+                        lowered_name: variable.family.clone(),
+                    })?;
+            Ok(MappedVariableResult {
+                dsl_name: variable.family.clone(),
+                lowered_name: variable.family.clone(),
+                representative_value: solved_variable.representative_value,
+                values: solved_variable
+                    .values
+                    .iter()
+                    .map(|value| MappedVariableValue {
+                        dsl_name: value.lowered_name.clone(),
+                        lowered_name: value.lowered_name.clone(),
+                        value: value.value,
+                    })
+                    .collect(),
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(ExecutionResult {
+        backend,
+        status: solve_output.status,
+        objective_sense: problem.objective.sense.clone(),
+        objective,
+        reports,
+        variables,
+    })
+}
+
+pub fn render_problem_model(problem: &LoweredProblem) -> Result<String, ExecutionError> {
+    let built = build_model(problem, "arco-rust-highs")?;
+    Ok(built.model.format_ascii(PrettyPrintOptions::full()))
+}
+
+struct BuiltModel {
+    model: Model,
+    variable_indices: BTreeMap<String, usize>,
+}
+
+fn build_model(problem: &LoweredProblem, backend: &str) -> Result<BuiltModel, ExecutionError> {
+    let mut model = Model::with_capacities(
+        problem.algebra.variable_instances.len(),
+        problem.algebra.constraints.len(),
+    );
+    let mut variable_indices = BTreeMap::new();
+
+    for variable in &problem.algebra.variable_instances {
+        let upper = variable.upper.unwrap_or(f64::INFINITY);
+        let variable_def = match variable.kind {
+            VariableKind::Continuous => Variable::continuous(Bounds::new(variable.lower, upper)),
+            VariableKind::Integer => Variable::integer(Bounds::new(variable.lower, upper)),
+            VariableKind::Binary => Variable::binary(),
+        };
+        let variable_id =
+            model
+                .add_variable(variable_def)
+                .map_err(|source| ExecutionError::AddVariable {
+                    backend: backend.to_string(),
+                    lowered_name: variable.name.clone(),
+                    source,
+                })?;
+        model
+            .set_variable_name(variable_id, variable.name.clone())
+            .map_err(|source| ExecutionError::NameVariable {
+                backend: backend.to_string(),
+                lowered_name: variable.name.clone(),
+                source,
+            })?;
+        variable_indices.insert(variable.name.clone(), variable_id.inner() as usize);
+    }
+
+    for constraint in &problem.algebra.constraints {
+        let constraint_id = model
+            .add_constraint(Constraint {
+                bounds: to_bounds(constraint.sense, constraint.rhs),
+            })
+            .map_err(|source| ExecutionError::AddConstraint {
+                backend: backend.to_string(),
+                lowered_name: constraint.name.clone(),
+                source,
+            })?;
+        model
+            .set_constraint_name(constraint_id, constraint.name.clone())
+            .map_err(|source| ExecutionError::NameConstraint {
+                backend: backend.to_string(),
+                lowered_name: constraint.name.clone(),
+                source,
+            })?;
+
+        for term in &constraint.terms {
+            let variable_id = model
+                .get_variable_by_name(&term.variable_name)
+                .ok_or_else(|| ExecutionError::UnknownLoweredVariable {
+                    backend: backend.to_string(),
+                    lowered_name: term.variable_name.clone(),
+                })?;
+            model
+                .set_coefficient(variable_id, constraint_id, term.coefficient)
+                .map_err(|source| ExecutionError::SetCoefficient {
+                    backend: backend.to_string(),
+                    constraint_name: constraint.name.clone(),
+                    source,
+                })?;
+        }
+    }
+
+    let objective_terms = problem
+        .algebra
+        .objective
+        .terms
+        .iter()
+        .map(|term| {
+            let variable_id = model
+                .get_variable_by_name(&term.variable_name)
+                .ok_or_else(|| ExecutionError::UnknownLoweredVariable {
+                    backend: backend.to_string(),
+                    lowered_name: term.variable_name.clone(),
+                })?;
+            Ok((variable_id, term.coefficient))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    model
+        .set_objective(Objective {
+            sense: Some(to_objective_sense(problem.algebra.objective.sense)),
+            terms: objective_terms,
+        })
+        .map_err(|source| ExecutionError::SetObjective {
+            backend: backend.to_string(),
+            lowered_name: problem.algebra.objective.name.clone(),
+            source,
+        })?;
+    model
+        .set_objective_name(Some(problem.algebra.objective.name.clone()))
+        .map_err(|source| ExecutionError::NameObjective {
+            backend: backend.to_string(),
+            lowered_name: problem.algebra.objective.name.clone(),
+            source,
+        })?;
+
+    Ok(BuiltModel {
+        model,
+        variable_indices,
+    })
+}
+
+fn evaluate_linear_report(
+    backend: &str,
+    report: &LinearReport,
+    variable_indices: &BTreeMap<String, usize>,
+    primal_values: &[f64],
+) -> Result<f64, ExecutionError> {
+    let terms_value =
+        evaluate_linear_terms(backend, &report.terms, variable_indices, primal_values)?;
+    Ok(report.constant + terms_value)
+}
+
+fn evaluate_linear_terms(
+    backend: &str,
+    terms: &[LinearTerm],
+    variable_indices: &BTreeMap<String, usize>,
+    primal_values: &[f64],
+) -> Result<f64, ExecutionError> {
+    terms.iter().try_fold(0.0, |accumulator, term| {
+        let value = lookup_primal_value(
+            backend,
+            &term.variable_name,
+            variable_indices,
+            primal_values,
+        )?;
+        Ok(accumulator + (term.coefficient * value))
+    })
+}
+
+fn lookup_primal_value(
+    backend: &str,
+    lowered_name: &str,
+    variable_indices: &BTreeMap<String, usize>,
+    primal_values: &[f64],
+) -> Result<f64, ExecutionError> {
+    let index = variable_indices.get(lowered_name).copied().ok_or_else(|| {
+        ExecutionError::UnknownLoweredVariable {
+            backend: backend.to_string(),
+            lowered_name: lowered_name.to_string(),
+        }
+    })?;
+    primal_values
+        .get(index)
+        .copied()
+        .ok_or_else(|| ExecutionError::UnknownLoweredVariable {
+            backend: backend.to_string(),
+            lowered_name: lowered_name.to_string(),
+        })
+}
+
+fn to_bounds(sense: ConstraintSense, rhs: f64) -> Bounds {
+    match sense {
+        ConstraintSense::GreaterEqual => Bounds::new(rhs, f64::INFINITY),
+        ConstraintSense::LessEqual => Bounds::new(f64::NEG_INFINITY, rhs),
+        ConstraintSense::Equal => Bounds::new(rhs, rhs),
+    }
+}
+
+fn to_objective_sense(sense: ObjectiveSense) -> Sense {
+    match sense {
+        ObjectiveSense::Minimize => Sense::Minimize,
+        ObjectiveSense::Maximize => Sense::Maximize,
+    }
+}
+
+fn map_solver_status(status: ArcoSolverStatus) -> SolveStatus {
+    match status {
+        ArcoSolverStatus::Optimal => SolveStatus::Optimal,
+        ArcoSolverStatus::Infeasible => SolveStatus::Infeasible,
+        ArcoSolverStatus::Unbounded
+        | ArcoSolverStatus::TimeLimit
+        | ArcoSolverStatus::IterationLimit
+        | ArcoSolverStatus::Unknown => SolveStatus::Failed,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::execution::{MockArcoAdapter, execute_problem_with_options};
+    use arco_kdl::lowering::{
+        AlgebraicProblem, LinearObjective, LoweredObjective, LoweredProblem, LoweredVariable,
+        ObjectiveSense, VariableInstance, VariableKind,
+    };
+
+    #[test]
+    #[allow(clippy::float_cmp)]
+    fn compact_execution_can_skip_detailed_variable_values() {
+        let problem = LoweredProblem {
+            parameters: Vec::new(),
+            variables: vec![LoweredVariable {
+                family: "x[a,t]".to_string(),
+            }],
+            constraints: Vec::new(),
+            objective: LoweredObjective {
+                name: "obj".to_string(),
+                sense: "maximize".to_string(),
+                expression: "0".to_string(),
+            },
+            reports: Vec::new(),
+            traceability: Vec::new(),
+            algebra: AlgebraicProblem {
+                variable_instances: vec![VariableInstance {
+                    name: "x[A,1]".to_string(),
+                    family: "x[a,t]".to_string(),
+                    lower: 0.0,
+                    upper: None,
+                    kind: VariableKind::Continuous,
+                }],
+                constraints: Vec::new(),
+                objective: LinearObjective {
+                    name: "obj".to_string(),
+                    sense: ObjectiveSense::Maximize,
+                    constant: 0.0,
+                    terms: Vec::new(),
+                },
+                reports: Vec::new(),
+            },
+        };
+
+        let execution = execute_problem_with_options(&problem, &MockArcoAdapter::new(), false)
+            .expect("compact execution should succeed");
+
+        assert_eq!(execution.status, crate::execution::SolveStatus::Optimal);
+        assert_eq!(execution.objective.dsl_name, "obj");
+        assert_eq!(execution.objective.value, 0.0);
+        assert_eq!(execution.objective_sense, "maximize");
+        assert!(execution.reports.is_empty());
+
+        assert_eq!(execution.variables.len(), 1);
+        assert_eq!(execution.variables[0].dsl_name, "x[a,t]");
+        assert_eq!(execution.variables[0].representative_value, 0.0);
+        assert!(execution.variables[0].values.is_empty());
+    }
+}

--- a/crates/arco-cli/src/export.rs
+++ b/crates/arco-cli/src/export.rs
@@ -1,0 +1,353 @@
+// thiserror's Display derive triggers unused_assignments in edition 2024
+// because derive-generated code no longer inherits item-level #[allow].
+#![allow(unused_assignments)]
+
+use arco_kdl::lowering::{
+    AlgebraicProblem, ConstraintSense, LinearTerm, ObjectiveSense, VariableInstance, VariableKind,
+};
+use miette::Diagnostic;
+use std::collections::BTreeMap;
+use std::io::Write;
+use thiserror::Error;
+
+#[derive(Debug, Error, Diagnostic)]
+pub enum ExportError {
+    #[error("failed to write exported model: {source}")]
+    #[diagnostic(
+        code(arco::export::io),
+        help("verify the destination path is writable")
+    )]
+    Io {
+        #[source]
+        source: std::io::Error,
+    },
+}
+
+pub fn write_lp(problem: &AlgebraicProblem, writer: &mut dyn Write) -> Result<(), ExportError> {
+    writeln!(writer, "\\ Problem name: MODEL").map_err(io_error)?;
+    writeln!(writer, "{}", lp_objective_header(problem.objective.sense)).map_err(io_error)?;
+    writeln!(
+        writer,
+        "  {}: {}",
+        problem.objective.name,
+        format_linear_expression(&problem.objective.terms, problem.objective.constant)
+    )
+    .map_err(io_error)?;
+    writeln!(writer, "Subject To").map_err(io_error)?;
+    for constraint in &problem.constraints {
+        writeln!(
+            writer,
+            "  {}: {} {} {}",
+            constraint.name,
+            format_linear_expression(&constraint.terms, 0.0),
+            lp_constraint_sense(constraint.sense),
+            format_number(constraint.rhs)
+        )
+        .map_err(io_error)?;
+    }
+
+    writeln!(writer, "Bounds").map_err(io_error)?;
+    for variable in &problem.variable_instances {
+        write_lp_bounds_line(variable, writer)?;
+    }
+
+    let generals = problem
+        .variable_instances
+        .iter()
+        .filter(|variable| variable.kind == VariableKind::Integer)
+        .map(|variable| variable.name.as_str())
+        .collect::<Vec<_>>();
+    if !generals.is_empty() {
+        writeln!(writer, "Generals").map_err(io_error)?;
+        for name in generals {
+            writeln!(writer, "  {name}").map_err(io_error)?;
+        }
+    }
+
+    let binaries = problem
+        .variable_instances
+        .iter()
+        .filter(|variable| variable.kind == VariableKind::Binary)
+        .map(|variable| variable.name.as_str())
+        .collect::<Vec<_>>();
+    if !binaries.is_empty() {
+        writeln!(writer, "Binaries").map_err(io_error)?;
+        for name in binaries {
+            writeln!(writer, "  {name}").map_err(io_error)?;
+        }
+    }
+
+    writeln!(writer, "End").map_err(io_error)?;
+    Ok(())
+}
+
+pub fn write_mps(problem: &AlgebraicProblem, writer: &mut dyn Write) -> Result<(), ExportError> {
+    writeln!(writer, "NAME          MODEL").map_err(io_error)?;
+    writeln!(writer, "ROWS").map_err(io_error)?;
+    writeln!(writer, " N  OBJ").map_err(io_error)?;
+    for constraint in &problem.constraints {
+        writeln!(
+            writer,
+            " {}  {}",
+            mps_row_type(constraint.sense),
+            constraint.name
+        )
+        .map_err(io_error)?;
+    }
+
+    let objective_terms = problem
+        .objective
+        .terms
+        .iter()
+        .map(|term| (term.variable_name.clone(), term.coefficient))
+        .collect::<BTreeMap<_, _>>();
+    let column_terms = build_column_terms(problem, &objective_terms);
+
+    writeln!(writer, "COLUMNS").map_err(io_error)?;
+    let mut in_integer_block = false;
+    for variable in &problem.variable_instances {
+        let is_integer = variable.kind != VariableKind::Continuous;
+        if is_integer && !in_integer_block {
+            writeln!(writer, "    MARKER    'MARKER'                 'INTORG'")
+                .map_err(io_error)?;
+            in_integer_block = true;
+        } else if !is_integer && in_integer_block {
+            writeln!(writer, "    MARKER    'MARKER'                 'INTEND'")
+                .map_err(io_error)?;
+            in_integer_block = false;
+        }
+
+        let entries = column_terms
+            .get(&variable.name)
+            .cloned()
+            .unwrap_or_default();
+        for pair in entries.chunks(2) {
+            match pair {
+                [(row_1, value_1), (row_2, value_2)] => writeln!(
+                    writer,
+                    "    {:<8}  {:<8}  {:>16}  {:<8}  {:>16}",
+                    variable.name,
+                    row_1,
+                    format_number(*value_1),
+                    row_2,
+                    format_number(*value_2)
+                )
+                .map_err(io_error)?,
+                [(row_1, value_1)] => writeln!(
+                    writer,
+                    "    {:<8}  {:<8}  {:>16}",
+                    variable.name,
+                    row_1,
+                    format_number(*value_1)
+                )
+                .map_err(io_error)?,
+                _ => {}
+            }
+        }
+    }
+    if in_integer_block {
+        writeln!(writer, "    MARKER    'MARKER'                 'INTEND'").map_err(io_error)?;
+    }
+
+    writeln!(writer, "RHS").map_err(io_error)?;
+    for constraint in &problem.constraints {
+        writeln!(
+            writer,
+            "    RHS1      {:<8}  {:>16}",
+            constraint.name,
+            format_number(constraint.rhs)
+        )
+        .map_err(io_error)?;
+    }
+
+    writeln!(writer, "BOUNDS").map_err(io_error)?;
+    for variable in &problem.variable_instances {
+        write_mps_bounds(variable, writer)?;
+    }
+
+    writeln!(writer, "ENDATA").map_err(io_error)?;
+    Ok(())
+}
+
+fn build_column_terms(
+    problem: &AlgebraicProblem,
+    objective_terms: &BTreeMap<String, f64>,
+) -> BTreeMap<String, Vec<(String, f64)>> {
+    let mut terms = BTreeMap::<String, Vec<(String, f64)>>::new();
+
+    for variable in &problem.variable_instances {
+        if let Some(value) = objective_terms.get(&variable.name) {
+            terms
+                .entry(variable.name.clone())
+                .or_default()
+                .push(("OBJ".to_string(), *value));
+        }
+    }
+
+    for constraint in &problem.constraints {
+        for term in &constraint.terms {
+            terms
+                .entry(term.variable_name.clone())
+                .or_default()
+                .push((constraint.name.clone(), term.coefficient));
+        }
+    }
+
+    terms
+}
+
+fn lp_objective_header(sense: ObjectiveSense) -> &'static str {
+    match sense {
+        ObjectiveSense::Minimize => "Minimize",
+        ObjectiveSense::Maximize => "Maximize",
+    }
+}
+
+fn lp_constraint_sense(sense: ConstraintSense) -> &'static str {
+    match sense {
+        ConstraintSense::GreaterEqual => ">=",
+        ConstraintSense::LessEqual => "<=",
+        ConstraintSense::Equal => "=",
+    }
+}
+
+fn mps_row_type(sense: ConstraintSense) -> char {
+    match sense {
+        ConstraintSense::GreaterEqual => 'G',
+        ConstraintSense::LessEqual => 'L',
+        ConstraintSense::Equal => 'E',
+    }
+}
+
+fn write_lp_bounds_line(
+    variable: &VariableInstance,
+    writer: &mut dyn Write,
+) -> Result<(), ExportError> {
+    match variable.upper {
+        Some(upper) if (variable.lower - upper).abs() < f64::EPSILON => writeln!(
+            writer,
+            "  {} = {}",
+            variable.name,
+            format_number(variable.lower)
+        )
+        .map_err(io_error)?,
+        Some(upper) => writeln!(
+            writer,
+            "  {} <= {} <= {}",
+            format_number(variable.lower),
+            variable.name,
+            format_number(upper)
+        )
+        .map_err(io_error)?,
+        None if variable.lower == f64::NEG_INFINITY => {
+            writeln!(writer, "  {} free", variable.name).map_err(io_error)?;
+        }
+        None => writeln!(
+            writer,
+            "  {} <= {}",
+            format_number(variable.lower),
+            variable.name
+        )
+        .map_err(io_error)?,
+    }
+
+    Ok(())
+}
+
+fn write_mps_bounds(
+    variable: &VariableInstance,
+    writer: &mut dyn Write,
+) -> Result<(), ExportError> {
+    match variable.kind {
+        VariableKind::Binary => {
+            writeln!(writer, " BV BND1      {}", variable.name).map_err(io_error)?;
+            return Ok(());
+        }
+        VariableKind::Integer | VariableKind::Continuous => {}
+    }
+
+    if variable.lower == f64::NEG_INFINITY && variable.upper.is_none() {
+        writeln!(writer, " FR BND1      {}", variable.name).map_err(io_error)?;
+        return Ok(());
+    }
+
+    let lower_code = if variable.kind == VariableKind::Integer {
+        "LI"
+    } else {
+        "LO"
+    };
+    writeln!(
+        writer,
+        " {} BND1      {:<8}  {}",
+        lower_code,
+        variable.name,
+        format_number(variable.lower)
+    )
+    .map_err(io_error)?;
+
+    if let Some(upper) = variable.upper {
+        let upper_code = if variable.kind == VariableKind::Integer {
+            "UI"
+        } else {
+            "UP"
+        };
+        writeln!(
+            writer,
+            " {} BND1      {:<8}  {}",
+            upper_code,
+            variable.name,
+            format_number(upper)
+        )
+        .map_err(io_error)?;
+    }
+
+    Ok(())
+}
+
+fn format_linear_expression(terms: &[LinearTerm], constant: f64) -> String {
+    let mut parts = Vec::new();
+    if constant != 0.0 || terms.is_empty() {
+        parts.push(format_number(constant));
+    }
+
+    for term in terms {
+        let sign = if term.coefficient < 0.0 { "-" } else { "+" };
+        let absolute = term.coefficient.abs();
+        let body = if approximately_one(absolute) {
+            term.variable_name.clone()
+        } else {
+            format!("{} {}", format_number(absolute), term.variable_name)
+        };
+
+        if parts.is_empty() {
+            if sign == "-" {
+                parts.push(format!("- {body}"));
+            } else {
+                parts.push(body);
+            }
+        } else {
+            parts.push(format!("{sign} {body}"));
+        }
+    }
+
+    parts.join(" ")
+}
+
+fn approximately_one(value: f64) -> bool {
+    (value - 1.0).abs() < 1e-9
+}
+
+fn format_number(value: f64) -> String {
+    if value.fract().abs() < 1e-9 {
+        format!("{value:.0}")
+    } else {
+        format!("{value:.12}")
+            .trim_end_matches('0')
+            .trim_end_matches('.')
+            .to_string()
+    }
+}
+
+fn io_error(source: std::io::Error) -> ExportError {
+    ExportError::Io { source }
+}

--- a/crates/arco-cli/src/lib.rs
+++ b/crates/arco-cli/src/lib.rs
@@ -1,0 +1,7 @@
+pub mod benchmark;
+pub mod cli_io;
+pub mod config;
+pub mod debug;
+pub mod driver;
+pub mod execution;
+pub mod export;

--- a/crates/arco-cli/src/main.rs
+++ b/crates/arco-cli/src/main.rs
@@ -1,0 +1,202 @@
+use arco_cli::cli_io::{should_log_solver_to_console, write_stdout, write_stdout_line};
+use arco_cli::config::{SolverBackend, SolverConfig, load_solver_config, save_solver_config};
+use arco_cli::debug::launch_ipython;
+use arco_cli::driver::{
+    RunOptions, print_file_model, run_file_json_with_options_and_backend, validate_file_report,
+};
+use arco_cli::export::{write_lp, write_mps};
+use arco_kdl::pipeline::compile_file;
+use clap::{ArgAction, Parser, Subcommand, ValueEnum};
+use miette::IntoDiagnostic;
+use std::fs;
+use std::io::IsTerminal;
+use std::path::PathBuf;
+
+#[derive(Parser)]
+#[command(
+    name = "arco",
+    about = "Algebraic optimization DSL compiler and solver"
+)]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+
+    /// Increase verbosity (-v, -vv)
+    #[arg(short, long, action = ArgAction::Count, global = true)]
+    verbose: u8,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Compile and solve a .kdl formulation
+    Run {
+        path: PathBuf,
+        /// Filter output variables by glob pattern
+        #[arg(long)]
+        filter_variable: Option<String>,
+        /// Filter output by asset name glob
+        #[arg(long)]
+        filter_asset: Option<String>,
+        /// Omit full value arrays from the JSON summary
+        #[arg(long)]
+        compact: bool,
+    },
+    /// Print the algebraic model sent to the solver
+    PrintModel { path: PathBuf },
+    /// Validate a .kdl file without solving
+    Validate { path: PathBuf },
+    /// Open an interactive debug shell in IPython
+    Debug { path: PathBuf },
+    /// Export the algebraic model in LP or MPS format
+    Export {
+        path: PathBuf,
+        #[arg(long, default_value = "lp")]
+        format: ExportFormat,
+        #[arg(short, long)]
+        output: Option<PathBuf>,
+    },
+    /// Configure solver specification
+    Solver {
+        #[command(subcommand)]
+        action: SolverAction,
+    },
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum ExportFormat {
+    Lp,
+    Mps,
+}
+
+#[derive(Subcommand)]
+enum SolverAction {
+    /// Show the active solver backend
+    Show,
+    /// Set the solver backend
+    Set { backend: SolverBackendArg },
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum SolverBackendArg {
+    Highs,
+    Xpress,
+}
+
+impl From<SolverBackendArg> for SolverBackend {
+    fn from(value: SolverBackendArg) -> Self {
+        match value {
+            SolverBackendArg::Highs => SolverBackend::Highs,
+            SolverBackendArg::Xpress => SolverBackend::Xpress,
+        }
+    }
+}
+
+fn main() -> miette::Result<()> {
+    let cli = Cli::parse();
+    let _ = miette::set_hook(Box::new(|_| {
+        Box::new(miette::MietteHandlerOpts::new().build())
+    }));
+    init_tracing(cli.verbose);
+
+    match cli.command {
+        Command::Run {
+            path,
+            filter_variable,
+            filter_asset,
+            compact,
+        } => {
+            let solver_config = load_solver_config()?;
+            let output = run_file_json_with_options_and_backend(
+                &path,
+                &RunOptions {
+                    compact,
+                    filter_variable,
+                    filter_asset,
+                    solver_log: should_log_solver_to_console(
+                        cli.verbose,
+                        std::io::stdout().is_terminal(),
+                    ),
+                },
+                solver_config.backend,
+            )?;
+            write_stdout(output.as_bytes()).into_diagnostic()?;
+        }
+        Command::PrintModel { path } => {
+            write_stdout_line(&print_file_model(&path)?).into_diagnostic()?;
+        }
+        Command::Validate { path } => {
+            write_stdout_line(&validate_file_report(&path)?).into_diagnostic()?;
+        }
+        Command::Debug { path } => {
+            launch_ipython(&path)?;
+        }
+        Command::Export {
+            path,
+            format,
+            output,
+        } => export_model(path, format, output)?,
+        Command::Solver { action } => handle_solver_action(action)?,
+    }
+
+    Ok(())
+}
+
+fn export_model(
+    path: PathBuf,
+    format: ExportFormat,
+    output: Option<PathBuf>,
+) -> miette::Result<()> {
+    let compiled = compile_file(&path)?;
+    let mut buffer = Vec::new();
+    match format {
+        ExportFormat::Lp => write_lp(&compiled.lowered_problem.algebra, &mut buffer)?,
+        ExportFormat::Mps => write_mps(&compiled.lowered_problem.algebra, &mut buffer)?,
+    }
+
+    if let Some(output_path) = output {
+        fs::write(output_path, buffer).into_diagnostic()?;
+    } else {
+        write_stdout(&buffer).into_diagnostic()?;
+    }
+
+    Ok(())
+}
+
+fn handle_solver_action(action: SolverAction) -> miette::Result<()> {
+    match action {
+        SolverAction::Show => {
+            let config = load_solver_config()?;
+            write_stdout_line(&format!("backend: {}", config.backend.as_str()))
+                .into_diagnostic()?;
+        }
+        SolverAction::Set { backend } => {
+            let config = SolverConfig {
+                backend: backend.into(),
+            };
+            let path = save_solver_config(&config)?;
+            write_stdout_line(&format!("backend: {}", config.backend.as_str()))
+                .into_diagnostic()?;
+            write_stdout_line(&format!("path: {}", path.display())).into_diagnostic()?;
+        }
+    }
+
+    Ok(())
+}
+
+fn init_tracing(verbose: u8) {
+    if verbose == 0 {
+        return;
+    }
+
+    let level = match verbose {
+        1 => tracing::Level::INFO,
+        _ => tracing::Level::DEBUG,
+    };
+
+    tracing_subscriber::fmt()
+        .with_max_level(level)
+        .with_writer(std::io::stderr)
+        .with_target(false)
+        .without_time()
+        .init();
+}

--- a/crates/arco-cli/tests/benchmark_suite.rs
+++ b/crates/arco-cli/tests/benchmark_suite.rs
@@ -1,0 +1,54 @@
+use arco_cli::benchmark::evaluate_manifest;
+use std::path::PathBuf;
+
+#[test]
+fn benchmark_manifest_cases_match_golden_semantic_programs()
+-> Result<(), Box<dyn std::error::Error>> {
+    let manifest_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("e2e")
+        .join("manifest.json");
+
+    let outcomes = evaluate_manifest(&manifest_path)?;
+
+    let case_ids: Vec<&str> = outcomes.iter().map(|c| c.case_id.as_str()).collect();
+    assert_eq!(
+        case_ids,
+        &[
+            "price-taker-battery",
+            "capacity-expansion",
+            "pcm",
+            "simple-electricity-market-storage",
+            "generator-allocation",
+            "sdom",
+            "sdom-canonical",
+        ]
+    );
+
+    for outcome in &outcomes {
+        assert!(
+            outcome.actual_e2e_summary.expect_parse_success,
+            "case {} failed parse",
+            outcome.case_id
+        );
+        assert!(
+            outcome
+                .actual_e2e_summary
+                .expect_semantic_validation_success,
+            "case {} failed semantic validation",
+            outcome.case_id
+        );
+        assert!(
+            outcome.actual_e2e_summary.expect_lowering_success,
+            "case {} failed lowering",
+            outcome.case_id
+        );
+        assert!(
+            outcome.actual_e2e_summary.expect_solve_success,
+            "case {} failed solve",
+            outcome.case_id
+        );
+    }
+
+    Ok(())
+}

--- a/crates/arco-cli/tests/cli_run.rs
+++ b/crates/arco-cli/tests/cli_run.rs
@@ -1,0 +1,329 @@
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn fixture_path(parts: &[&str]) -> PathBuf {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    for part in parts {
+        path.push(part);
+    }
+    path
+}
+
+fn price_taker_battery_input() -> PathBuf {
+    fixture_path(&["tests", "e2e", "price-taker-battery", "input.kdl"])
+}
+
+fn simple_market_storage_input() -> PathBuf {
+    fixture_path(&[
+        "tests",
+        "e2e",
+        "simple-electricity-market-storage",
+        "input.kdl",
+    ])
+}
+
+fn arco_command() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_arco"));
+    cmd.env("ARCO_CONFIG_DIR", env!("CARGO_TARGET_TMPDIR"));
+    cmd
+}
+
+#[test]
+fn cli_runs_a_fixture_file() -> Result<(), Box<dyn std::error::Error>> {
+    let input = price_taker_battery_input();
+
+    let output = arco_command().arg("run").arg(&input).output()?;
+
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8(output.stdout)?;
+    assert!(!stdout.contains('\n'));
+    assert!(stdout.contains("\"active_scenario\":\"BatteryArbitrageDay\""));
+    assert!(stdout.contains("\"backend\":\"arco-rust-highs\""));
+    assert!(stdout.contains("\"solve_status\":\"optimal\""));
+    assert!(stdout.contains("\"name\":\"ArbitrageProfit\""));
+    assert!(stdout.contains("\"timing\""));
+    assert!(stdout.contains("\"peak_memory_bytes\""));
+
+    Ok(())
+}
+
+#[test]
+fn cli_run_handles_broken_pipe_without_panicking() -> Result<(), Box<dyn std::error::Error>> {
+    let input = price_taker_battery_input();
+
+    let command = format!(
+        "'{}' run '{}' | head -c 1 >/dev/null",
+        env!("CARGO_BIN_EXE_arco"),
+        input.display()
+    );
+    let output = Command::new("sh")
+        .arg("-c")
+        .arg(command)
+        .env("ARCO_CONFIG_DIR", env!("CARGO_TARGET_TMPDIR"))
+        .output()?;
+
+    assert!(output.status.success());
+
+    let stderr = String::from_utf8(output.stderr)?;
+    assert!(!stderr.contains("panicked at"));
+    assert!(!stderr.contains("Broken pipe"));
+
+    Ok(())
+}
+
+#[test]
+fn cli_run_keeps_json_pipeable_at_double_verbose() -> Result<(), Box<dyn std::error::Error>> {
+    let input = price_taker_battery_input();
+
+    let command = format!(
+        "'{}' run '{}' -vv | jq -r '.active_scenario'",
+        env!("CARGO_BIN_EXE_arco"),
+        input.display()
+    );
+    let output = Command::new("sh")
+        .arg("-c")
+        .arg(command)
+        .env("ARCO_CONFIG_DIR", env!("CARGO_TARGET_TMPDIR"))
+        .output()?;
+
+    assert!(output.status.success());
+    assert_eq!(String::from_utf8(output.stdout)?, "BatteryArbitrageDay\n");
+
+    Ok(())
+}
+
+#[test]
+fn cli_emits_debug_tracing_at_double_verbose() -> Result<(), Box<dyn std::error::Error>> {
+    let input = price_taker_battery_input();
+
+    let output = arco_command().arg("-vv").arg("run").arg(&input).output()?;
+
+    assert!(output.status.success());
+
+    let stderr = String::from_utf8(output.stderr)?;
+    assert!(stderr.contains("lowering program"));
+    assert!(stderr.contains("HiGHS solve completed"));
+
+    Ok(())
+}
+
+#[test]
+fn cli_prints_the_model_sent_to_highs() -> Result<(), Box<dyn std::error::Error>> {
+    let input = price_taker_battery_input();
+
+    let output = arco_command().arg("print-model").arg(&input).output()?;
+
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8(output.stdout)?;
+    assert!(stdout.contains("Max ArbitrageProfit:"));
+    assert!(stdout.contains("s.t."));
+    assert!(stdout.contains("soc_balance[Battery1,1]:"));
+    assert!(stdout.contains("charge[Battery1,1]"));
+
+    Ok(())
+}
+
+#[test]
+fn cli_rejects_missing_arguments() -> Result<(), Box<dyn std::error::Error>> {
+    let output = arco_command().output()?;
+
+    assert_eq!(output.status.code(), Some(2));
+
+    let stderr = String::from_utf8(output.stderr)?;
+    assert!(stderr.contains("Usage: arco"));
+    assert!(stderr.contains("Commands:"));
+    assert!(stderr.contains("validate"));
+    assert!(stderr.contains("debug"));
+    assert!(stderr.contains("export"));
+    assert!(stderr.contains("solver"));
+
+    Ok(())
+}
+
+#[test]
+fn cli_validates_a_fixture_file() -> Result<(), Box<dyn std::error::Error>> {
+    let input = price_taker_battery_input();
+
+    let output = arco_command().arg("validate").arg(&input).output()?;
+
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8(output.stdout)?;
+    assert!(stdout.contains("Validation succeeded"));
+    assert!(stdout.contains("scenario: BatteryArbitrageDay"));
+
+    Ok(())
+}
+
+#[test]
+fn cli_exports_a_fixture_to_lp() -> Result<(), Box<dyn std::error::Error>> {
+    let input = price_taker_battery_input();
+
+    let output = arco_command()
+        .arg("export")
+        .arg(&input)
+        .arg("--format")
+        .arg("lp")
+        .output()?;
+
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8(output.stdout)?;
+    assert!(stdout.contains("Maximize"));
+    assert!(stdout.contains("Subject To"));
+    assert!(stdout.contains("Bounds"));
+    assert!(stdout.contains("End"));
+
+    Ok(())
+}
+
+#[test]
+fn cli_filters_run_output_by_variable_and_omits_full_values_in_compact_mode()
+-> Result<(), Box<dyn std::error::Error>> {
+    let input = price_taker_battery_input();
+
+    let output = arco_command()
+        .arg("run")
+        .arg(&input)
+        .arg("--filter-variable")
+        .arg("charge*")
+        .arg("--compact")
+        .output()?;
+
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8(output.stdout)?;
+    assert!(stdout.contains("\"name\":\"charge[a,t]\""));
+    assert!(!stdout.contains("\"name\":\"discharge[a,t]\""));
+    assert!(!stdout.contains("\"values\""));
+
+    Ok(())
+}
+
+#[test]
+fn cli_filters_run_output_by_asset() -> Result<(), Box<dyn std::error::Error>> {
+    let input = simple_market_storage_input();
+
+    let output = arco_command()
+        .arg("run")
+        .arg(&input)
+        .arg("--filter-asset")
+        .arg("Pumped*")
+        .output()?;
+
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8(output.stdout)?;
+    assert!(stdout.contains("[PumpedHydro,1]"));
+    assert!(!stdout.contains("[Coal,1]"));
+
+    Ok(())
+}
+
+#[test]
+fn cli_debug_reports_missing_uvx() -> Result<(), Box<dyn std::error::Error>> {
+    let input = price_taker_battery_input();
+
+    let output = arco_command()
+        .env("PATH", "")
+        .arg("debug")
+        .arg(&input)
+        .output()?;
+
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8(output.stderr)?;
+    assert!(stderr.contains("failed to start uvx"));
+    assert!(stderr.contains("Install uv first"));
+
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn cli_debug_starts_ipython_without_banner_and_preloads_model()
+-> Result<(), Box<dyn std::error::Error>> {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    let root = std::env::temp_dir().join(format!(
+        "arco-cli-debug-{}",
+        SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos()
+    ));
+    fs::create_dir_all(&root)?;
+
+    let fake_bin = root.join("uvx");
+    let args_file = root.join("uvx-args.txt");
+    let script_file = root.join("bootstrap.py");
+    fs::write(
+        &fake_bin,
+        "#!/bin/sh\nprintf '%s\n' \"$@\" > \"$ARCO_UVX_ARGS_FILE\"\nlast_arg=''\nfor arg in \"$@\"; do\n  last_arg=\"$arg\"\ndone\n/bin/cp \"$last_arg\" \"$ARCO_UVX_SCRIPT_FILE\"\n",
+    )?;
+    let mut permissions = fs::metadata(&fake_bin)?.permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&fake_bin, permissions)?;
+
+    let input = price_taker_battery_input();
+
+    let output = arco_command()
+        .env("PATH", &root)
+        .env("ARCO_UVX_ARGS_FILE", &args_file)
+        .env("ARCO_UVX_SCRIPT_FILE", &script_file)
+        .arg("debug")
+        .arg(&input)
+        .output()?;
+
+    assert!(output.status.success());
+
+    let args = fs::read_to_string(&args_file)?;
+    assert!(args.contains("--with"));
+    assert!(args.contains("ipython"));
+    assert!(args.contains("--no-banner"));
+    assert!(args.contains("arco"));
+
+    let script = fs::read_to_string(&script_file)?;
+    assert!(script.contains("import arco"));
+    assert!(script.contains("model = arco.Model.from_csc("));
+    assert!(script.contains("model.set_variable_name(index, name=name)"));
+    assert!(script.contains("model.set_constraint_name(index, name=name)"));
+    assert!(script.contains("model.set_objective("));
+    assert!(script.contains(&format!("model_path = Path(r\"{}\")", input.display())));
+
+    fs::remove_dir_all(&root)?;
+    Ok(())
+}
+
+#[test]
+fn cli_persists_solver_configuration() -> Result<(), Box<dyn std::error::Error>> {
+    let root = std::env::temp_dir().join(format!(
+        "arco-cli-solver-{}",
+        SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos()
+    ));
+    std::fs::create_dir_all(&root)?;
+
+    let set_output = arco_command()
+        .env("ARCO_CONFIG_DIR", &root)
+        .arg("solver")
+        .arg("set")
+        .arg("highs")
+        .output()?;
+
+    assert!(set_output.status.success());
+    let set_stdout = String::from_utf8(set_output.stdout)?;
+    assert!(set_stdout.contains("backend: highs"));
+
+    let show_output = arco_command()
+        .env("ARCO_CONFIG_DIR", &root)
+        .arg("solver")
+        .arg("show")
+        .output()?;
+
+    assert!(show_output.status.success());
+    let show_stdout = String::from_utf8(show_output.stdout)?;
+    assert!(show_stdout.contains("backend: highs"));
+
+    std::fs::remove_dir_all(&root)?;
+    Ok(())
+}

--- a/crates/arco-cli/tests/csv_benchmark.rs
+++ b/crates/arco-cli/tests/csv_benchmark.rs
@@ -1,0 +1,47 @@
+use arco_cli::benchmark::evaluate_manifest;
+use std::path::PathBuf;
+use std::time::Instant;
+
+#[test]
+fn csv_reading_performance_benchmark() -> Result<(), Box<dyn std::error::Error>> {
+    let manifest_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("e2e")
+        .join("manifest.json");
+
+    let start = Instant::now();
+    let outcomes = evaluate_manifest(&manifest_path)?;
+    let elapsed = start.elapsed();
+
+    let total_us = elapsed.as_micros();
+    println!("METRIC csv_read_us={}", total_us);
+
+    // Verify all cases passed
+    for outcome in &outcomes {
+        assert!(
+            outcome.actual_e2e_summary.expect_parse_success,
+            "case {} failed parse",
+            outcome.case_id
+        );
+        assert!(
+            outcome
+                .actual_e2e_summary
+                .expect_semantic_validation_success,
+            "case {} failed semantic validation",
+            outcome.case_id
+        );
+        assert!(
+            outcome.actual_e2e_summary.expect_lowering_success,
+            "case {} failed lowering",
+            outcome.case_id
+        );
+        assert!(
+            outcome.actual_e2e_summary.expect_solve_success,
+            "case {} failed solve",
+            outcome.case_id
+        );
+    }
+
+    println!("✓ All {} benchmark cases passed", outcomes.len());
+    Ok(())
+}

--- a/crates/arco-cli/tests/csv_read_isolated.rs
+++ b/crates/arco-cli/tests/csv_read_isolated.rs
@@ -1,0 +1,64 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::time::Instant;
+
+#[test]
+fn isolated_csv_reading_performance() -> Result<(), Box<dyn std::error::Error>> {
+    let test_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("e2e");
+
+    // Find all CSV files in test data
+    let csv_files = vec![
+        "price-taker-battery/data/prices.csv",
+        "pcm/data/demand.csv",
+        "pcm/data/fuel_cost.csv",
+        "pcm/data/lol_penalty.csv",
+        "pcm/data/initial_commitment.csv",
+        "pcm/data/thermal_units.csv",
+        "sdom/data/demand.csv",
+        "sdom/data/solar_cf.csv",
+        "sdom/data/wind_cf.csv",
+        "sdom/data/export_price.csv",
+        "sdom/data/import_price.csv",
+        "sdom/data/wind_plants.csv",
+        "sdom/data/pv_plants.csv",
+        "sdom/data/hydro_min.csv",
+        "sdom/data/hydro_max.csv",
+        "sdom/data/budget_periods.csv",
+        "capacity-expansion/data/demand.csv",
+        "capacity-expansion/data/voll.csv",
+        "capacity-expansion/data/candidate_gas.csv",
+        "capacity-expansion/data/existing_thermal.csv",
+    ];
+
+    let start = Instant::now();
+    let mut total_rows = 0;
+
+    for csv_path in csv_files {
+        let path = test_dir.join(csv_path);
+        if path.exists() {
+            let mut reader = csv::Reader::from_path(&path)?;
+            let headers = reader.headers()?.clone();
+
+            for record in reader.records() {
+                let record = record?;
+                let mut _row = HashMap::with_capacity(headers.len());
+                for i in 0..headers.len() {
+                    if let Some(value) = record.get(i) {
+                        _row.insert(headers[i].to_string(), value.to_string());
+                    }
+                }
+                total_rows += 1;
+            }
+        }
+    }
+
+    let elapsed = start.elapsed();
+    let total_us = elapsed.as_micros();
+    println!("METRIC csv_isolated_us={}", total_us);
+    println!("Read {} total rows in {} us", total_rows, total_us);
+
+    assert!(total_rows > 0, "Should have read some CSV rows");
+    Ok(())
+}

--- a/crates/arco-cli/tests/e2e/capacity-expansion/expected/e2e-summary.json
+++ b/crates/arco-cli/tests/e2e/capacity-expansion/expected/e2e-summary.json
@@ -1,0 +1,12 @@
+{
+  "case_id": "capacity-expansion",
+  "expect_parse_success": true,
+  "expect_semantic_validation_success": true,
+  "expect_lowering_success": true,
+  "expect_solve_success": true,
+  "objective": {
+    "name": "ExpansionCost",
+    "sense": "minimize"
+  },
+  "reports": []
+}

--- a/crates/arco-cli/tests/e2e/capacity-expansion/expected/semantic-program.json
+++ b/crates/arco-cli/tests/e2e/capacity-expansion/expected/semantic-program.json
@@ -1,0 +1,26 @@
+{
+  "case_id": "capacity-expansion",
+  "active_scenario": "ExpansionCase",
+  "sets": {
+    "assets": ["CandidateCT1", "CandidateCT2", "ExistingCT1", "ExistingCT2"],
+    "candidate_assets": ["CandidateCT1", "CandidateCT2"],
+    "time": {
+      "steps": 24,
+      "resolution": "PT1H"
+    }
+  },
+  "parameters": {
+    "series": ["demand[t]", "voll[t]"],
+    "asset": [
+      "build_cost[a]",
+      "existing_capacity[a]",
+      "max_build[a]",
+      "variable_cost[a]"
+    ]
+  },
+  "variable_families": ["build[a]", "dispatch[a,t]", "unserved_energy[t]"],
+  "lowering_rules": [
+    "build[a] is a decision family over candidate_assets",
+    "build[a] is fixed to zero for non-candidate assets"
+  ]
+}

--- a/crates/arco-cli/tests/e2e/capacity-expansion/input.kdl
+++ b/crates/arco-cli/tests/e2e/capacity-expansion/input.kdl
@@ -1,0 +1,60 @@
+technology "GasCT" {
+  control "dispatch"
+}
+
+operation "ExpansionDispatch" {
+  constraint "dispatch_limit" {
+    dispatch[a,t] <= existing_capacity[a] + build[a]
+  }
+}
+
+instances "ExistingThermal" from="data/existing_thermal.csv" {
+  technology "GasCT"
+  operation "ExpansionDispatch"
+  map "name" from="asset_name"
+  map "existing_capacity" from="existing_capacity_mw"
+  map "variable_cost" from="variable_cost"
+}
+
+instances "CandidateGas" from="data/candidate_gas.csv" {
+  technology "GasCT"
+  operation "ExpansionDispatch"
+  map "name" from="asset_name"
+  map "max_build" from="max_build_mw"
+  map "build_cost" from="build_cost"
+  map "variable_cost" from="variable_cost"
+}
+
+rule "EnergyBalance" {
+  constraint "balance" {
+    sum(dispatch[a,t] for a in assets) + unserved_energy[t] = demand[t]
+  }
+}
+
+expression "InvestmentCost" {
+  sum(build_cost[a] * build[a] for a in candidate_assets)
+}
+
+expression "OperatingCost" {
+  sum(variable_cost[a] * dispatch[a,t] for a in assets for t in time)
+}
+
+expression "PenaltyCost" {
+  sum(voll[t] * unserved_energy[t] for t in time)
+}
+
+minimize "ExpansionCost" {
+  InvestmentCost + OperatingCost + PenaltyCost
+}
+
+scenario "ExpansionCase" {
+  horizon steps=24 resolution="PT1H"
+  technology "GasCT"
+  operation "ExpansionDispatch"
+  rule "EnergyBalance"
+  data "demand" from="data/demand.csv"
+  data "voll" from="data/voll.csv"
+  instances "ExistingThermal"
+  instances "CandidateGas"
+  minimize "ExpansionCost"
+}

--- a/crates/arco-cli/tests/e2e/generalized-two-node-network/input.kdl
+++ b/crates/arco-cli/tests/e2e/generalized-two-node-network/input.kdl
@@ -1,0 +1,58 @@
+technology "Generator" {
+  control "dispatch"
+}
+
+technology "Line" {
+  control "flow"
+}
+
+operation "Dispatch" {
+  constraint "capacity_limit" {
+    dispatch[g,t] <= capacity_mw[g]
+  }
+}
+
+operation "Transmission" {
+  constraint "forward_limit" {
+    -thermal_limit_mw[l] <= flow[l,t] <= thermal_limit_mw[l]
+  }
+}
+
+rule "NodeBalance" {
+  constraint "balance" {
+    sum(dispatch[g,t] for g in generators if generator_node[g] == n)
+    + sum(flow[l,t] for l in incoming_lines if line_to[l] == n)
+    - sum(flow[l,t] for l in outgoing_lines if line_from[l] == n)
+    = demand[n,t]
+  }
+}
+
+expression "GenerationCost" {
+  sum(variable_cost[g] * dispatch[g,t] for g in generators for t in time)
+}
+
+expression "LossPenalty" {
+  sum(loss_penalty[n,t] for n in nodes for t in time)
+}
+
+minimize "TotalCost" {
+  GenerationCost + LossPenalty
+}
+
+scenario "TwoNodeDispatch" {
+  horizon steps=24 resolution="PT1H"
+  technology "Generator"
+  technology "Line"
+  operation "Dispatch"
+  operation "Transmission"
+  rule "NodeBalance"
+  data "demand" from="data/demand.csv"
+  data "generator_node" from="data/generator_node.csv"
+  data "line_from" from="data/line_from.csv"
+  data "line_to" from="data/line_to.csv"
+  data "variable_cost" from="data/variable_cost.csv"
+  data "capacity_mw" from="data/capacity_mw.csv"
+  data "thermal_limit_mw" from="data/thermal_limit_mw.csv"
+  data "loss_penalty" from="data/loss_penalty.csv"
+  minimize "TotalCost"
+}

--- a/crates/arco-cli/tests/e2e/generator-allocation/expected/e2e-summary.json
+++ b/crates/arco-cli/tests/e2e/generator-allocation/expected/e2e-summary.json
@@ -1,0 +1,12 @@
+{
+  "case_id": "generator-allocation",
+  "expect_parse_success": true,
+  "expect_semantic_validation_success": true,
+  "expect_lowering_success": true,
+  "expect_solve_success": true,
+  "objective": {
+    "name": "TotalCost",
+    "sense": "minimize"
+  },
+  "reports": []
+}

--- a/crates/arco-cli/tests/e2e/generator-allocation/expected/semantic-program.json
+++ b/crates/arco-cli/tests/e2e/generator-allocation/expected/semantic-program.json
@@ -1,0 +1,15 @@
+{
+  "case_id": "generator-allocation",
+  "active_scenario": "GeneratorAllocationDay",
+  "sets": {
+    "assets": [],
+    "time": {
+      "steps": 3,
+      "resolution": "PT1H"
+    }
+  },
+  "parameters": {},
+  "variable_families": ["dispatch[a,t]"],
+  "chronology": {},
+  "lowering_rules": []
+}

--- a/crates/arco-cli/tests/e2e/generator-allocation/input.kdl
+++ b/crates/arco-cli/tests/e2e/generator-allocation/input.kdl
@@ -1,0 +1,19 @@
+model "GeneratorAllocation" {
+  control "dispatch" {
+    a
+    t
+  }
+
+  constraint "capacity_limit" {
+    dispatch[a,t] <= 10
+  }
+
+  minimize "TotalCost" {
+    sum(dispatch[a,t] for a in assets for t in time)
+  }
+}
+
+scenario "GeneratorAllocationDay" {
+  horizon steps=3 resolution="PT1H"
+  use "GeneratorAllocation"
+}

--- a/crates/arco-cli/tests/e2e/manifest.json
+++ b/crates/arco-cli/tests/e2e/manifest.json
@@ -1,0 +1,61 @@
+{
+  "version": 1,
+  "cases": [
+    {
+      "id": "price-taker-battery",
+      "description": "Single-asset battery arbitrage benchmark from RFD-0006.",
+      "entrypoint": "tests/e2e/price-taker-battery/input.kdl",
+      "expected_semantic_program": "tests/e2e/price-taker-battery/expected/semantic-program.json",
+      "expected_e2e_summary": "tests/e2e/price-taker-battery/expected/e2e-summary.json",
+      "solvable": true
+    },
+    {
+      "id": "capacity-expansion",
+      "description": "Copperplate capacity expansion benchmark from RFD-0006.",
+      "entrypoint": "tests/e2e/capacity-expansion/input.kdl",
+      "expected_semantic_program": "tests/e2e/capacity-expansion/expected/semantic-program.json",
+      "expected_e2e_summary": "tests/e2e/capacity-expansion/expected/e2e-summary.json",
+      "solvable": true
+    },
+    {
+      "id": "pcm",
+      "description": "Production cost model benchmark from RFD-0006.",
+      "entrypoint": "tests/e2e/pcm/input.kdl",
+      "expected_semantic_program": "tests/e2e/pcm/expected/semantic-program.json",
+      "expected_e2e_summary": "tests/e2e/pcm/expected/e2e-summary.json",
+      "solvable": true
+    },
+    {
+      "id": "simple-electricity-market-storage",
+      "description": "Single bidding zone with fixed load and storage over several periods, aligned to the PyPSA example.",
+      "entrypoint": "tests/e2e/simple-electricity-market-storage/input.kdl",
+      "expected_semantic_program": "tests/e2e/simple-electricity-market-storage/expected/semantic-program.json",
+      "expected_e2e_summary": "tests/e2e/simple-electricity-market-storage/expected/e2e-summary.json",
+      "solvable": true
+    },
+    {
+      "id": "generator-allocation",
+      "description": "Canonical model syntax smoke test for single-fleet generator allocation.",
+      "entrypoint": "tests/e2e/generator-allocation/input.kdl",
+      "expected_semantic_program": "tests/e2e/generator-allocation/expected/semantic-program.json",
+      "expected_e2e_summary": "tests/e2e/generator-allocation/expected/e2e-summary.json",
+      "solvable": true
+    },
+    {
+      "id": "sdom",
+      "description": "Storage Deployment Optimization Model: co-optimizes VRE investment, balancing, storage, and trade with clean-energy target.",
+      "entrypoint": "tests/e2e/sdom/input.kdl",
+      "expected_semantic_program": "tests/e2e/sdom/expected/semantic-program.json",
+      "expected_e2e_summary": "tests/e2e/sdom/expected/e2e-summary.json",
+      "solvable": true
+    },
+    {
+      "id": "sdom-canonical",
+      "description": "SDOM expressed with low-level model syntax and custom index sets.",
+      "entrypoint": "tests/e2e/sdom-canonical/input.kdl",
+      "expected_semantic_program": "tests/e2e/sdom-canonical/expected/semantic-program.json",
+      "expected_e2e_summary": "tests/e2e/sdom-canonical/expected/e2e-summary.json",
+      "solvable": true
+    }
+  ]
+}

--- a/crates/arco-cli/tests/e2e/pcm/expected/e2e-summary.json
+++ b/crates/arco-cli/tests/e2e/pcm/expected/e2e-summary.json
@@ -1,0 +1,12 @@
+{
+  "case_id": "pcm",
+  "expect_parse_success": true,
+  "expect_semantic_validation_success": true,
+  "expect_lowering_success": true,
+  "expect_solve_success": true,
+  "objective": {
+    "name": "SystemCost",
+    "sense": "minimize"
+  },
+  "reports": ["FuelCost", "StartupCost", "PenaltyCost"]
+}

--- a/crates/arco-cli/tests/e2e/pcm/expected/semantic-program.json
+++ b/crates/arco-cli/tests/e2e/pcm/expected/semantic-program.json
@@ -1,0 +1,33 @@
+{
+  "case_id": "pcm",
+  "active_scenario": "BaseCase",
+  "sets": {
+    "assets": ["Thermal1", "Thermal2"],
+    "time": {
+      "steps": 24,
+      "resolution": "PT1H"
+    }
+  },
+  "parameters": {
+    "series": ["demand[t]", "lol_penalty[t]"],
+    "indexed": ["fuel_cost[a,t]"],
+    "asset": [
+      "initial_commitment[a]",
+      "p_max[a]",
+      "p_min[a]",
+      "ramp_down[a]",
+      "ramp_up[a]",
+      "startup_cost[a]"
+    ]
+  },
+  "variable_families": [
+    "commit[a,t]",
+    "generation[a,t]",
+    "shutdown[a,t]",
+    "start[a,t]",
+    "unserved_energy[t]"
+  ],
+  "chronology": {
+    "initial_commitment_boundary": "initial_commitment[a]"
+  }
+}

--- a/crates/arco-cli/tests/e2e/pcm/input.kdl
+++ b/crates/arco-cli/tests/e2e/pcm/input.kdl
@@ -1,0 +1,73 @@
+technology "Thermal" {
+  control "generation"
+  state "commit"
+  state "start"
+  state "shutdown"
+}
+
+operation "StandardUC" {
+  constraint "commitment_transition" {
+    commit[a,t] - commit[a,t-1] = start[a,t] - shutdown[a,t]
+  }
+  constraint "min_output" {
+    generation[a,t] >= p_min[a] * commit[a,t]
+  }
+  constraint "max_output" {
+    generation[a,t] <= p_max[a] * commit[a,t]
+  }
+  constraint "ramp_up_limit" {
+    generation[a,t] - generation[a,t-1] <= ramp_up[a]
+  }
+  constraint "ramp_down_limit" {
+    generation[a,t-1] - generation[a,t] <= ramp_down[a]
+  }
+}
+
+instances "ThermalUnits" from="data/thermal_units.csv" {
+  technology "Thermal"
+  operation "StandardUC"
+  map "name" from="asset_name"
+  map "p_min" from="p_min_mw"
+  map "p_max" from="p_max_mw"
+  map "ramp_up" from="ramp_up"
+  map "ramp_down" from="ramp_down"
+  map "startup_cost" from="startup_cost"
+}
+
+rule "EnergyBalance" {
+  constraint "balance" {
+    sum(generation[a,t] for a in assets) + unserved_energy[t] = demand[t]
+  }
+}
+
+expression "FuelCost" {
+  sum(fuel_cost[a,t] * generation[a,t] for a in assets for t in time)
+}
+
+expression "StartupCost" {
+  sum(startup_cost[a] * start[a,t] for a in assets for t in time)
+}
+
+expression "PenaltyCost" {
+  sum(lol_penalty[t] * unserved_energy[t] for t in time)
+}
+
+minimize "SystemCost" {
+  FuelCost + StartupCost + PenaltyCost
+}
+
+scenario "BaseCase" {
+  horizon steps=24 resolution="PT1H"
+  technology "Thermal"
+  operation "StandardUC"
+  rule "EnergyBalance"
+  data "demand" from="data/demand.csv"
+  data "fuel_cost" from="data/fuel_cost.csv"
+  data "lol_penalty" from="data/lol_penalty.csv"
+  data "initial_commitment" from="data/initial_commitment.csv"
+  instances "ThermalUnits"
+  minimize "SystemCost"
+  report "FuelCost"
+  report "StartupCost"
+  report "PenaltyCost"
+}

--- a/crates/arco-cli/tests/e2e/price-taker-battery/expected/e2e-summary.json
+++ b/crates/arco-cli/tests/e2e/price-taker-battery/expected/e2e-summary.json
@@ -1,0 +1,12 @@
+{
+  "case_id": "price-taker-battery",
+  "expect_parse_success": true,
+  "expect_semantic_validation_success": true,
+  "expect_lowering_success": true,
+  "expect_solve_success": true,
+  "objective": {
+    "name": "ArbitrageProfit",
+    "sense": "maximize"
+  },
+  "reports": ["ArbitrageRevenue"]
+}

--- a/crates/arco-cli/tests/e2e/price-taker-battery/expected/semantic-program.json
+++ b/crates/arco-cli/tests/e2e/price-taker-battery/expected/semantic-program.json
@@ -1,0 +1,27 @@
+{
+  "case_id": "price-taker-battery",
+  "active_scenario": "BatteryArbitrageDay",
+  "sets": {
+    "assets": ["Battery1"],
+    "time": {
+      "steps": 24,
+      "resolution": "PT1H"
+    }
+  },
+  "parameters": {
+    "series": ["prices[t]"],
+    "asset": [
+      "charge_efficiency[a]",
+      "discharge_efficiency[a]",
+      "energy_mwh[a]",
+      "initial_soc_mwh[a]",
+      "power_mw[a]",
+      "terminal_soc_mwh[a]"
+    ]
+  },
+  "variable_families": ["charge[a,t]", "discharge[a,t]", "soc[a,t]"],
+  "chronology": {
+    "initial_boundary": "initial_soc_mwh[a]",
+    "terminal_boundary": "terminal_soc_mwh[a]"
+  }
+}

--- a/crates/arco-cli/tests/e2e/price-taker-battery/input.kdl
+++ b/crates/arco-cli/tests/e2e/price-taker-battery/input.kdl
@@ -1,0 +1,49 @@
+technology "Battery" {
+  control "charge"
+  control "discharge"
+  state "soc"
+}
+
+asset "Battery1" {
+  technology "Battery"
+  operation "PriceTakerBattery"
+  power_mw 100
+  energy_mwh 400
+  charge_efficiency 0.92
+  discharge_efficiency 0.92
+  initial_soc_mwh 200
+  terminal_soc_mwh 200
+}
+
+operation "PriceTakerBattery" {
+  constraint name="soc_balance" {
+    soc[a,t] = soc[a,t-1] + charge_efficiency[a] * charge[a,t] - discharge[a,t] / discharge_efficiency[a]
+  }
+  constraint "charge_limit" {
+    charge[a,t] <= power_mw[a]
+  }
+  constraint "discharge_limit" {
+    discharge[a,t] <= power_mw[a]
+  }
+  constraint "soc_bounds" {
+    0 <= soc[a,t] <= energy_mwh[a]
+  }
+}
+
+expression "ArbitrageRevenue" {
+  sum(prices[t] * (discharge[a,t] - charge[a,t]) for a in assets for t in time)
+}
+
+maximize "ArbitrageProfit" {
+  ArbitrageRevenue
+}
+
+scenario "BatteryArbitrageDay" {
+  horizon steps=24 resolution="PT1H"
+  technology "Battery"
+  operation "PriceTakerBattery"
+  data "prices" from="data/prices.csv"
+  asset "Battery1"
+  maximize "ArbitrageProfit"
+  report "ArbitrageRevenue"
+}

--- a/crates/arco-cli/tests/e2e/sdom-canonical/data
+++ b/crates/arco-cli/tests/e2e/sdom-canonical/data
@@ -1,0 +1,1 @@
+../sdom/data

--- a/crates/arco-cli/tests/e2e/sdom-canonical/expected/e2e-summary.json
+++ b/crates/arco-cli/tests/e2e/sdom-canonical/expected/e2e-summary.json
@@ -1,0 +1,12 @@
+{
+  "case_id": "sdom-canonical",
+  "expect_parse_success": true,
+  "expect_semantic_validation_success": true,
+  "expect_lowering_success": true,
+  "expect_solve_success": true,
+  "objective": {
+    "name": "SystemCost",
+    "sense": "minimize"
+  },
+  "reports": []
+}

--- a/crates/arco-cli/tests/e2e/sdom-canonical/expected/semantic-program.json
+++ b/crates/arco-cli/tests/e2e/sdom-canonical/expected/semantic-program.json
@@ -1,0 +1,47 @@
+{
+  "case_id": "sdom-canonical",
+  "active_scenario": "SDOMCanonical",
+  "sets": {
+    "assets": [
+      "DispatchableHydro",
+      "GasCT",
+      "LiIon",
+      "PV_North",
+      "PV_South",
+      "TradeNode",
+      "Wind_East"
+    ],
+    "candidate_assets": [],
+    "time": {
+      "steps": 24,
+      "resolution": "PT1H"
+    }
+  },
+  "parameters": {
+    "series": [],
+    "indexed": [],
+    "asset": []
+  },
+  "variable_families": [
+    "pv_fraction[p]",
+    "wind_fraction[w]",
+    "bal_capacity[k]",
+    "power_charge[j]",
+    "power_discharge[j]",
+    "energy_cap[j]",
+    "pv_dispatch[p,t]",
+    "wind_dispatch[w,t]",
+    "bal_dispatch[k,t]",
+    "charge[j,t]",
+    "discharge[j,t]",
+    "charge_indicator[j,t]",
+    "soc[j,t]",
+    "dispatch[h,t]",
+    "imports[n,t]",
+    "exports[n,t]"
+  ],
+  "chronology": {
+    "initial_boundary": "initial_soc_mwh"
+  },
+  "lowering_rules": []
+}

--- a/crates/arco-cli/tests/e2e/sdom-canonical/input.kdl
+++ b/crates/arco-cli/tests/e2e/sdom-canonical/input.kdl
@@ -1,0 +1,371 @@
+// ---------------------------------------------------------------------------
+// SDOM Canonical: Low-level model form of the SDOM fixture
+//
+// Expresses the exact same optimization problem as tests/e2e/sdom/input.kdl
+// using the canonical `model` block with explicit index sets instead of the
+// high-level technology/operation/rule pattern.
+//
+// Expected objective: ~$472,928.62 (must match within solver tolerance)
+// ---------------------------------------------------------------------------
+
+model "SDOM" {
+
+    // ===================================================================
+    // Investment variables (asset-only, one index)
+    // ===================================================================
+    control "pv_fraction" lower=0 upper=1 {
+        p in="pv_plants"
+    }
+    control "wind_fraction" lower=0 upper=1 {
+        w in="wind_plants"
+    }
+    control "bal_capacity" lower=0 {
+        k in="balancing_units"
+    }
+    control "power_charge" lower=0 {
+        j in="storage_techs"
+    }
+    control "power_discharge" lower=0 {
+        j in="storage_techs"
+    }
+    control "energy_cap" lower=0 {
+        j in="storage_techs"
+    }
+
+    // ===================================================================
+    // Dispatch variables (asset + time, two indices)
+    // ===================================================================
+    control "pv_dispatch" lower=0 {
+        p in="pv_plants"
+        t in="time"
+    }
+    control "wind_dispatch" lower=0 {
+        w in="wind_plants"
+        t in="time"
+    }
+    control "bal_dispatch" lower=0 {
+        k in="balancing_units"
+        t in="time"
+    }
+    control "charge" lower=0 {
+        j in="storage_techs"
+        t in="time"
+    }
+    control "discharge" lower=0 {
+        j in="storage_techs"
+        t in="time"
+    }
+    control "charge_indicator" kind="binary" lower=0 upper=1 {
+        j in="storage_techs"
+        t in="time"
+    }
+    control "soc" lower=0 {
+        j in="storage_techs"
+        t in="time"
+    }
+    control "dispatch" lower=0 {
+        h in="hydro_units"
+        t in="time"
+    }
+    control "imports" lower=0 {
+        n in="trade_nodes"
+        t in="time"
+    }
+    control "exports" lower=0 {
+        n in="trade_nodes"
+        t in="time"
+    }
+
+    // ===================================================================
+    // PV dispatch limit
+    // ===================================================================
+    constraint "pv_dispatch_limit" {
+        over "p" in="pv_plants"
+        over "t" in="time"
+        expr {
+            pv_dispatch[p,t] <= solar_cf[p,t] * pv_max_cap[p] * pv_fraction[p]
+        }
+    }
+
+    // ===================================================================
+    // Wind dispatch limit
+    // ===================================================================
+    constraint "wind_dispatch_limit" {
+        over "w" in="wind_plants"
+        over "t" in="time"
+        expr {
+            wind_dispatch[w,t] <= wind_cf[w,t] * wind_max_cap[w] * wind_fraction[w]
+        }
+    }
+
+    // ===================================================================
+    // Balancing unit constraints
+    // ===================================================================
+    constraint "dispatch_limit" {
+        over "k" in="balancing_units"
+        over "t" in="time"
+        expr { bal_dispatch[k,t] <= bal_capacity[k] }
+    }
+
+    constraint "capacity_lower" {
+        over "k" in="balancing_units"
+        expr { bal_capacity[k] >= min_bal_cap[k] }
+    }
+
+    constraint "capacity_upper" {
+        over "k" in="balancing_units"
+        expr { bal_capacity[k] <= max_bal_cap[k] }
+    }
+
+    // ===================================================================
+    // Storage constraints
+    // ===================================================================
+    constraint "coupled_power" {
+        over "j" in="storage_techs"
+        expr { power_charge[j] = power_discharge[j] }
+    }
+
+    constraint "charge_power_cap" {
+        over "j" in="storage_techs"
+        expr { power_charge[j] <= max_stor_power[j] }
+    }
+
+    constraint "discharge_power_cap" {
+        over "j" in="storage_techs"
+        expr { power_discharge[j] <= max_stor_power[j] }
+    }
+
+    constraint "charge_limit" {
+        over "j" in="storage_techs"
+        over "t" in="time"
+        expr { charge[j,t] <= power_charge[j] }
+    }
+
+    constraint "discharge_limit" {
+        over "j" in="storage_techs"
+        over "t" in="time"
+        expr { discharge[j,t] <= power_discharge[j] }
+    }
+
+    constraint "charge_big_m" {
+        over "j" in="storage_techs"
+        over "t" in="time"
+        expr { charge[j,t] <= max_stor_power[j] * charge_indicator[j,t] }
+    }
+
+    constraint "discharge_big_m" {
+        over "j" in="storage_techs"
+        over "t" in="time"
+        expr {
+            discharge[j,t] <= max_stor_power[j] - max_stor_power[j] * charge_indicator[j,t]
+        }
+    }
+
+    // SOC initial: handles t=1 explicitly so we don't reference soc[j,0]
+    constraint "soc_initial" {
+        over "j" in="storage_techs"
+        over "t" in="time"
+        when "t == 1"
+        expr {
+            soc[j,t] = initial_soc_mwh[j]
+                + sqrt(roundtrip_eff[j]) * charge[j,t]
+                - discharge[j,t] / sqrt(roundtrip_eff[j])
+        }
+    }
+
+    // SOC balance: t >= 2, references soc[j,t-1]
+    constraint "soc_balance" {
+        over "j" in="storage_techs"
+        over "t" in="time"
+        when "t >= 2"
+        expr {
+            soc[j,t] = soc[j,t-1]
+                + sqrt(roundtrip_eff[j]) * charge[j,t]
+                - discharge[j,t] / sqrt(roundtrip_eff[j])
+        }
+    }
+
+    constraint "soc_lower" {
+        over "j" in="storage_techs"
+        over "t" in="time"
+        expr { soc[j,t] >= 0 }
+    }
+
+    constraint "soc_upper" {
+        over "j" in="storage_techs"
+        over "t" in="time"
+        expr { soc[j,t] <= energy_cap[j] }
+    }
+
+    constraint "min_duration" {
+        over "j" in="storage_techs"
+        expr {
+            energy_cap[j] >= min_dur[j] * power_discharge[j] / sqrt(roundtrip_eff[j])
+        }
+    }
+
+    constraint "max_duration" {
+        over "j" in="storage_techs"
+        expr {
+            energy_cap[j] <= max_dur[j] * power_discharge[j] / sqrt(roundtrip_eff[j])
+        }
+    }
+
+    constraint "cycle_limit" {
+        over "j" in="storage_techs"
+        expr {
+            sum(discharge[j,t] for t in time) <= annualized_max_cycles[j] * energy_cap[j]
+        }
+    }
+
+    // ===================================================================
+    // Hydro constraints
+    // ===================================================================
+    constraint "hydro_min_bound" {
+        over "h" in="hydro_units"
+        over "t" in="time"
+        expr { dispatch[h,t] >= hydro_min[h,t] }
+    }
+
+    constraint "hydro_max_bound" {
+        over "h" in="hydro_units"
+        over "t" in="time"
+        expr { dispatch[h,t] <= hydro_max[h,t] }
+    }
+
+    constraint "energy_budget" {
+        over "b" in="budget_periods"
+        expr {
+            sum(dispatch[h,t] for h in hydro_units for t in time
+                if t >= budget_start[b] if t <= budget_end[b])
+            = energy_budget[b]
+        }
+    }
+
+    // ===================================================================
+    // Trade constraints
+    // ===================================================================
+    constraint "import_cap" {
+        over "n" in="trade_nodes"
+        over "t" in="time"
+        expr { imports[n,t] <= max_import[n] }
+    }
+
+    constraint "export_cap" {
+        over "n" in="trade_nodes"
+        over "t" in="time"
+        expr { exports[n,t] <= max_export[n] }
+    }
+
+    // ===================================================================
+    // System constraints
+    // ===================================================================
+    constraint "energy_balance" {
+        over "t" in="time"
+        expr {
+            sum(pv_dispatch[p,t] for p in pv_plants)
+            + sum(wind_dispatch[w,t] for w in wind_plants)
+            + sum(bal_dispatch[k,t] for k in balancing_units)
+            + sum(dispatch[h,t] for h in hydro_units)
+            + nuclear_gen[t]
+            + sum(discharge[j,t] for j in storage_techs)
+            + sum(imports[n,t] for n in trade_nodes)
+            = demand[t]
+            + sum(charge[j,t] for j in storage_techs)
+            + sum(exports[n,t] for n in trade_nodes)
+        }
+    }
+
+    constraint "clean_target" {
+        expr {
+            sum(bal_dispatch[k,t] for k in balancing_units for t in time)
+            <= 0.2 * (
+                sum(demand[t] for t in time)
+                + sum(charge[j,t] for j in storage_techs for t in time)
+                - sum(discharge[j,t] for j in storage_techs for t in time)
+            )
+        }
+    }
+
+    // ===================================================================
+    // Objective
+    // ===================================================================
+    minimize "SystemCost" {
+        sum(annualized_pv_cost[p] * pv_max_cap[p] * pv_fraction[p] for p in pv_plants)
+        + sum(annualized_wind_cost[w] * wind_max_cap[w] * wind_fraction[w] for w in wind_plants)
+        + sum(annualized_bal_invest[k] * bal_capacity[k] for k in balancing_units)
+        + sum(marginal_cost[k] * bal_dispatch[k,t] for k in balancing_units for t in time)
+        + sum(
+            power_discharge[j] * annualized_power_cost[j]
+            - cost_ratio[j] * power_discharge[j] * annualized_power_cost[j]
+            + cost_ratio[j] * power_charge[j] * annualized_power_cost[j]
+            + annualized_energy_cost[j] * energy_cap[j]
+          for j in storage_techs)
+        + sum(vom_stor[j] * discharge[j,t] for j in storage_techs for t in time)
+        + sum(import_price[t] * imports[n,t] for n in trade_nodes for t in time)
+        - sum(export_price[t] * exports[n,t] for n in trade_nodes for t in time)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Scenario: wire the model to data
+// ---------------------------------------------------------------------------
+
+scenario "SDOMCanonical" {
+    horizon steps=24 resolution="PT1H"
+    use "SDOM"
+
+    // Assets (all seven from the high-level fixture)
+    asset "PV_North"
+    asset "PV_South"
+    asset "Wind_East"
+    asset "GasCT"
+    asset "LiIon"
+    asset "DispatchableHydro"
+    asset "TradeNode"
+
+    // Custom sets mapping index letters to asset subsets
+    pv_plants { "PV_North"; "PV_South" }
+    wind_plants { "Wind_East" }
+    balancing_units { "GasCT" }
+    storage_techs { "LiIon" }
+    hydro_units { "DispatchableHydro" }
+    trade_nodes { "TradeNode" }
+
+    // Set with parameters (budget periods from CSV)
+    set "budget_periods" from="data/budget_periods.csv"
+
+    // Time-indexed data (t-only)
+    data "demand" from="data/demand.csv"
+    data "nuclear_gen" from="data/nuclear_gen.csv"
+    data "import_price" from="data/import_price.csv"
+    data "export_price" from="data/export_price.csv"
+
+    // Asset+time indexed data (asset_name, t)
+    data "solar_cf" from="data/solar_cf.csv"
+    data "wind_cf" from="data/wind_cf.csv"
+    data "hydro_min" from="data/hydro_min.csv"
+    data "hydro_max" from="data/hydro_max.csv"
+
+    // Asset-level parameters from instance CSVs (asset_name, no t)
+    data "pv_max_cap" from="data/pv_plants.csv"
+    data "annualized_pv_cost" from="data/pv_plants.csv"
+    data "wind_max_cap" from="data/wind_plants.csv"
+    data "annualized_wind_cost" from="data/wind_plants.csv"
+    data "min_bal_cap" from="data/balancing_units.csv"
+    data "max_bal_cap" from="data/balancing_units.csv"
+    data "annualized_bal_invest" from="data/balancing_units.csv"
+    data "marginal_cost" from="data/balancing_units.csv"
+    data "max_stor_power" from="data/storage_techs.csv"
+    data "annualized_power_cost" from="data/storage_techs.csv"
+    data "annualized_energy_cost" from="data/storage_techs.csv"
+    data "roundtrip_eff" from="data/storage_techs.csv"
+    data "min_dur" from="data/storage_techs.csv"
+    data "max_dur" from="data/storage_techs.csv"
+    data "vom_stor" from="data/storage_techs.csv"
+    data "annualized_max_cycles" from="data/storage_techs.csv"
+    data "cost_ratio" from="data/storage_techs.csv"
+    data "initial_soc_mwh" from="data/storage_techs.csv"
+    data "max_import" from="trade_nodes.csv"
+    data "max_export" from="trade_nodes.csv"
+}

--- a/crates/arco-cli/tests/e2e/sdom/expected/e2e-summary.json
+++ b/crates/arco-cli/tests/e2e/sdom/expected/e2e-summary.json
@@ -1,0 +1,12 @@
+{
+  "case_id": "sdom",
+  "expect_parse_success": true,
+  "expect_semantic_validation_success": true,
+  "expect_lowering_success": true,
+  "expect_solve_success": true,
+  "objective": {
+    "name": "SystemCost",
+    "sense": "minimize"
+  },
+  "reports": ["PVCost", "WindCost", "BalancingCost", "StorageCost", "TradeCost"]
+}

--- a/crates/arco-cli/tests/e2e/sdom/expected/semantic-program.json
+++ b/crates/arco-cli/tests/e2e/sdom/expected/semantic-program.json
@@ -1,0 +1,78 @@
+{
+  "case_id": "sdom",
+  "active_scenario": "SDOMCase",
+  "sets": {
+    "assets": [
+      "DispatchableHydro",
+      "GasCT",
+      "LiIon",
+      "PV_North",
+      "PV_South",
+      "TradeNode",
+      "Wind_East"
+    ],
+    "candidate_assets": [],
+    "time": {
+      "steps": 24,
+      "resolution": "PT1H"
+    }
+  },
+  "parameters": {
+    "series": [
+      "demand[t]",
+      "export_price[t]",
+      "import_price[t]",
+      "nuclear_gen[t]"
+    ],
+    "indexed": [
+      "hydro_max[a,t]",
+      "hydro_min[a,t]",
+      "solar_cf[a,t]",
+      "wind_cf[a,t]"
+    ],
+    "asset": [
+      "annualized_bal_invest[a]",
+      "annualized_energy_cost[a]",
+      "annualized_max_cycles[a]",
+      "annualized_power_cost[a]",
+      "annualized_pv_cost[a]",
+      "annualized_wind_cost[a]",
+      "cost_ratio[a]",
+      "initial_soc_mwh[a]",
+      "marginal_cost[a]",
+      "max_bal_cap[a]",
+      "max_dur[a]",
+      "max_export[a]",
+      "max_import[a]",
+      "max_stor_power[a]",
+      "min_bal_cap[a]",
+      "min_dur[a]",
+      "pv_max_cap[a]",
+      "roundtrip_eff[a]",
+      "vom_stor[a]",
+      "wind_max_cap[a]"
+    ]
+  },
+  "variable_families": [
+    "bal_capacity[a]",
+    "bal_dispatch[a,t]",
+    "charge[a,t]",
+    "charge_indicator[a,t]",
+    "discharge[a,t]",
+    "dispatch[a,t]",
+    "energy_cap[a]",
+    "exports[a,t]",
+    "imports[a,t]",
+    "power_charge[a]",
+    "power_discharge[a]",
+    "pv_dispatch[a,t]",
+    "pv_fraction[a]",
+    "soc[a,t]",
+    "wind_dispatch[a,t]",
+    "wind_fraction[a]"
+  ],
+  "chronology": {
+    "initial_boundary": "initial_soc_mwh[a]"
+  },
+  "lowering_rules": []
+}

--- a/crates/arco-cli/tests/e2e/sdom/input.kdl
+++ b/crates/arco-cli/tests/e2e/sdom/input.kdl
@@ -1,0 +1,212 @@
+// ---------------------------------------------------------------------------
+// SDOM: Storage Deployment Optimization Model
+//
+// Co-optimizes investment in renewable generation, balancing units, and
+// storage technologies while dispatching all resources to meet demand at
+// minimum annualized system cost subject to a clean-energy target.
+// ---------------------------------------------------------------------------
+
+// --- Technologies -----------------------------------------------------------
+// The as= property names the set of assets for each technology, making
+// constraint references like `for a in pv_plants` explicit and greppable.
+
+technology "PV" as="pv_plants" {
+    invest "pv_fraction" lower=0 upper=1
+    control "pv_dispatch" lower=0
+}
+
+technology "Wind" as="wind_plants" {
+    invest "wind_fraction" lower=0 upper=1
+    control "wind_dispatch" lower=0
+}
+
+technology "BalancingUnit" as="balancing_units" {
+    invest "bal_capacity" lower=0
+    control "bal_dispatch" lower=0
+}
+
+technology "CoupledStorage" as="storage_techs" {
+    invest "power_charge" lower=0
+    invest "power_discharge" lower=0
+    invest "energy_cap" lower=0
+    control "charge" lower=0
+    control "discharge" lower=0
+    control "charge_indicator" kind="binary"
+    state "soc"
+}
+
+technology "Hydro" as="hydro_units" {
+    control "dispatch" lower=0
+}
+
+technology "Trade" as="trade_nodes" {
+    control "imports" lower=0
+    control "exports" lower=0
+}
+
+// --- Operations (per-asset constraints) -------------------------------------
+
+operation "PVDispatch" {
+    constraint "pv_dispatch_limit" {
+        pv_dispatch[a,t] <= solar_cf[a,t] * pv_max_cap[a] * pv_fraction[a]
+    }
+}
+
+operation "WindDispatch" {
+    constraint "wind_dispatch_limit" {
+        wind_dispatch[a,t] <= wind_cf[a,t] * wind_max_cap[a] * wind_fraction[a]
+    }
+}
+
+operation "BalancingOp" {
+    constraint "dispatch_limit" { bal_dispatch[a,t] <= bal_capacity[a] }
+    constraint "capacity_lower" { bal_capacity[a] >= min_bal_cap[a] }
+    constraint "capacity_upper" { bal_capacity[a] <= max_bal_cap[a] }
+}
+
+operation "StorageOp" {
+    constraint "coupled_power" { power_charge[a] = power_discharge[a] }
+    constraint "charge_power_cap" { power_charge[a] <= max_stor_power[a] }
+    constraint "discharge_power_cap" { power_discharge[a] <= max_stor_power[a] }
+    constraint "charge_limit" { charge[a,t] <= power_charge[a] }
+    constraint "discharge_limit" { discharge[a,t] <= power_discharge[a] }
+    constraint "charge_big_m" { charge[a,t] <= max_stor_power[a] * charge_indicator[a,t] }
+    constraint "discharge_big_m" {
+        discharge[a,t] <= max_stor_power[a] - max_stor_power[a] * charge_indicator[a,t]
+    }
+    constraint "soc_balance" {
+        soc[a,t] = soc[a,t-1] + sqrt(roundtrip_eff[a]) * charge[a,t] - discharge[a,t] / sqrt(roundtrip_eff[a])
+    }
+    constraint "soc_lower" { soc[a,t] >= 0 }
+    constraint "soc_upper" { soc[a,t] <= energy_cap[a] }
+    constraint "min_duration" { energy_cap[a] >= min_dur[a] * power_discharge[a] / sqrt(roundtrip_eff[a]) }
+    constraint "max_duration" { energy_cap[a] <= max_dur[a] * power_discharge[a] / sqrt(roundtrip_eff[a]) }
+    constraint "cycle_limit" {
+        over "a" in="storage_techs"
+        expr { sum(discharge[a,t] for t in time) <= annualized_max_cycles[a] * energy_cap[a] }
+    }
+}
+
+operation "HydroOp" {
+    constraint "hydro_min_bound" { dispatch[a,t] >= hydro_min[a,t] }
+    constraint "hydro_max_bound" { dispatch[a,t] <= hydro_max[a,t] }
+}
+
+operation "TradeOp" {
+    constraint "import_cap" { imports[a,t] <= max_import[a] }
+    constraint "export_cap" { exports[a,t] <= max_export[a] }
+}
+
+// --- Rules (system-level constraints) ---------------------------------------
+
+rule "EnergyBalance" {
+    constraint "balance" {
+        sum(pv_dispatch[a,t] for a in pv_plants)
+        + sum(wind_dispatch[a,t] for a in wind_plants)
+        + sum(bal_dispatch[a,t] for a in balancing_units)
+        + sum(dispatch[a,t] for a in hydro_units)
+        + nuclear_gen[t]
+        + sum(discharge[a,t] for a in storage_techs)
+        + sum(imports[a,t] for a in trade_nodes)
+        = demand[t]
+        + sum(charge[a,t] for a in storage_techs)
+        + sum(exports[a,t] for a in trade_nodes)
+    }
+}
+
+rule "CleanEnergyTarget" {
+    constraint "clean_target" {
+        over "a" in="balancing_units"
+        expr {
+            sum(bal_dispatch[a,t] for a in balancing_units for t in time)
+            <= 0.2 * (
+                sum(demand[t] for t in time)
+                + sum(charge[a,t] for a in storage_techs for t in time)
+                - sum(discharge[a,t] for a in storage_techs for t in time)
+            )
+        }
+    }
+}
+
+rule "HydroBudget" {
+    constraint "energy_budget" {
+        over "b" in="budget_periods"
+        expr {
+            sum(dispatch[a,t] for a in hydro_units for t in time
+                if t >= budget_start[b] if t <= budget_end[b])
+            = energy_budget[b]
+        }
+    }
+}
+
+// --- Cost expressions -------------------------------------------------------
+
+expression "PVCost" {
+    sum(annualized_pv_cost[a] * pv_max_cap[a] * pv_fraction[a] for a in pv_plants)
+}
+
+expression "WindCost" {
+    sum(annualized_wind_cost[a] * wind_max_cap[a] * wind_fraction[a] for a in wind_plants)
+}
+
+expression "BalancingCost" {
+    sum(annualized_bal_invest[a] * bal_capacity[a] for a in balancing_units)
+    + sum(marginal_cost[a] * bal_dispatch[a,t] for a in balancing_units for t in time)
+}
+
+expression "StorageCost" {
+    sum(
+        annualized_power_cost[a] * power_discharge[a]
+        - annualized_power_cost[a] * cost_ratio[a] * power_discharge[a]
+        + annualized_power_cost[a] * cost_ratio[a] * power_charge[a]
+        + annualized_energy_cost[a] * energy_cap[a]
+    for a in storage_techs)
+    + sum(vom_stor[a] * discharge[a,t] for a in storage_techs for t in time)
+}
+
+expression "TradeCost" {
+    sum(import_price[t] * imports[a,t] for a in trade_nodes for t in time)
+    - sum(export_price[t] * exports[a,t] for a in trade_nodes for t in time)
+}
+
+minimize "SystemCost" { PVCost + WindCost + BalancingCost + StorageCost + TradeCost }
+
+// --- Instances and Assets ---------------------------------------------------
+// Auto-map: CSV columns auto-map to parameters by name (no map directives needed).
+
+instances "PVPlants" from="data/pv_plants.csv" { technology "PV"; operation "PVDispatch" }
+instances "WindPlants" from="data/wind_plants.csv" { technology "Wind"; operation "WindDispatch" }
+instances "BalancingUnits" from="data/balancing_units.csv" { technology "BalancingUnit"; operation "BalancingOp" }
+instances "StorageTechs" from="data/storage_techs.csv" { technology "CoupledStorage"; operation "StorageOp" }
+
+asset "DispatchableHydro" { technology "Hydro"; operation "HydroOp" }
+asset "TradeNode" { technology "Trade"; operation "TradeOp"; max_import 500; max_export 500 }
+
+// --- Scenario ---------------------------------------------------------------
+// Auto-wire: technologies, operations, and rules are inferred from the
+// instances and assets declared above. No need to re-list them.
+
+scenario "SDOMCase" {
+    horizon steps=24 resolution="PT1H"
+    set "budget_periods" from="data/budget_periods.csv"
+    data "demand" from="data/demand.csv"
+    data "solar_cf" from="data/solar_cf.csv"
+    data "wind_cf" from="data/wind_cf.csv"
+    data "nuclear_gen" from="data/nuclear_gen.csv"
+    data "hydro_min" from="data/hydro_min.csv"
+    data "hydro_max" from="data/hydro_max.csv"
+    data "import_price" from="data/import_price.csv"
+    data "export_price" from="data/export_price.csv"
+    instances "PVPlants"
+    instances "WindPlants"
+    instances "BalancingUnits"
+    instances "StorageTechs"
+    asset "DispatchableHydro"
+    asset "TradeNode"
+    minimize "SystemCost"
+    report "PVCost"
+    report "WindCost"
+    report "BalancingCost"
+    report "StorageCost"
+    report "TradeCost"
+}

--- a/crates/arco-cli/tests/e2e/simple-electricity-market-storage/expected/e2e-summary.json
+++ b/crates/arco-cli/tests/e2e/simple-electricity-market-storage/expected/e2e-summary.json
@@ -1,0 +1,12 @@
+{
+  "case_id": "simple-electricity-market-storage",
+  "expect_parse_success": true,
+  "expect_semantic_validation_success": true,
+  "expect_lowering_success": true,
+  "expect_solve_success": true,
+  "objective": {
+    "name": "TotalSystemCost",
+    "sense": "minimize"
+  },
+  "reports": ["DispatchCost"]
+}

--- a/crates/arco-cli/tests/e2e/simple-electricity-market-storage/expected/semantic-program.json
+++ b/crates/arco-cli/tests/e2e/simple-electricity-market-storage/expected/semantic-program.json
@@ -1,0 +1,20 @@
+{
+  "case_id": "simple-electricity-market-storage",
+  "active_scenario": "SouthAfricaSingleZoneWithStorage",
+  "sets": {
+    "assets": ["Coal", "Gas", "Oil", "PumpedHydro", "Wind"],
+    "time": {
+      "steps": 4,
+      "resolution": "PT1H"
+    }
+  },
+  "parameters": {
+    "series": ["load[t]"],
+    "indexed": ["availability[a,t]"],
+    "asset": ["capacity_mw[a]", "energy_mwh[a]", "initial_soc_mwh[a]", "marginal_cost[a]", "power_mw[a]"]
+  },
+  "variable_families": ["dispatch[a,t]", "soc[a,t]"],
+  "chronology": {
+    "initial_boundary": "initial_soc_mwh[a]"
+  }
+}

--- a/crates/arco-cli/tests/e2e/simple-electricity-market-storage/input.kdl
+++ b/crates/arco-cli/tests/e2e/simple-electricity-market-storage/input.kdl
@@ -1,0 +1,96 @@
+technology "Generator" {
+  control "dispatch"
+}
+
+technology "Storage" {
+  control "dispatch"
+  state "soc"
+}
+
+operation "GeneratorDispatch" {
+  constraint "generator_limit" {
+    dispatch[a,t] <= capacity_mw[a] * availability[a,t]
+  }
+}
+
+operation "StorageDispatch" {
+  constraint "soc_balance" {
+    soc[a,t] = soc[a,t-1] - dispatch[a,t]
+  }
+
+  constraint "dispatch_limit" {
+    -power_mw[a] <= dispatch[a,t] <= power_mw[a]
+  }
+
+  constraint "soc_bounds" {
+    0 <= soc[a,t] <= energy_mwh[a]
+  }
+}
+
+rule "SingleZoneBalance" {
+  constraint "balance" {
+    sum(dispatch[a,t] for a in assets) = load[t]
+  }
+}
+
+expression "DispatchCost" {
+  sum(marginal_cost[a] * dispatch[a,t] for a in assets for t in time)
+}
+
+minimize "TotalSystemCost" {
+  DispatchCost
+}
+
+asset "Coal" {
+  technology "Generator"
+  operation "GeneratorDispatch"
+  capacity_mw 35000
+  marginal_cost 30
+}
+
+asset "Wind" {
+  technology "Generator"
+  operation "GeneratorDispatch"
+  capacity_mw 3000
+  marginal_cost 0
+}
+
+asset "Gas" {
+  technology "Generator"
+  operation "GeneratorDispatch"
+  capacity_mw 8000
+  marginal_cost 60
+}
+
+asset "Oil" {
+  technology "Generator"
+  operation "GeneratorDispatch"
+  capacity_mw 2000
+  marginal_cost 80
+}
+
+asset "PumpedHydro" {
+  technology "Storage"
+  operation "StorageDispatch"
+  power_mw 1000
+  energy_mwh 6000
+  initial_soc_mwh 0
+}
+
+scenario "SouthAfricaSingleZoneWithStorage" {
+  horizon steps=4 resolution="PT1H"
+  technology "Generator"
+  technology "Storage"
+  operation "GeneratorDispatch"
+  operation "StorageDispatch"
+  rule "SingleZoneBalance"
+  data "availability" from="data/availability.csv"
+  data "load" from="data/load.csv"
+  asset "Coal"
+  asset "Wind"
+  asset "Gas"
+  asset "Oil"
+  asset "PumpedHydro"
+  minimize "TotalSystemCost"
+  report "DispatchCost"
+}

--- a/crates/arco-cli/tests/execution_suite.rs
+++ b/crates/arco-cli/tests/execution_suite.rs
@@ -1,0 +1,283 @@
+use arco_cli::execution::{
+    AdapterSolveOutput, ExecutionError, OptimizationAdapter, RustArcoAdapter, ScalarArtifactValue,
+    SolveStatus, VariableArtifactValue, execute_problem,
+};
+use arco_kdl::lowering::lower_program;
+use arco_kdl::semantic::validate_program;
+use arco_kdl::source::parse_program_file;
+use std::path::PathBuf;
+
+#[test]
+fn executes_price_taker_battery_fixture_through_rust_arco_adapter()
+-> Result<(), Box<dyn std::error::Error>> {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("e2e")
+        .join("price-taker-battery")
+        .join("input.kdl");
+
+    let parsed = parse_program_file(&path)?;
+    let semantic_program = validate_program(&parsed.program, &path)?;
+    let lowered_problem = lower_program(&semantic_program, &parsed.program, &path)?;
+    let execution_result = execute_problem(&lowered_problem, &RustArcoAdapter::new())?;
+
+    assert_eq!(execution_result.backend, "arco-rust-highs");
+    assert_eq!(execution_result.status, SolveStatus::Optimal);
+    assert_eq!(execution_result.objective.dsl_name, "ArbitrageProfit");
+    assert_eq!(execution_result.objective_sense, "maximize");
+    assert!(execution_result.objective.value.is_finite());
+    assert!(execution_result.objective.value > 0.0);
+    assert_eq!(execution_result.reports.len(), 1);
+    assert_eq!(execution_result.reports[0].dsl_name, "ArbitrageRevenue");
+    assert!(execution_result.reports[0].value > 0.0);
+
+    let variable_families: Vec<&str> = execution_result
+        .variables
+        .iter()
+        .map(|v| v.dsl_name.as_str())
+        .collect();
+    assert_eq!(
+        variable_families,
+        &["charge[a,t]", "discharge[a,t]", "soc[a,t]"]
+    );
+
+    Ok(())
+}
+
+#[test]
+fn executes_simple_electricity_market_storage_fixture_with_expected_dispatch()
+-> Result<(), Box<dyn std::error::Error>> {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("e2e")
+        .join("simple-electricity-market-storage")
+        .join("input.kdl");
+
+    let parsed = parse_program_file(&path)?;
+    let semantic_program = validate_program(&parsed.program, &path)?;
+    let lowered_problem = lower_program(&semantic_program, &parsed.program, &path)?;
+    let execution_result = execute_problem(&lowered_problem, &RustArcoAdapter::new())?;
+
+    assert_eq!(execution_result.backend, "arco-rust-highs");
+    assert_eq!(execution_result.status, SolveStatus::Optimal);
+    assert_eq!(execution_result.objective.dsl_name, "TotalSystemCost");
+    assert_eq!(execution_result.objective_sense, "minimize");
+    assert!((execution_result.objective.value - 6_046_000.0).abs() < 1e-6);
+
+    let dispatch = execution_result
+        .variables
+        .iter()
+        .find(|variable| variable.dsl_name == "dispatch[a,t]")
+        .ok_or("missing dispatch family")?;
+    let soc = execution_result
+        .variables
+        .iter()
+        .find(|variable| variable.dsl_name == "soc[a,t]")
+        .ok_or("missing soc family")?;
+
+    let dispatch_points = variable_points(dispatch);
+    let soc_points = variable_points(soc);
+    let pypsa_dispatch = vec![
+        ("dispatch[Coal,1]".to_string(), 35_000.0),
+        ("dispatch[Coal,2]".to_string(), 35_000.0),
+        ("dispatch[Coal,3]".to_string(), 35_000.0),
+        ("dispatch[Coal,4]".to_string(), 35_000.0),
+        ("dispatch[Gas,1]".to_string(), 6_900.0),
+        ("dispatch[Gas,2]".to_string(), 7_200.0),
+        ("dispatch[Gas,3]".to_string(), 8_000.0),
+        ("dispatch[Gas,4]".to_string(), 8_000.0),
+        ("dispatch[Oil,1]".to_string(), 0.0),
+        ("dispatch[Oil,2]".to_string(), 0.0),
+        ("dispatch[Oil,3]".to_string(), 0.0),
+        ("dispatch[Oil,4]".to_string(), 500.0),
+        ("dispatch[PumpedHydro,1]".to_string(), -800.0),
+        ("dispatch[PumpedHydro,2]".to_string(), -1_000.0),
+        ("dispatch[PumpedHydro,3]".to_string(), 800.0),
+        ("dispatch[PumpedHydro,4]".to_string(), 1_000.0),
+        ("dispatch[Wind,1]".to_string(), 900.0),
+        ("dispatch[Wind,2]".to_string(), 1_800.0),
+        ("dispatch[Wind,3]".to_string(), 1_200.0),
+        ("dispatch[Wind,4]".to_string(), 1_500.0),
+    ];
+    let equivalent_dispatch = vec![
+        ("dispatch[Coal,1]".to_string(), 35_000.0),
+        ("dispatch[Coal,2]".to_string(), 35_000.0),
+        ("dispatch[Coal,3]".to_string(), 35_000.0),
+        ("dispatch[Coal,4]".to_string(), 35_000.0),
+        ("dispatch[Gas,1]".to_string(), 7_100.0),
+        ("dispatch[Gas,2]".to_string(), 7_000.0),
+        ("dispatch[Gas,3]".to_string(), 8_000.0),
+        ("dispatch[Gas,4]".to_string(), 8_000.0),
+        ("dispatch[Oil,1]".to_string(), 0.0),
+        ("dispatch[Oil,2]".to_string(), 0.0),
+        ("dispatch[Oil,3]".to_string(), 0.0),
+        ("dispatch[Oil,4]".to_string(), 500.0),
+        ("dispatch[PumpedHydro,1]".to_string(), -1_000.0),
+        ("dispatch[PumpedHydro,2]".to_string(), -800.0),
+        ("dispatch[PumpedHydro,3]".to_string(), 800.0),
+        ("dispatch[PumpedHydro,4]".to_string(), 1_000.0),
+        ("dispatch[Wind,1]".to_string(), 900.0),
+        ("dispatch[Wind,2]".to_string(), 1_800.0),
+        ("dispatch[Wind,3]".to_string(), 1_200.0),
+        ("dispatch[Wind,4]".to_string(), 1_500.0),
+    ];
+    let pypsa_soc = vec![
+        ("soc[PumpedHydro,1]".to_string(), 800.0),
+        ("soc[PumpedHydro,2]".to_string(), 1_800.0),
+        ("soc[PumpedHydro,3]".to_string(), 1_000.0),
+        ("soc[PumpedHydro,4]".to_string(), 0.0),
+    ];
+    let equivalent_soc = vec![
+        ("soc[PumpedHydro,1]".to_string(), 1_000.0),
+        ("soc[PumpedHydro,2]".to_string(), 1_800.0),
+        ("soc[PumpedHydro,3]".to_string(), 1_000.0),
+        ("soc[PumpedHydro,4]".to_string(), 0.0),
+    ];
+
+    assert!(dispatch_points == pypsa_dispatch || dispatch_points == equivalent_dispatch);
+    assert!(soc_points == pypsa_soc || soc_points == equivalent_soc);
+
+    Ok(())
+}
+
+#[test]
+fn execution_rejects_missing_report_mapping() -> Result<(), Box<dyn std::error::Error>> {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("e2e")
+        .join("pcm")
+        .join("input.kdl");
+
+    let parsed = parse_program_file(&path)?;
+    let semantic_program = validate_program(&parsed.program, &path)?;
+    let lowered_problem = lower_program(&semantic_program, &parsed.program, &path)?;
+    let adapter = MissingReportAdapter;
+
+    let error = execute_problem(&lowered_problem, &adapter).expect_err("execution should fail");
+    assert!(matches!(error, ExecutionError::MissingReportValue { .. }));
+
+    Ok(())
+}
+
+struct MissingReportAdapter;
+
+impl OptimizationAdapter for MissingReportAdapter {
+    fn backend_name(&self) -> &'static str {
+        "missing-report"
+    }
+
+    fn solve(
+        &self,
+        problem: &arco_kdl::lowering::LoweredProblem,
+        _include_variable_values: bool,
+    ) -> Result<AdapterSolveOutput, ExecutionError> {
+        Ok(AdapterSolveOutput {
+            status: SolveStatus::Optimal,
+            objective_value: ScalarArtifactValue {
+                lowered_name: problem.objective.name.clone(),
+                value: 0.0,
+            },
+            report_values: Vec::new(),
+            variable_values: problem
+                .variables
+                .iter()
+                .map(|variable| VariableArtifactValue {
+                    lowered_name: variable.family.clone(),
+                    representative_value: 0.0,
+                    values: Vec::new(),
+                })
+                .collect(),
+        })
+    }
+}
+
+#[test]
+fn executes_sdom_fixture_through_full_pipeline() -> Result<(), Box<dyn std::error::Error>> {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/e2e/sdom/input.kdl");
+
+    let parsed = parse_program_file(&path)?;
+    let semantic = validate_program(&parsed.program, &path)?;
+    let lowered = lower_program(&semantic, &parsed.program, &path)?;
+    let result = execute_problem(&lowered, &RustArcoAdapter::new())?;
+
+    assert_eq!(result.status, SolveStatus::Optimal);
+    assert_eq!(result.objective.dsl_name, "SystemCost");
+    assert_eq!(result.objective_sense, "minimize");
+    assert!(result.objective.value.is_finite());
+    assert!(result.objective.value > 0.0);
+
+    let families: Vec<&str> = result
+        .variables
+        .iter()
+        .map(|v| v.dsl_name.as_str())
+        .collect();
+    assert!(
+        families.contains(&"pv_fraction[a]"),
+        "missing pv_fraction: {families:?}"
+    );
+    assert!(
+        families.contains(&"bal_capacity[a]"),
+        "missing bal_capacity: {families:?}"
+    );
+    assert!(
+        families.contains(&"energy_cap[a]"),
+        "missing energy_cap: {families:?}"
+    );
+    assert!(
+        families.contains(&"charge[a,t]"),
+        "missing charge: {families:?}"
+    );
+    assert!(
+        families.contains(&"discharge[a,t]"),
+        "missing discharge: {families:?}"
+    );
+    assert!(families.contains(&"soc[a,t]"), "missing soc: {families:?}");
+    assert!(
+        families.contains(&"charge_indicator[a,t]"),
+        "missing charge_indicator: {families:?}"
+    );
+
+    assert_eq!(result.reports.len(), 5, "expected 5 report components");
+
+    Ok(())
+}
+
+#[test]
+fn sdom_and_sdom_canonical_produce_matching_objectives() -> Result<(), Box<dyn std::error::Error>> {
+    let sdom_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/e2e/sdom/input.kdl");
+    let canonical_path =
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/e2e/sdom-canonical/input.kdl");
+
+    let sdom_parsed = parse_program_file(&sdom_path)?;
+    let sdom_semantic = validate_program(&sdom_parsed.program, &sdom_path)?;
+    let sdom_lowered = lower_program(&sdom_semantic, &sdom_parsed.program, &sdom_path)?;
+    let sdom_result = execute_problem(&sdom_lowered, &RustArcoAdapter::new())?;
+
+    let canon_parsed = parse_program_file(&canonical_path)?;
+    let canon_semantic = validate_program(&canon_parsed.program, &canonical_path)?;
+    let canon_lowered = lower_program(&canon_semantic, &canon_parsed.program, &canonical_path)?;
+    let canon_result = execute_problem(&canon_lowered, &RustArcoAdapter::new())?;
+
+    assert_eq!(sdom_result.status, SolveStatus::Optimal);
+    assert_eq!(canon_result.status, SolveStatus::Optimal);
+
+    let relative_error = (sdom_result.objective.value - canon_result.objective.value).abs()
+        / sdom_result.objective.value.abs();
+    assert!(
+        relative_error < 1e-6,
+        "objectives should match: sdom={}, canonical={}, relative_error={}",
+        sdom_result.objective.value,
+        canon_result.objective.value,
+        relative_error
+    );
+
+    Ok(())
+}
+
+fn variable_points(variable: &arco_cli::execution::MappedVariableResult) -> Vec<(String, f64)> {
+    variable
+        .values
+        .iter()
+        .map(|value| (value.lowered_name.clone(), value.value))
+        .collect()
+}

--- a/crates/arco-cli/tests/export_suite.rs
+++ b/crates/arco-cli/tests/export_suite.rs
@@ -1,0 +1,76 @@
+use arco_cli::export::{write_lp, write_mps};
+use arco_kdl::pipeline::compile_file;
+use std::path::PathBuf;
+
+#[test]
+fn exports_price_taker_battery_fixture_to_lp() -> Result<(), Box<dyn std::error::Error>> {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("e2e")
+        .join("price-taker-battery")
+        .join("input.kdl");
+
+    let compiled = compile_file(&path)?;
+    let mut output = Vec::new();
+    write_lp(&compiled.lowered_problem.algebra, &mut output)?;
+
+    let text = String::from_utf8(output)?;
+    assert!(text.contains("Maximize"));
+    assert!(text.contains("ArbitrageProfit:"));
+    assert!(text.contains("Subject To"));
+    assert!(text.contains("soc_balance[Battery1,1]:"));
+    assert!(text.contains("Bounds"));
+    assert!(text.contains("End"));
+
+    // Verify the charge efficiency coefficient (1/0.92 ≈ 1.0869...) appears in soc balance rows.
+    assert!(text.contains("1.086956521739 discharge[Battery1,1]"));
+    // Verify the -0.92 charge efficiency coefficient.
+    assert!(text.contains("- 0.92 charge[Battery1,1]"));
+    // Verify the initial SOC boundary (initial_soc_mwh = 200) is the RHS of the first balance.
+    assert!(text.contains("soc_balance[Battery1,1]: - 0.92 charge[Battery1,1] + 1.086956521739 discharge[Battery1,1] + soc[Battery1,1] = 200"));
+    // Verify the power capacity bound (power_mw = 100).
+    assert!(text.contains("charge_limit[Battery1,1]: charge[Battery1,1] <= 100"));
+    // Verify the energy capacity bound (energy_mwh = 400).
+    assert!(text.contains("soc_bounds[Battery1,1]_upper: soc[Battery1,1] <= 400"));
+    // Verify the terminal SOC constraint (terminal_soc_mwh = 200 over 24 steps).
+    assert!(text.contains("terminal_soc[Battery1]: soc[Battery1,24] = 200"));
+
+    Ok(())
+}
+
+#[test]
+fn exports_price_taker_battery_fixture_to_mps() -> Result<(), Box<dyn std::error::Error>> {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("e2e")
+        .join("price-taker-battery")
+        .join("input.kdl");
+
+    let compiled = compile_file(&path)?;
+    let mut output = Vec::new();
+    write_mps(&compiled.lowered_problem.algebra, &mut output)?;
+
+    let text = String::from_utf8(output)?;
+    assert!(text.contains("NAME          MODEL"));
+    assert!(text.contains("ROWS"));
+    assert!(text.contains("COLUMNS"));
+    assert!(text.contains("RHS"));
+    assert!(text.contains("BOUNDS"));
+    assert!(text.contains("ENDATA"));
+
+    // Verify constraint types: equality for soc_balance, inequality for charge_limit.
+    assert!(text.contains(" E  soc_balance[Battery1,1]"));
+    assert!(text.contains(" L  charge_limit[Battery1,1]"));
+    // Verify the charge efficiency coefficient in the COLUMNS section.
+    assert!(text.contains("soc_balance[Battery1,1]             -0.92"));
+    // Verify the power capacity RHS (power_mw = 100).
+    assert!(text.contains("RHS1      charge_limit[Battery1,1]               100"));
+    // Verify the initial SOC as the soc_balance RHS (initial_soc_mwh = 200).
+    assert!(text.contains("RHS1      soc_balance[Battery1,1]               200"));
+    // Verify the energy capacity RHS (energy_mwh = 400).
+    assert!(text.contains("RHS1      soc_bounds[Battery1,1]_upper               400"));
+    // Verify soc variables are declared free (no lower bound).
+    assert!(text.contains(" FR BND1      soc[Battery1,1]"));
+
+    Ok(())
+}

--- a/crates/arco-kdl/Cargo.toml
+++ b/crates/arco-kdl/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "arco-kdl"
+version = { workspace = true }
+description = "KDL-based DSL compiler for optimization models"
+edition = { workspace = true }
+rust-version = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+authors = { workspace = true }
+license-file = { workspace = true }
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+csv = "1.4"
+kdl = "6.5"
+miette = { version = "7", features = ["fancy"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = { workspace = true }
+thiserror = "2.0"
+tracing = { workspace = true }

--- a/crates/arco-kdl/src/algebra.rs
+++ b/crates/arco-kdl/src/algebra.rs
@@ -1,0 +1,934 @@
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+use std::error::Error;
+use std::fmt::{self, Display, Formatter};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Expr {
+    Number(String),
+    String(String),
+    Boolean(bool),
+    Identifier(String),
+    Indexed {
+        target: String,
+        indices: Vec<Expr>,
+    },
+    Unary {
+        op: UnaryOp,
+        expr: Box<Expr>,
+    },
+    Binary {
+        op: BinaryOp,
+        left: Box<Expr>,
+        right: Box<Expr>,
+    },
+    Comparison {
+        op: ComparisonOp,
+        left: Box<Expr>,
+        right: Box<Expr>,
+    },
+    FunctionCall {
+        name: String,
+        args: Vec<Expr>,
+    },
+    Reduction(ReductionExpr),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReductionExpr {
+    pub op: ReductionOp,
+    pub body: Box<Expr>,
+    pub bindings: Vec<Binding>,
+    pub filters: Vec<Expr>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Binding {
+    pub pattern: BindingPattern,
+    pub domain: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum BindingPattern {
+    Name(String),
+    Tuple(Vec<String>),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ReductionOp {
+    Sum,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum UnaryOp {
+    Negate,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum BinaryOp {
+    Add,
+    Subtract,
+    Multiply,
+    Divide,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ComparisonOp {
+    Equal,
+    DoubleEqual,
+    LessEqual,
+    GreaterEqual,
+    Less,
+    Greater,
+    NotEqual,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ConstraintBody {
+    Comparison {
+        op: ComparisonOp,
+        left: Expr,
+        right: Expr,
+    },
+    Range {
+        lower: Expr,
+        lower_op: ComparisonOp,
+        middle: Expr,
+        upper_op: ComparisonOp,
+        upper: Expr,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParseError {
+    position: usize,
+    message: String,
+}
+
+impl ParseError {
+    fn new(position: usize, message: impl Into<String>) -> Self {
+        Self {
+            position,
+            message: message.into(),
+        }
+    }
+
+    pub fn position(&self) -> usize {
+        self.position
+    }
+}
+
+impl Display for ParseError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{} at byte {}", self.message, self.position)
+    }
+}
+
+impl Error for ParseError {}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum TokenKind {
+    Identifier(String),
+    Number(String),
+    String(String),
+    LParen,
+    RParen,
+    LBracket,
+    RBracket,
+    Comma,
+    Plus,
+    Minus,
+    Star,
+    Slash,
+    Equal,
+    DoubleEqual,
+    NotEqual,
+    Less,
+    LessEqual,
+    Greater,
+    GreaterEqual,
+    KeywordFor,
+    KeywordIf,
+    KeywordIn,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Token {
+    kind: TokenKind,
+    position: usize,
+}
+
+pub fn parse_value_formula(text: &str) -> Result<Expr, ParseError> {
+    parse_formula(text, |parser| parser.parse_value_expr())
+}
+
+pub fn parse_constraint_formula(text: &str) -> Result<ConstraintBody, ParseError> {
+    parse_formula(text, |parser| {
+        let left = parser.parse_arithmetic_expr()?;
+        let op = parser.parse_comparison_operator()?;
+        let middle = parser.parse_arithmetic_expr()?;
+        Ok(if let Some(next_op) = parser.maybe_comparison_operator() {
+            let upper = parser.parse_arithmetic_expr()?;
+            ConstraintBody::Range {
+                lower: left,
+                lower_op: op,
+                middle,
+                upper_op: next_op,
+                upper,
+            }
+        } else {
+            ConstraintBody::Comparison {
+                op,
+                left,
+                right: middle,
+            }
+        })
+    })
+}
+
+fn parse_formula<T>(
+    text: &str,
+    parse: impl FnOnce(&mut Parser<'_>) -> Result<T, ParseError>,
+) -> Result<T, ParseError> {
+    let tokens = tokenize(text)?;
+    let mut parser = Parser::new(&tokens);
+    let constraint = parse(&mut parser)?;
+    parser.expect_end()?;
+    Ok(constraint)
+}
+
+pub fn collect_named_expression_dependencies(expr: &Expr) -> BTreeSet<String> {
+    let mut names = BTreeSet::new();
+    collect_named_dependencies(expr, &mut BTreeSet::new(), &mut names);
+    names
+}
+
+pub fn constraint_mentions_previous_time(constraint: &ConstraintBody) -> bool {
+    match constraint {
+        ConstraintBody::Comparison { left, right, .. } => {
+            expr_mentions_previous_time(left) || expr_mentions_previous_time(right)
+        }
+        ConstraintBody::Range {
+            lower,
+            middle,
+            upper,
+            ..
+        } => {
+            expr_mentions_previous_time(lower)
+                || expr_mentions_previous_time(middle)
+                || expr_mentions_previous_time(upper)
+        }
+    }
+}
+
+impl Display for Expr {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        format_expr(self, f, 0)
+    }
+}
+
+impl Display for ConstraintBody {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Comparison { op, left, right } => write!(f, "{left} {op} {right}"),
+            Self::Range {
+                lower,
+                lower_op,
+                middle,
+                upper_op,
+                upper,
+            } => write!(f, "{lower} {lower_op} {middle} {upper_op} {upper}"),
+        }
+    }
+}
+
+impl Display for UnaryOp {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Negate => f.write_str("-"),
+        }
+    }
+}
+
+impl Display for BinaryOp {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Add => "+",
+            Self::Subtract => "-",
+            Self::Multiply => "*",
+            Self::Divide => "/",
+        })
+    }
+}
+
+impl Display for ComparisonOp {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Equal => "=",
+            Self::DoubleEqual => "==",
+            Self::LessEqual => "<=",
+            Self::GreaterEqual => ">=",
+            Self::Less => "<",
+            Self::Greater => ">",
+            Self::NotEqual => "!=",
+        })
+    }
+}
+
+fn format_expr(expr: &Expr, f: &mut Formatter<'_>, parent_precedence: u8) -> fmt::Result {
+    let precedence = expr_precedence(expr);
+    let needs_parens = precedence < parent_precedence;
+    if needs_parens {
+        f.write_str("(")?;
+    }
+
+    match expr {
+        Expr::Number(value) | Expr::Identifier(value) => f.write_str(value)?,
+        Expr::String(value) => write!(f, "\"{}\"", value.replace('"', "\\\""))?,
+        Expr::Boolean(value) => f.write_str(if *value { "true" } else { "false" })?,
+        Expr::Indexed { target, indices } => {
+            write!(f, "{target}[")?;
+            for (index, value) in indices.iter().enumerate() {
+                if index > 0 {
+                    f.write_str(",")?;
+                }
+                format_expr(value, f, 0)?;
+            }
+            f.write_str("]")?;
+        }
+        Expr::Unary { op, expr } => {
+            write!(f, "{op}")?;
+            format_expr(expr, f, precedence)?;
+        }
+        Expr::Binary { op, left, right } => {
+            format_expr(left, f, precedence)?;
+            write!(f, " {op} ")?;
+            format_expr(right, f, precedence + 1)?;
+        }
+        Expr::Comparison { op, left, right } => {
+            format_expr(left, f, precedence)?;
+            write!(f, " {op} ")?;
+            format_expr(right, f, precedence + 1)?;
+        }
+        Expr::FunctionCall { name, args } => {
+            write!(f, "{name}(")?;
+            for (index, arg) in args.iter().enumerate() {
+                if index > 0 {
+                    f.write_str(", ")?;
+                }
+                format_expr(arg, f, 0)?;
+            }
+            f.write_str(")")?;
+        }
+        Expr::Reduction(reduction) => {
+            write!(f, "sum(")?;
+            format_expr(&reduction.body, f, 0)?;
+            for binding in &reduction.bindings {
+                write!(f, " for ")?;
+                match &binding.pattern {
+                    BindingPattern::Name(name) => f.write_str(name)?,
+                    BindingPattern::Tuple(names) => {
+                        f.write_str("(")?;
+                        for (index, name) in names.iter().enumerate() {
+                            if index > 0 {
+                                f.write_str(", ")?;
+                            }
+                            f.write_str(name)?;
+                        }
+                        f.write_str(")")?;
+                    }
+                }
+                write!(f, " in {}", binding.domain)?;
+            }
+            for filter in &reduction.filters {
+                write!(f, " if ")?;
+                format_expr(filter, f, 0)?;
+            }
+            f.write_str(")")?;
+        }
+    }
+
+    if needs_parens {
+        f.write_str(")")?;
+    }
+    Ok(())
+}
+
+fn expr_precedence(expr: &Expr) -> u8 {
+    match expr {
+        Expr::Comparison { .. } => 1,
+        Expr::Binary {
+            op: BinaryOp::Add | BinaryOp::Subtract,
+            ..
+        } => 2,
+        Expr::Binary {
+            op: BinaryOp::Multiply | BinaryOp::Divide,
+            ..
+        } => 3,
+        Expr::Unary { .. } => 4,
+        Expr::Number(_)
+        | Expr::String(_)
+        | Expr::Boolean(_)
+        | Expr::Identifier(_)
+        | Expr::Indexed { .. }
+        | Expr::FunctionCall { .. }
+        | Expr::Reduction(_) => 5,
+    }
+}
+
+fn tokenize(text: &str) -> Result<Vec<Token>, ParseError> {
+    let bytes = text.as_bytes();
+    let mut tokens = Vec::new();
+    let mut index = 0usize;
+
+    while index < bytes.len() {
+        let character = bytes[index] as char;
+        if character.is_ascii_whitespace() {
+            index += 1;
+            continue;
+        }
+
+        let token = match character {
+            '(' => Token {
+                kind: TokenKind::LParen,
+                position: index,
+            },
+            ')' => Token {
+                kind: TokenKind::RParen,
+                position: index,
+            },
+            '[' => Token {
+                kind: TokenKind::LBracket,
+                position: index,
+            },
+            ']' => Token {
+                kind: TokenKind::RBracket,
+                position: index,
+            },
+            ',' => Token {
+                kind: TokenKind::Comma,
+                position: index,
+            },
+            '+' => Token {
+                kind: TokenKind::Plus,
+                position: index,
+            },
+            '-' => Token {
+                kind: TokenKind::Minus,
+                position: index,
+            },
+            '*' => Token {
+                kind: TokenKind::Star,
+                position: index,
+            },
+            '/' => Token {
+                kind: TokenKind::Slash,
+                position: index,
+            },
+            '=' => {
+                if bytes.get(index + 1) == Some(&b'=') {
+                    index += 1;
+                    Token {
+                        kind: TokenKind::DoubleEqual,
+                        position: index - 1,
+                    }
+                } else {
+                    Token {
+                        kind: TokenKind::Equal,
+                        position: index,
+                    }
+                }
+            }
+            '!' => {
+                if bytes.get(index + 1) != Some(&b'=') {
+                    return Err(ParseError::new(index, "unexpected `!`"));
+                }
+                index += 1;
+                Token {
+                    kind: TokenKind::NotEqual,
+                    position: index - 1,
+                }
+            }
+            '<' => {
+                if bytes.get(index + 1) == Some(&b'=') {
+                    index += 1;
+                    Token {
+                        kind: TokenKind::LessEqual,
+                        position: index - 1,
+                    }
+                } else {
+                    Token {
+                        kind: TokenKind::Less,
+                        position: index,
+                    }
+                }
+            }
+            '>' => {
+                if bytes.get(index + 1) == Some(&b'=') {
+                    index += 1;
+                    Token {
+                        kind: TokenKind::GreaterEqual,
+                        position: index - 1,
+                    }
+                } else {
+                    Token {
+                        kind: TokenKind::Greater,
+                        position: index,
+                    }
+                }
+            }
+            '"' => {
+                let start = index;
+                index += 1;
+                let mut value = String::new();
+                let mut escaped = false;
+                while index < bytes.len() {
+                    let current = bytes[index] as char;
+                    if escaped {
+                        value.push(match current {
+                            'n' => '\n',
+                            'r' => '\r',
+                            't' => '\t',
+                            '\\' => '\\',
+                            '"' => '"',
+                            other => other,
+                        });
+                        escaped = false;
+                    } else if current == '\\' {
+                        escaped = true;
+                    } else if current == '"' {
+                        break;
+                    } else {
+                        value.push(current);
+                    }
+                    index += 1;
+                }
+                if index >= bytes.len() || bytes[index] as char != '"' {
+                    return Err(ParseError::new(start, "unterminated string literal"));
+                }
+                Token {
+                    kind: TokenKind::String(value),
+                    position: start,
+                }
+            }
+            character if character.is_ascii_digit() => {
+                let start = index;
+                while index + 1 < bytes.len() {
+                    let next = bytes[index + 1] as char;
+                    if next.is_ascii_digit() || next == '.' {
+                        index += 1;
+                    } else {
+                        break;
+                    }
+                }
+                Token {
+                    kind: TokenKind::Number(text[start..=index].to_string()),
+                    position: start,
+                }
+            }
+            character if is_identifier_start(character) => {
+                let start = index;
+                while index + 1 < bytes.len() && is_identifier_continue(bytes[index + 1] as char) {
+                    index += 1;
+                }
+                let identifier = &text[start..=index];
+                let kind = match identifier {
+                    "for" => TokenKind::KeywordFor,
+                    "if" => TokenKind::KeywordIf,
+                    "in" => TokenKind::KeywordIn,
+                    _ => TokenKind::Identifier(identifier.to_string()),
+                };
+                Token {
+                    kind,
+                    position: start,
+                }
+            }
+            other => {
+                return Err(ParseError::new(
+                    index,
+                    format!("unexpected character `{other}`"),
+                ));
+            }
+        };
+
+        tokens.push(token);
+        index += 1;
+    }
+
+    Ok(tokens)
+}
+
+fn is_builtin_function(name: &str) -> bool {
+    matches!(name, "sqrt" | "pow" | "exp" | "ln" | "abs")
+}
+
+struct Parser<'a> {
+    tokens: &'a [Token],
+    index: usize,
+}
+
+impl<'a> Parser<'a> {
+    fn new(tokens: &'a [Token]) -> Self {
+        Self { tokens, index: 0 }
+    }
+
+    fn expect_end(&self) -> Result<(), ParseError> {
+        if let Some(token) = self.tokens.get(self.index) {
+            Err(ParseError::new(token.position, "unexpected trailing input"))
+        } else {
+            Ok(())
+        }
+    }
+
+    fn parse_value_expr(&mut self) -> Result<Expr, ParseError> {
+        let left = self.parse_arithmetic_expr()?;
+        if let Some(op) = self.maybe_comparison_operator() {
+            let right = self.parse_arithmetic_expr()?;
+            Ok(Expr::Comparison {
+                op,
+                left: Box::new(left),
+                right: Box::new(right),
+            })
+        } else {
+            Ok(left)
+        }
+    }
+
+    fn parse_arithmetic_expr(&mut self) -> Result<Expr, ParseError> {
+        self.parse_binary_expr(Parser::parse_term_expr, |kind| match kind {
+            TokenKind::Plus => Some(BinaryOp::Add),
+            TokenKind::Minus => Some(BinaryOp::Subtract),
+            _ => None,
+        })
+    }
+
+    fn parse_term_expr(&mut self) -> Result<Expr, ParseError> {
+        self.parse_binary_expr(Parser::parse_unary_expr, |kind| match kind {
+            TokenKind::Star => Some(BinaryOp::Multiply),
+            TokenKind::Slash => Some(BinaryOp::Divide),
+            _ => None,
+        })
+    }
+
+    fn parse_unary_expr(&mut self) -> Result<Expr, ParseError> {
+        if self.matches(|kind| matches!(kind, TokenKind::Minus)) {
+            return Ok(Expr::Unary {
+                op: UnaryOp::Negate,
+                expr: Box::new(self.parse_unary_expr()?),
+            });
+        }
+        self.parse_primary_expr()
+    }
+
+    fn parse_primary_expr(&mut self) -> Result<Expr, ParseError> {
+        let token = self
+            .tokens
+            .get(self.index)
+            .ok_or_else(|| ParseError::new(0, "unexpected end of input"))?;
+
+        match &token.kind {
+            TokenKind::Number(value) => {
+                self.index += 1;
+                Ok(Expr::Number(value.clone()))
+            }
+            TokenKind::String(value) => {
+                self.index += 1;
+                Ok(Expr::String(value.clone()))
+            }
+            TokenKind::Identifier(name) if name == "sum" => self.parse_sum_expr(),
+            TokenKind::Identifier(name) if name == "true" || name == "false" => {
+                self.index += 1;
+                Ok(Expr::Boolean(name == "true"))
+            }
+            TokenKind::Identifier(name)
+                if is_builtin_function(name)
+                    && self
+                        .tokens
+                        .get(self.index + 1)
+                        .is_some_and(|t| matches!(t.kind, TokenKind::LParen)) =>
+            {
+                let name = name.clone();
+                self.index += 2; // consume identifier and LParen
+                let mut args = vec![self.parse_value_expr()?];
+                while self.matches(|kind| matches!(kind, TokenKind::Comma)) {
+                    args.push(self.parse_value_expr()?);
+                }
+                self.expect_token(
+                    |kind| matches!(kind, TokenKind::RParen),
+                    "expected `)` to close function call",
+                )?;
+                Ok(Expr::FunctionCall { name, args })
+            }
+            TokenKind::Identifier(name) => {
+                self.index += 1;
+                if self.matches(|kind| matches!(kind, TokenKind::LBracket)) {
+                    let mut indices = Vec::new();
+                    if !self.matches(|kind| matches!(kind, TokenKind::RBracket)) {
+                        loop {
+                            indices.push(self.parse_value_expr()?);
+                            if self.matches(|kind| matches!(kind, TokenKind::RBracket)) {
+                                break;
+                            }
+                            self.expect_token(
+                                |kind| matches!(kind, TokenKind::Comma),
+                                "expected `,` or `]` in index list",
+                            )?;
+                        }
+                    }
+                    Ok(Expr::Indexed {
+                        target: name.clone(),
+                        indices,
+                    })
+                } else {
+                    Ok(Expr::Identifier(name.clone()))
+                }
+            }
+            TokenKind::LParen => {
+                self.index += 1;
+                let expression = self.parse_value_expr()?;
+                self.expect_token(|kind| matches!(kind, TokenKind::RParen), "expected `)`")?;
+                Ok(expression)
+            }
+            _ => Err(ParseError::new(
+                token.position,
+                "expected a value expression",
+            )),
+        }
+    }
+
+    fn parse_sum_expr(&mut self) -> Result<Expr, ParseError> {
+        self.index += 1;
+        self.expect_token(
+            |kind| matches!(kind, TokenKind::LParen),
+            "expected `(` after `sum`",
+        )?;
+        let body = self.parse_value_expr()?;
+
+        let mut bindings = Vec::new();
+        while self.matches(|kind| matches!(kind, TokenKind::KeywordFor)) {
+            let pattern = if self.matches(|kind| matches!(kind, TokenKind::LParen)) {
+                let mut members = Vec::new();
+                loop {
+                    members.push(self.parse_identifier_name()?);
+                    if self.matches(|kind| matches!(kind, TokenKind::RParen)) {
+                        break;
+                    }
+                    self.expect_token(
+                        |kind| matches!(kind, TokenKind::Comma),
+                        "expected `,` or `)` in tuple binding",
+                    )?;
+                }
+                BindingPattern::Tuple(members)
+            } else {
+                BindingPattern::Name(self.parse_identifier_name()?)
+            };
+            self.expect_token(
+                |kind| matches!(kind, TokenKind::KeywordIn),
+                "expected `in` in reduction binding",
+            )?;
+            bindings.push(Binding {
+                pattern,
+                domain: self.parse_identifier_name()?,
+            });
+        }
+
+        if bindings.is_empty() {
+            let position = self
+                .tokens
+                .get(self.index)
+                .map_or(0, |token| token.position);
+            return Err(ParseError::new(
+                position,
+                "expected at least one `for` binding in reduction",
+            ));
+        }
+
+        let mut filters = Vec::new();
+        while self.matches(|kind| matches!(kind, TokenKind::KeywordIf)) {
+            filters.push(self.parse_value_expr()?);
+        }
+
+        self.expect_token(
+            |kind| matches!(kind, TokenKind::RParen),
+            "expected `)` to close reduction",
+        )?;
+        Ok(Expr::Reduction(ReductionExpr {
+            op: ReductionOp::Sum,
+            body: Box::new(body),
+            bindings,
+            filters,
+        }))
+    }
+
+    fn parse_identifier_name(&mut self) -> Result<String, ParseError> {
+        let token = self
+            .tokens
+            .get(self.index)
+            .ok_or_else(|| ParseError::new(0, "unexpected end of input"))?;
+        if let TokenKind::Identifier(name) = &token.kind {
+            self.index += 1;
+            Ok(name.clone())
+        } else {
+            Err(ParseError::new(token.position, "expected an identifier"))
+        }
+    }
+
+    fn parse_comparison_operator(&mut self) -> Result<ComparisonOp, ParseError> {
+        self.maybe_comparison_operator().ok_or_else(|| {
+            ParseError::new(self.current_position(), "expected a comparison operator")
+        })
+    }
+
+    fn maybe_comparison_operator(&mut self) -> Option<ComparisonOp> {
+        let token = self.tokens.get(self.index)?;
+        let op = match token.kind {
+            TokenKind::Equal => ComparisonOp::Equal,
+            TokenKind::DoubleEqual => ComparisonOp::DoubleEqual,
+            TokenKind::NotEqual => ComparisonOp::NotEqual,
+            TokenKind::Less => ComparisonOp::Less,
+            TokenKind::LessEqual => ComparisonOp::LessEqual,
+            TokenKind::Greater => ComparisonOp::Greater,
+            TokenKind::GreaterEqual => ComparisonOp::GreaterEqual,
+            _ => return None,
+        };
+        self.index += 1;
+        Some(op)
+    }
+
+    fn matches(&mut self, predicate: impl FnOnce(&TokenKind) -> bool) -> bool {
+        if let Some(token) = self.tokens.get(self.index)
+            && predicate(&token.kind)
+        {
+            self.index += 1;
+            return true;
+        }
+        false
+    }
+
+    fn expect_token(
+        &mut self,
+        predicate: impl FnOnce(&TokenKind) -> bool,
+        message: &'static str,
+    ) -> Result<(), ParseError> {
+        let token = self
+            .tokens
+            .get(self.index)
+            .ok_or_else(|| ParseError::new(0, message))?;
+        if predicate(&token.kind) {
+            self.index += 1;
+            Ok(())
+        } else {
+            Err(ParseError::new(token.position, message))
+        }
+    }
+
+    fn parse_binary_expr(
+        &mut self,
+        parse_operand: impl Fn(&mut Self) -> Result<Expr, ParseError>,
+        operator_for: impl Fn(&TokenKind) -> Option<BinaryOp>,
+    ) -> Result<Expr, ParseError> {
+        let mut expression = parse_operand(self)?;
+        while let Some(token) = self.tokens.get(self.index) {
+            let Some(op) = operator_for(&token.kind) else {
+                break;
+            };
+            self.index += 1;
+            let right = parse_operand(self)?;
+            expression = Expr::Binary {
+                op,
+                left: Box::new(expression),
+                right: Box::new(right),
+            };
+        }
+        Ok(expression)
+    }
+
+    fn current_position(&self) -> usize {
+        self.tokens
+            .get(self.index)
+            .map_or(0, |token| token.position)
+    }
+}
+
+fn is_identifier_start(character: char) -> bool {
+    character.is_ascii_alphabetic() || character == '_'
+}
+
+fn is_identifier_continue(character: char) -> bool {
+    character.is_ascii_alphanumeric() || character == '_'
+}
+
+fn collect_named_dependencies(
+    expr: &Expr,
+    bound: &mut BTreeSet<String>,
+    names: &mut BTreeSet<String>,
+) {
+    match expr {
+        Expr::Identifier(name) => {
+            if !bound.contains(name) {
+                names.insert(name.clone());
+            }
+        }
+        Expr::Indexed { indices, .. } => {
+            for index in indices {
+                collect_named_dependencies(index, bound, names);
+            }
+        }
+        Expr::Unary { expr, .. } => collect_named_dependencies(expr, bound, names),
+        Expr::Binary { left, right, .. } | Expr::Comparison { left, right, .. } => {
+            collect_named_dependencies(left, bound, names);
+            collect_named_dependencies(right, bound, names);
+        }
+        Expr::Reduction(reduction) => {
+            let mut local_bound = bound.clone();
+            for binding in &reduction.bindings {
+                match &binding.pattern {
+                    BindingPattern::Name(name) => {
+                        local_bound.insert(name.clone());
+                    }
+                    BindingPattern::Tuple(names) => {
+                        local_bound.extend(names.iter().cloned());
+                    }
+                }
+            }
+            collect_named_dependencies(&reduction.body, &mut local_bound, names);
+            for filter in &reduction.filters {
+                collect_named_dependencies(filter, &mut local_bound, names);
+            }
+        }
+        Expr::FunctionCall { args, .. } => {
+            for arg in args {
+                collect_named_dependencies(arg, bound, names);
+            }
+        }
+        Expr::Number(_) | Expr::String(_) | Expr::Boolean(_) => {}
+    }
+}
+
+fn expr_mentions_previous_time(expr: &Expr) -> bool {
+    match expr {
+        Expr::Indexed { indices, .. } => indices.iter().any(index_mentions_previous_time),
+        Expr::Unary { expr, .. } => expr_mentions_previous_time(expr),
+        Expr::Binary { left, right, .. } | Expr::Comparison { left, right, .. } => {
+            expr_mentions_previous_time(left) || expr_mentions_previous_time(right)
+        }
+        Expr::FunctionCall { args, .. } => args.iter().any(expr_mentions_previous_time),
+        Expr::Reduction(reduction) => {
+            expr_mentions_previous_time(&reduction.body)
+                || reduction.filters.iter().any(expr_mentions_previous_time)
+        }
+        Expr::Number(_) | Expr::String(_) | Expr::Boolean(_) | Expr::Identifier(_) => false,
+    }
+}
+
+fn index_mentions_previous_time(expr: &Expr) -> bool {
+    matches!(
+        expr,
+        Expr::Binary {
+            op: BinaryOp::Subtract,
+            left,
+            right,
+        } if matches!(left.as_ref(), Expr::Identifier(name) if name == "t")
+            && matches!(right.as_ref(), Expr::Number(value) if value == "1")
+    ) || expr_mentions_previous_time(expr)
+}

--- a/crates/arco-kdl/src/lib.rs
+++ b/crates/arco-kdl/src/lib.rs
@@ -1,0 +1,6 @@
+pub mod algebra;
+pub mod lowering;
+pub mod normalize;
+pub mod pipeline;
+pub mod semantic;
+pub mod source;

--- a/crates/arco-kdl/src/lowering.rs
+++ b/crates/arco-kdl/src/lowering.rs
@@ -1,0 +1,2663 @@
+// thiserror's Display derive triggers unused_assignments in edition 2024
+// because derive-generated code no longer inherits item-level #[allow].
+#![allow(unused_assignments)]
+
+use crate::algebra::{BinaryOp, ComparisonOp, ConstraintBody, Expr, UnaryOp};
+use crate::semantic::{
+    FamilySignature, ResolvedConstraint, ResolvedObjective, ResolvedReport, SemanticProgram,
+    VariableDeclOverrides,
+};
+use crate::source::{
+    BoundExpr, GenerationBinding, LiteralValue, ScenarioDecl, SourceProgram, VariableKindDecl,
+};
+use csv::StringRecord;
+use miette::Diagnostic;
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+use tracing::{debug, info};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct LoweredProblem {
+    pub parameters: Vec<LoweredParameter>,
+    pub variables: Vec<LoweredVariable>,
+    pub constraints: Vec<LoweredConstraint>,
+    pub objective: LoweredObjective,
+    pub reports: Vec<LoweredReport>,
+    pub traceability: Vec<TraceabilityRecord>,
+    pub algebra: AlgebraicProblem,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LoweredParameter {
+    pub name: String,
+    pub binding_kind: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LoweredVariable {
+    pub family: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LoweredConstraint {
+    pub name: String,
+    pub source_kind: String,
+    pub source_name: String,
+    pub expression: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LoweredObjective {
+    pub name: String,
+    pub sense: String,
+    pub expression: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LoweredReport {
+    pub name: String,
+    pub formula: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TraceabilityRecord {
+    pub dsl_name: String,
+    pub artifact_kind: String,
+    pub lowered_name: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AlgebraicProblem {
+    pub variable_instances: Vec<VariableInstance>,
+    pub constraints: Vec<LinearConstraint>,
+    pub objective: LinearObjective,
+    pub reports: Vec<LinearReport>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct VariableInstance {
+    pub name: String,
+    pub family: String,
+    pub lower: f64,
+    pub upper: Option<f64>,
+    pub kind: VariableKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum VariableKind {
+    Continuous,
+    Integer,
+    Binary,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct LinearConstraint {
+    pub name: String,
+    pub sense: ConstraintSense,
+    pub rhs: f64,
+    pub terms: Vec<LinearTerm>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ConstraintSense {
+    GreaterEqual,
+    LessEqual,
+    Equal,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct LinearObjective {
+    pub name: String,
+    pub sense: ObjectiveSense,
+    pub constant: f64,
+    pub terms: Vec<LinearTerm>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct LinearReport {
+    pub name: String,
+    pub constant: f64,
+    pub terms: Vec<LinearTerm>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct LinearTerm {
+    pub variable_name: String,
+    pub coefficient: f64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ObjectiveSense {
+    Minimize,
+    Maximize,
+}
+
+#[derive(Debug)]
+struct ScenarioInputs {
+    assets: Vec<AssetInputs>,
+    series: BTreeMap<String, BTreeMap<usize, f64>>,
+    indexed: BTreeMap<String, BTreeMap<(String, usize), f64>>,
+    asset_data: BTreeMap<String, BTreeMap<String, f64>>,
+    set_params: BTreeMap<String, BTreeMap<String, f64>>,
+}
+
+#[derive(Debug)]
+struct AssetInputs {
+    name: String,
+    operation: Option<String>,
+    families: BTreeSet<String>,
+    parameters: BTreeMap<String, f64>,
+    candidate: bool,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct FilterScope<'a> {
+    asset: Option<&'a AssetInputs>,
+    time: Option<usize>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+enum FilterValue {
+    Number(f64),
+    String(String),
+    Boolean(bool),
+}
+
+#[derive(Debug, Error, Diagnostic)]
+pub enum LoweringError {
+    #[error("missing scenario `{name}` during lowering in {path}")]
+    #[diagnostic(
+        code(arco::lowering::missing_scenario),
+        help("ensure semantic validation selected a scenario before lowering")
+    )]
+    MissingScenario { name: String, path: PathBuf },
+    #[error("missing asset `{name}` during lowering in {path}")]
+    #[diagnostic(
+        code(arco::lowering::missing_asset),
+        help("ensure every referenced asset is declared in the input")
+    )]
+    MissingAsset { name: String, path: PathBuf },
+    #[error("missing declaration `{kind}` named `{name}` during lowering in {path}")]
+    #[diagnostic(
+        code(arco::lowering::missing_declaration),
+        help("add the missing declaration or update the lowering reference")
+    )]
+    MissingDeclaration {
+        kind: &'static str,
+        name: String,
+        path: PathBuf,
+    },
+    #[error("missing required parameter `{name}` for asset `{asset}` during lowering in {path}")]
+    #[diagnostic(
+        code(arco::lowering::missing_parameter),
+        help("provide the missing asset parameter before lowering")
+    )]
+    MissingParameter {
+        name: String,
+        asset: String,
+        path: PathBuf,
+    },
+    #[error("missing required data `{name}` during lowering in {path}")]
+    #[diagnostic(
+        code(arco::lowering::missing_data),
+        help("bind the required scenario data before lowering")
+    )]
+    MissingData { name: String, path: PathBuf },
+    #[error("missing required data point `{name}` for key `{key}` during lowering in {path}")]
+    #[diagnostic(
+        code(arco::lowering::missing_data_point),
+        help("fill in the missing data point in the input tables")
+    )]
+    MissingDataPoint {
+        name: String,
+        key: String,
+        path: PathBuf,
+    },
+    #[error("failed to read csv {path}: {source}")]
+    #[diagnostic(
+        code(arco::lowering::csv),
+        help("verify the CSV path exists and is readable")
+    )]
+    Csv {
+        path: PathBuf,
+        #[source]
+        source: csv::Error,
+    },
+    #[error("failed to parse numeric value `{value}` for `{field}` in {path}")]
+    #[diagnostic(
+        code(arco::lowering::invalid_number),
+        help("replace the non-numeric value with a valid number")
+    )]
+    InvalidNumber {
+        value: String,
+        field: String,
+        path: PathBuf,
+    },
+    #[error("missing required column `{column}` in {path}")]
+    #[diagnostic(
+        code(arco::lowering::missing_column),
+        help("add the missing CSV column or update the mapping")
+    )]
+    MissingColumn { column: String, path: PathBuf },
+    #[error("constraint filter for `{constraint}` is invalid during lowering in {path}: {message}")]
+    #[diagnostic(
+        code(arco::lowering::invalid_constraint_filter),
+        help(
+            "use only numeric, boolean, or string comparisons over names available in the current asset/time scope"
+        )
+    )]
+    InvalidConstraintFilter {
+        constraint: String,
+        message: String,
+        path: PathBuf,
+    },
+    #[error("invalid formulation during lowering in {path}: {message}")]
+    #[diagnostic(
+        code(arco::lowering::invalid_formulation),
+        help(
+            "rewrite the algebra so every constraint, objective term, and report remains linear over supported domains"
+        )
+    )]
+    InvalidFormulation { message: String, path: PathBuf },
+}
+
+pub fn lower_program(
+    program: &SemanticProgram,
+    source_program: &SourceProgram,
+    entrypoint: &Path,
+) -> Result<LoweredProblem, LoweringError> {
+    info!("lowering program");
+
+    let scenario = source_program
+        .scenario(&program.active_scenario)
+        .ok_or_else(|| LoweringError::MissingScenario {
+            name: program.active_scenario.clone(),
+            path: entrypoint.to_path_buf(),
+        })?;
+    let mut inputs = load_inputs(program, source_program, scenario, entrypoint)?;
+    inputs.set_params = program.set_params.clone();
+    let algebra = lower_algebra(program, &inputs, entrypoint)?;
+
+    let parameters = [
+        ("series", &program.parameters.series),
+        ("indexed", &program.parameters.indexed),
+        ("asset", &program.parameters.asset),
+    ]
+    .into_iter()
+    .flat_map(|(kind, names)| {
+        names.iter().map(move |name| LoweredParameter {
+            name: name.clone(),
+            binding_kind: kind.to_string(),
+        })
+    })
+    .collect::<Vec<_>>();
+
+    let variables = program
+        .variable_families
+        .iter()
+        .map(|family| LoweredVariable {
+            family: family.render(),
+        })
+        .collect::<Vec<_>>();
+
+    let constraints = program
+        .active_constraints
+        .iter()
+        .map(lower_constraint)
+        .collect::<Vec<_>>();
+    let objective = lower_objective(&program.active_objective);
+    let reports = program
+        .active_reports
+        .iter()
+        .map(lower_report)
+        .collect::<Vec<_>>();
+
+    let mut traceability = Vec::new();
+    traceability.extend(variables.iter().map(|variable| TraceabilityRecord {
+        dsl_name: variable.family.clone(),
+        artifact_kind: "variable".to_string(),
+        lowered_name: variable.family.clone(),
+    }));
+    traceability.push(TraceabilityRecord {
+        dsl_name: objective.name.clone(),
+        artifact_kind: "objective".to_string(),
+        lowered_name: objective.name.clone(),
+    });
+    traceability.extend(reports.iter().map(|report| TraceabilityRecord {
+        dsl_name: report.name.clone(),
+        artifact_kind: "report".to_string(),
+        lowered_name: report.name.clone(),
+    }));
+
+    let lowered = LoweredProblem {
+        parameters,
+        variables,
+        constraints,
+        objective,
+        reports,
+        traceability,
+        algebra,
+    };
+    debug!(
+        "generated {} variables, {} constraints, {} reports",
+        lowered.algebra.variable_instances.len(),
+        lowered.algebra.constraints.len(),
+        lowered.reports.len()
+    );
+
+    Ok(lowered)
+}
+
+fn lower_constraint(constraint: &ResolvedConstraint) -> LoweredConstraint {
+    LoweredConstraint {
+        name: constraint.name.clone(),
+        source_kind: constraint.source_kind.clone(),
+        source_name: constraint.source_name.clone(),
+        expression: constraint.expression_text.clone(),
+    }
+}
+
+fn lower_objective(objective: &ResolvedObjective) -> LoweredObjective {
+    LoweredObjective {
+        name: objective.name.clone(),
+        sense: objective.sense.clone(),
+        expression: objective.expression_text.clone(),
+    }
+}
+
+fn lower_report(report: &ResolvedReport) -> LoweredReport {
+    LoweredReport {
+        name: report.name.clone(),
+        formula: report.formula_text.clone(),
+    }
+}
+
+fn evaluate_constraint_filter(
+    expr: &Expr,
+    constraint: &ResolvedConstraint,
+    scope: FilterScope<'_>,
+    inputs: &ScenarioInputs,
+    path: &Path,
+) -> Result<bool, LoweringError> {
+    let value = evaluate_filter_expr(expr, constraint, scope, inputs, path)?;
+    truthy_filter_value(&value, constraint, path)
+}
+
+fn evaluate_filter_expr(
+    expr: &Expr,
+    constraint: &ResolvedConstraint,
+    scope: FilterScope<'_>,
+    inputs: &ScenarioInputs,
+    path: &Path,
+) -> Result<FilterValue, LoweringError> {
+    match expr {
+        Expr::Number(value) => value
+            .parse::<f64>()
+            .map(FilterValue::Number)
+            .map_err(|_| invalid_constraint_filter(constraint, path, "numeric literal is invalid")),
+        Expr::String(value) => Ok(FilterValue::String(value.clone())),
+        Expr::Boolean(value) => Ok(FilterValue::Boolean(*value)),
+        Expr::Identifier(name) => evaluate_identifier(name, constraint, scope, path),
+        Expr::Indexed { target, indices } => {
+            evaluate_indexed_value(target, indices, constraint, scope, inputs, path)
+        }
+        Expr::Unary { op, expr } => {
+            let value = evaluate_filter_expr(expr, constraint, scope, inputs, path)?;
+            match op {
+                UnaryOp::Negate => Ok(FilterValue::Number(-numeric_filter_value(
+                    &value, constraint, path,
+                )?)),
+            }
+        }
+        Expr::Binary { op, left, right } => {
+            let left = evaluate_filter_expr(left, constraint, scope, inputs, path)?;
+            let right = evaluate_filter_expr(right, constraint, scope, inputs, path)?;
+            let left = numeric_filter_value(&left, constraint, path)?;
+            let right = numeric_filter_value(&right, constraint, path)?;
+            let value = match op {
+                BinaryOp::Add => left + right,
+                BinaryOp::Subtract => left - right,
+                BinaryOp::Multiply => left * right,
+                BinaryOp::Divide => left / right,
+            };
+            Ok(FilterValue::Number(value))
+        }
+        Expr::Comparison { op, left, right } => {
+            let left = evaluate_filter_expr(left, constraint, scope, inputs, path)?;
+            let right = evaluate_filter_expr(right, constraint, scope, inputs, path)?;
+            Ok(FilterValue::Boolean(compare_filter_values(
+                *op, &left, &right, constraint, path,
+            )?))
+        }
+        Expr::FunctionCall { .. } => Err(invalid_constraint_filter(
+            constraint,
+            path,
+            "function calls are not supported in constraint filters",
+        )),
+        Expr::Reduction(_) => Err(invalid_constraint_filter(
+            constraint,
+            path,
+            "reductions are not supported in constraint filters",
+        )),
+    }
+}
+
+fn evaluate_identifier(
+    name: &str,
+    constraint: &ResolvedConstraint,
+    scope: FilterScope<'_>,
+    path: &Path,
+) -> Result<FilterValue, LoweringError> {
+    match name {
+        "a" => scope
+            .asset
+            .map(|asset| FilterValue::String(asset.name.clone()))
+            .ok_or_else(|| invalid_constraint_filter(constraint, path, "`a` is not in scope")),
+        "t" => scope
+            .time
+            .map(|time| FilterValue::Number(time as f64))
+            .ok_or_else(|| invalid_constraint_filter(constraint, path, "`t` is not in scope")),
+        "candidate" => scope
+            .asset
+            .map(|asset| FilterValue::Boolean(asset.candidate))
+            .ok_or_else(|| {
+                invalid_constraint_filter(constraint, path, "`candidate` is not in scope")
+            }),
+        other => scope
+            .asset
+            .and_then(|asset| asset.parameters.get(other).copied())
+            .map(FilterValue::Number)
+            .ok_or_else(|| {
+                invalid_constraint_filter(
+                    constraint,
+                    path,
+                    format!("`{other}` is not available in the current filter scope"),
+                )
+            }),
+    }
+}
+
+fn evaluate_indexed_value(
+    target: &str,
+    indices: &[Expr],
+    constraint: &ResolvedConstraint,
+    scope: FilterScope<'_>,
+    inputs: &ScenarioInputs,
+    path: &Path,
+) -> Result<FilterValue, LoweringError> {
+    let values = indices
+        .iter()
+        .map(|index| evaluate_filter_expr(index, constraint, scope, inputs, path))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    match values.as_slice() {
+        [index] => {
+            if let FilterValue::String(asset_name) = index {
+                if target == "candidate" {
+                    return find_asset(inputs, asset_name)
+                        .map(|asset| FilterValue::Boolean(asset.candidate))
+                        .ok_or_else(|| {
+                            invalid_constraint_filter(
+                                constraint,
+                                path,
+                                format!("asset `{asset_name}` is not available"),
+                            )
+                        });
+                }
+                if let Some(value) = asset_parameter_value(inputs, target, asset_name) {
+                    return Ok(FilterValue::Number(value));
+                }
+                if let Some(value) = inputs
+                    .asset_data
+                    .get(target)
+                    .and_then(|values| values.get(asset_name))
+                    .copied()
+                {
+                    return Ok(FilterValue::Number(value));
+                }
+                Err(invalid_constraint_filter(
+                    constraint,
+                    path,
+                    format!("`{target}[{asset_name}]` is not available"),
+                ))
+            } else {
+                let time = usize_filter_value(index, constraint, path)?;
+                inputs
+                    .series
+                    .get(target)
+                    .and_then(|values| values.get(&time))
+                    .copied()
+                    .map(FilterValue::Number)
+                    .ok_or_else(|| {
+                        invalid_constraint_filter(
+                            constraint,
+                            path,
+                            format!("`{target}[{time}]` is not available"),
+                        )
+                    })
+            }
+        }
+        [asset_name, time] => {
+            let asset_name = string_filter_value(asset_name, constraint, path)?;
+            let time = usize_filter_value(time, constraint, path)?;
+            inputs
+                .indexed
+                .get(target)
+                .and_then(|values| values.get(&(asset_name.clone(), time)))
+                .copied()
+                .map(FilterValue::Number)
+                .ok_or_else(|| {
+                    invalid_constraint_filter(
+                        constraint,
+                        path,
+                        format!("`{target}[{asset_name},{time}]` is not available"),
+                    )
+                })
+        }
+        _ => Err(invalid_constraint_filter(
+            constraint,
+            path,
+            "constraint filters support only one-dimensional asset/time lookups and two-dimensional asset-time lookups",
+        )),
+    }
+}
+
+fn compare_filter_values(
+    op: ComparisonOp,
+    left: &FilterValue,
+    right: &FilterValue,
+    constraint: &ResolvedConstraint,
+    path: &Path,
+) -> Result<bool, LoweringError> {
+    match op {
+        ComparisonOp::Equal | ComparisonOp::DoubleEqual => {
+            compare_for_equality(left, right, constraint, path)
+        }
+        ComparisonOp::NotEqual => {
+            compare_for_equality(left, right, constraint, path).map(|value| !value)
+        }
+        ComparisonOp::Less
+        | ComparisonOp::LessEqual
+        | ComparisonOp::Greater
+        | ComparisonOp::GreaterEqual => {
+            let left = numeric_filter_value(left, constraint, path)?;
+            let right = numeric_filter_value(right, constraint, path)?;
+            Ok(match op {
+                ComparisonOp::Less => left < right,
+                ComparisonOp::LessEqual => left <= right,
+                ComparisonOp::Greater => left > right,
+                ComparisonOp::GreaterEqual => left >= right,
+                ComparisonOp::Equal | ComparisonOp::DoubleEqual | ComparisonOp::NotEqual => {
+                    unreachable!()
+                }
+            })
+        }
+    }
+}
+
+fn compare_for_equality(
+    left: &FilterValue,
+    right: &FilterValue,
+    constraint: &ResolvedConstraint,
+    path: &Path,
+) -> Result<bool, LoweringError> {
+    match (left, right) {
+        (FilterValue::String(left), FilterValue::String(right)) => Ok(left == right),
+        (FilterValue::Boolean(left), FilterValue::Boolean(right)) => Ok(left == right),
+        _ => {
+            let left = numeric_filter_value(left, constraint, path)?;
+            let right = numeric_filter_value(right, constraint, path)?;
+            Ok((left - right).abs() < f64::EPSILON)
+        }
+    }
+}
+
+fn truthy_filter_value(
+    value: &FilterValue,
+    constraint: &ResolvedConstraint,
+    path: &Path,
+) -> Result<bool, LoweringError> {
+    match value {
+        FilterValue::Boolean(value) => Ok(*value),
+        FilterValue::Number(value) => Ok(*value != 0.0),
+        FilterValue::String(_) => Err(invalid_constraint_filter(
+            constraint,
+            path,
+            "string-valued filters must be used inside an explicit comparison",
+        )),
+    }
+}
+
+fn numeric_filter_value(
+    value: &FilterValue,
+    constraint: &ResolvedConstraint,
+    path: &Path,
+) -> Result<f64, LoweringError> {
+    match value {
+        FilterValue::Number(value) => Ok(*value),
+        FilterValue::Boolean(value) => Ok(if *value { 1.0 } else { 0.0 }),
+        FilterValue::String(_) => Err(invalid_constraint_filter(
+            constraint,
+            path,
+            "numeric operations in constraint filters require numeric or boolean values",
+        )),
+    }
+}
+
+fn string_filter_value(
+    value: &FilterValue,
+    constraint: &ResolvedConstraint,
+    path: &Path,
+) -> Result<String, LoweringError> {
+    match value {
+        FilterValue::String(value) => Ok(value.clone()),
+        _ => Err(invalid_constraint_filter(
+            constraint,
+            path,
+            "asset-indexed lookups require a string asset name",
+        )),
+    }
+}
+
+fn usize_filter_value(
+    value: &FilterValue,
+    constraint: &ResolvedConstraint,
+    path: &Path,
+) -> Result<usize, LoweringError> {
+    let number = numeric_filter_value(value, constraint, path)?;
+    if number.fract() == 0.0 && number >= 0.0 {
+        Ok(number as usize)
+    } else {
+        Err(invalid_constraint_filter(
+            constraint,
+            path,
+            "time-indexed lookups require a non-negative integer time index",
+        ))
+    }
+}
+
+fn find_asset<'a>(inputs: &'a ScenarioInputs, name: &str) -> Option<&'a AssetInputs> {
+    inputs.assets.iter().find(|asset| asset.name == name)
+}
+
+fn asset_parameter_value(
+    inputs: &ScenarioInputs,
+    parameter: &str,
+    asset_name: &str,
+) -> Option<f64> {
+    find_asset(inputs, asset_name).and_then(|asset| asset.parameters.get(parameter).copied())
+}
+
+fn invalid_constraint_filter(
+    constraint: &ResolvedConstraint,
+    path: &Path,
+    message: impl Into<String>,
+) -> LoweringError {
+    LoweringError::InvalidConstraintFilter {
+        constraint: format!(
+            "{}:{}:{}",
+            constraint.source_kind, constraint.source_name, constraint.name
+        ),
+        message: message.into(),
+        path: path.to_path_buf(),
+    }
+}
+
+fn load_inputs(
+    program: &SemanticProgram,
+    source_program: &SourceProgram,
+    scenario: &ScenarioDecl,
+    entrypoint: &Path,
+) -> Result<ScenarioInputs, LoweringError> {
+    let entry_dir = entrypoint
+        .parent()
+        .ok_or_else(|| LoweringError::MissingScenario {
+            name: program.active_scenario.clone(),
+            path: entrypoint.to_path_buf(),
+        })?;
+
+    let mut assets = Vec::new();
+    let has_model = scenario.model_use.is_some();
+    for asset_name in &scenario.assets {
+        match source_program.asset(asset_name) {
+            Some(asset) => {
+                let parameters = asset
+                    .parameters
+                    .iter()
+                    .map(|(name, value)| {
+                        literal_to_f64(name, value, entrypoint).map(|parsed| (name.clone(), parsed))
+                    })
+                    .collect::<Result<BTreeMap<_, _>, _>>()?;
+                let families = technology_families(source_program, &asset.technology, entrypoint)?;
+                assets.push(AssetInputs {
+                    name: asset.name.clone(),
+                    operation: asset.operation.clone(),
+                    families,
+                    parameters,
+                    candidate: false,
+                });
+            }
+            None if has_model => {
+                // Model-path assets declared inline in the scenario don't have
+                // top-level asset declarations. Create a bare entry; the model
+                // block below will assign control families.
+                assets.push(AssetInputs {
+                    name: asset_name.clone(),
+                    operation: None,
+                    families: BTreeSet::new(),
+                    parameters: BTreeMap::new(),
+                    candidate: false,
+                });
+            }
+            None => {
+                return Err(LoweringError::MissingDeclaration {
+                    kind: "asset",
+                    name: asset_name.clone(),
+                    path: entrypoint.to_path_buf(),
+                });
+            }
+        }
+    }
+
+    for instances_name in &scenario.instances {
+        let instances = source_program.instances(instances_name).ok_or_else(|| {
+            LoweringError::MissingDeclaration {
+                kind: "instances",
+                name: instances_name.clone(),
+                path: entrypoint.to_path_buf(),
+            }
+        })?;
+        let csv_path = entry_dir.join(&instances.source);
+        let rows = read_csv_rows(&csv_path)?;
+        let name_column = if instances.columns.is_empty() {
+            "asset_name".to_string()
+        } else {
+            instances
+                .columns
+                .iter()
+                .find(|column| column.target == "name")
+                .map(|column| column.source.clone())
+                .ok_or_else(|| LoweringError::MissingColumn {
+                    column: "name".to_string(),
+                    path: csv_path.clone(),
+                })?
+        };
+
+        for row in &rows {
+            let asset_name =
+                row.get(&name_column)
+                    .cloned()
+                    .ok_or_else(|| LoweringError::MissingColumn {
+                        column: name_column.clone(),
+                        path: csv_path.clone(),
+                    })?;
+            let mut parameters = BTreeMap::new();
+            if instances.columns.is_empty() {
+                // Auto-map: every column except the identity becomes a parameter.
+                for (col_name, raw_value) in row {
+                    if col_name == &name_column {
+                        continue;
+                    }
+                    let parsed =
+                        raw_value
+                            .parse::<f64>()
+                            .map_err(|_| LoweringError::InvalidNumber {
+                                value: raw_value.clone(),
+                                field: col_name.clone(),
+                                path: csv_path.clone(),
+                            })?;
+                    parameters.insert(col_name.clone(), parsed);
+                }
+            } else {
+                for column in &instances.columns {
+                    if column.target == "name" {
+                        continue;
+                    }
+                    let raw_value = row.get(&column.source).cloned().ok_or_else(|| {
+                        LoweringError::MissingColumn {
+                            column: column.source.clone(),
+                            path: csv_path.clone(),
+                        }
+                    })?;
+                    let parsed =
+                        raw_value
+                            .parse::<f64>()
+                            .map_err(|_| LoweringError::InvalidNumber {
+                                value: raw_value,
+                                field: column.target.clone(),
+                                path: csv_path.clone(),
+                            })?;
+                    parameters.insert(column.target.clone(), parsed);
+                }
+            }
+            let families = technology_families(source_program, &instances.technology, entrypoint)?;
+            assets.push(AssetInputs {
+                name: asset_name,
+                operation: instances.operation.clone(),
+                families,
+                parameters,
+                candidate: instances.name.starts_with("Candidate"),
+            });
+        }
+    }
+
+    if let Some(model_name) = &scenario.model_use {
+        let model =
+            source_program
+                .model(model_name)
+                .ok_or_else(|| LoweringError::MissingDeclaration {
+                    kind: "model",
+                    name: model_name.clone(),
+                    path: entrypoint.to_path_buf(),
+                })?;
+
+        let model_families: BTreeSet<String> = model
+            .controls
+            .iter()
+            .map(|control| control.name.clone())
+            .collect();
+
+        if assets.is_empty() {
+            // No explicit assets: create a synthetic default asset.
+            if !model_families.is_empty() {
+                assets.push(AssetInputs {
+                    name: "default".to_string(),
+                    operation: None,
+                    families: model_families,
+                    parameters: BTreeMap::new(),
+                    candidate: false,
+                });
+            }
+        } else {
+            // Explicit assets declared: assign model control families to each.
+            for asset in &mut assets {
+                asset.families.clone_from(&model_families);
+            }
+        }
+    }
+
+    assets.sort_by(|a, b| a.name.cmp(&b.name));
+
+    let mut series = BTreeMap::new();
+    let mut indexed = BTreeMap::new();
+    let mut asset_data = BTreeMap::new();
+    for binding in &scenario.data {
+        let csv_path = entry_dir.join(&binding.source);
+        let rows = read_csv_rows(&csv_path)?;
+        let Some(first_row) = rows.first() else {
+            return Err(LoweringError::MissingData {
+                name: binding.name.clone(),
+                path: csv_path,
+            });
+        };
+        let headers = first_row.keys().cloned().collect::<BTreeSet<_>>();
+        if headers.contains("asset_name") && headers.contains("t") {
+            let mut values = BTreeMap::new();
+            for row in &rows {
+                let asset_name =
+                    row.get("asset_name")
+                        .cloned()
+                        .ok_or_else(|| LoweringError::MissingColumn {
+                            column: "asset_name".to_string(),
+                            path: csv_path.clone(),
+                        })?;
+                let time = parse_usize_field(row, "t", &csv_path)?;
+                let value = parse_data_value(row, &binding.name, &csv_path)?;
+                values.insert((asset_name, time), value);
+            }
+            indexed.insert(binding.name.clone(), values);
+        } else if headers.contains("asset_name") {
+            let mut values = BTreeMap::new();
+            for row in &rows {
+                let asset_name =
+                    row.get("asset_name")
+                        .cloned()
+                        .ok_or_else(|| LoweringError::MissingColumn {
+                            column: "asset_name".to_string(),
+                            path: csv_path.clone(),
+                        })?;
+                let value = parse_data_value(row, &binding.name, &csv_path)?;
+                values.insert(asset_name, value);
+            }
+            asset_data.insert(binding.name.clone(), values);
+        } else if headers.contains("t") {
+            let mut values = BTreeMap::new();
+            for row in &rows {
+                let time = parse_usize_field(row, "t", &csv_path)?;
+                let value = parse_data_value(row, &binding.name, &csv_path)?;
+                values.insert(time, value);
+            }
+            series.insert(binding.name.clone(), values);
+        } else {
+            return Err(LoweringError::MissingData {
+                name: binding.name.clone(),
+                path: csv_path,
+            });
+        }
+    }
+
+    Ok(ScenarioInputs {
+        assets,
+        series,
+        indexed,
+        asset_data,
+        set_params: BTreeMap::new(),
+    })
+}
+
+fn technology_families(
+    source_program: &SourceProgram,
+    technology_name: &str,
+    path: &Path,
+) -> Result<BTreeSet<String>, LoweringError> {
+    let technology = source_program.technology(technology_name).ok_or_else(|| {
+        LoweringError::MissingDeclaration {
+            kind: "technology",
+            name: technology_name.to_string(),
+            path: path.to_path_buf(),
+        }
+    })?;
+    Ok(technology
+        .investments
+        .iter()
+        .map(|i| i.name.clone())
+        .chain(technology.controls.iter().map(|c| c.name.clone()))
+        .chain(technology.states.iter().cloned())
+        .collect())
+}
+
+#[derive(Debug, Clone, Default)]
+struct AffineExpr {
+    constant: f64,
+    terms: BTreeMap<String, f64>,
+}
+
+#[derive(Debug, Clone, Default)]
+struct LinearizationBindings {
+    values: BTreeMap<String, FilterValue>,
+}
+
+fn lower_algebra(
+    program: &SemanticProgram,
+    inputs: &ScenarioInputs,
+    entrypoint: &Path,
+) -> Result<AlgebraicProblem, LoweringError> {
+    let named_expressions = program
+        .active_expressions
+        .iter()
+        .map(|expression| (expression.name.clone(), expression.formula.clone()))
+        .collect::<BTreeMap<_, _>>();
+    let variable_signatures = program
+        .variable_families
+        .iter()
+        .map(|family| (family.render(), family.clone()))
+        .collect::<BTreeMap<_, _>>();
+
+    let mut variable_instances =
+        instantiate_variable_instances(program, inputs, &variable_signatures, entrypoint)?;
+    let instantiated_names: BTreeSet<String> =
+        variable_instances.iter().map(|i| i.name.clone()).collect();
+    let mut constraints = lower_constraint_instances(
+        program,
+        inputs,
+        &named_expressions,
+        &variable_signatures,
+        &instantiated_names,
+        entrypoint,
+    )?;
+    constraints.extend(emit_terminal_boundary_constraints(
+        program,
+        inputs,
+        &variable_signatures,
+        entrypoint,
+    )?);
+
+    let objective = linearize_value_expr(
+        &program.active_objective.expression,
+        &LinearizationBindings::default(),
+        program,
+        inputs,
+        &named_expressions,
+        &variable_signatures,
+        &instantiated_names,
+        entrypoint,
+    )?;
+    let reports = program
+        .active_reports
+        .iter()
+        .map(|report| {
+            linearize_value_expr(
+                &report.formula,
+                &LinearizationBindings::default(),
+                program,
+                inputs,
+                &named_expressions,
+                &variable_signatures,
+                &instantiated_names,
+                entrypoint,
+            )
+            .map(|linearized| LinearReport {
+                name: report.name.clone(),
+                constant: linearized.constant,
+                terms: linearized.into_terms(),
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    variable_instances.sort_by(|a, b| a.name.cmp(&b.name));
+    constraints.sort_by(|a, b| a.name.cmp(&b.name));
+
+    Ok(AlgebraicProblem {
+        variable_instances,
+        constraints,
+        objective: LinearObjective {
+            name: program.active_objective.name.clone(),
+            sense: objective_sense(&program.active_objective.sense),
+            constant: objective.constant,
+            terms: objective.into_terms(),
+        },
+        reports,
+    })
+}
+
+impl AffineExpr {
+    fn constant(value: f64) -> Self {
+        Self {
+            constant: value,
+            terms: BTreeMap::new(),
+        }
+    }
+
+    fn variable(name: String, coefficient: f64) -> Self {
+        let mut terms = BTreeMap::new();
+        terms.insert(name, coefficient);
+        Self {
+            constant: 0.0,
+            terms,
+        }
+    }
+
+    fn add_assign(&mut self, other: Self) {
+        self.constant += other.constant;
+        for (name, coefficient) in other.terms {
+            let entry = self.terms.entry(name).or_default();
+            *entry += coefficient;
+        }
+        self.terms
+            .retain(|_, coefficient| coefficient.abs() >= 1e-12);
+    }
+
+    fn subtract(self, other: Self) -> Self {
+        let mut value = self;
+        value.add_assign(other.scale(-1.0));
+        value
+    }
+
+    fn scale(mut self, factor: f64) -> Self {
+        self.constant *= factor;
+        for coefficient in self.terms.values_mut() {
+            *coefficient *= factor;
+        }
+        self.terms
+            .retain(|_, coefficient| coefficient.abs() >= 1e-12);
+        self
+    }
+
+    fn as_scalar(&self, path: &Path, context: &str) -> Result<f64, LoweringError> {
+        if self.terms.is_empty() {
+            Ok(self.constant)
+        } else {
+            Err(LoweringError::InvalidFormulation {
+                message: format!("{context} must remain scalar"),
+                path: path.to_path_buf(),
+            })
+        }
+    }
+
+    fn into_terms(self) -> Vec<LinearTerm> {
+        self.terms
+            .into_iter()
+            .filter(|(_, coefficient)| coefficient.abs() >= 1e-12)
+            .map(|(variable_name, coefficient)| LinearTerm {
+                variable_name,
+                coefficient,
+            })
+            .collect()
+    }
+}
+
+fn instantiate_variable_instances(
+    program: &SemanticProgram,
+    inputs: &ScenarioInputs,
+    variable_signatures: &BTreeMap<String, FamilySignature>,
+    entrypoint: &Path,
+) -> Result<Vec<VariableInstance>, LoweringError> {
+    let mut instances = Vec::new();
+    for (family, signature) in variable_signatures {
+        let overrides = program.variable_overrides.get(&signature.target);
+        match signature.indices.as_slice() {
+            [asset_index, time_index] if asset_index == "a" && time_index == "t" => {
+                for asset in &inputs.assets {
+                    if !variable_instance_is_active(&signature.target, Some(asset)) {
+                        continue;
+                    }
+                    for time in 1..=program.sets.time.steps {
+                        instances.push(variable_instance_from_signature(
+                            family,
+                            signature,
+                            Some(asset),
+                            Some(time),
+                            overrides,
+                            entrypoint,
+                        )?);
+                    }
+                }
+            }
+            [asset_index] if asset_index == "a" => {
+                for asset in &inputs.assets {
+                    if !variable_instance_is_active(&signature.target, Some(asset)) {
+                        continue;
+                    }
+                    instances.push(variable_instance_from_signature(
+                        family,
+                        signature,
+                        Some(asset),
+                        None,
+                        overrides,
+                        entrypoint,
+                    )?);
+                }
+            }
+            [time_index] if time_index == "t" => {
+                for time in 1..=program.sets.time.steps {
+                    instances.push(variable_instance_from_signature(
+                        family,
+                        signature,
+                        None,
+                        Some(time),
+                        overrides,
+                        entrypoint,
+                    )?);
+                }
+            }
+            _ => {
+                // Try to resolve custom index domains via the set registry.
+                let resolved = resolve_custom_index_domains(
+                    signature, program, inputs, family, overrides, entrypoint,
+                )?;
+                instances.extend(resolved);
+            }
+        }
+    }
+    Ok(instances)
+}
+
+/// Expand variable instances for families with custom index domains that
+/// don't match the built-in "a"/"t" patterns. Each index is resolved by
+/// checking its explicit domain binding (from `IndexDecl`) or falling back
+/// to the set_registry. Indices bound to "time" produce numeric time steps;
+/// all others produce string-named instances.
+fn resolve_custom_index_domains(
+    signature: &FamilySignature,
+    program: &SemanticProgram,
+    inputs: &ScenarioInputs,
+    family: &str,
+    overrides: Option<&VariableDeclOverrides>,
+    entrypoint: &Path,
+) -> Result<Vec<VariableInstance>, LoweringError> {
+    // Resolve each index to its domain values.
+    let mut domain_values: Vec<Vec<String>> = Vec::new();
+    for index_name in &signature.indices {
+        let values = resolve_single_index_domain(
+            index_name, signature, program, inputs, family, entrypoint,
+        )?;
+        domain_values.push(values);
+    }
+
+    // Cartesian product of all domain values.
+    let mut combos: Vec<Vec<String>> = vec![vec![]];
+    for values in &domain_values {
+        let mut next = Vec::new();
+        for combo in &combos {
+            for value in values {
+                let mut extended = combo.clone();
+                extended.push(value.clone());
+                next.push(extended);
+            }
+        }
+        combos = next;
+    }
+
+    let mut instances = Vec::new();
+    for combo in &combos {
+        let name = format!("{}[{}]", signature.target, combo.join(","));
+        let (lower, upper, kind) =
+            variable_domain_policy(&signature.target, None, overrides, entrypoint)?;
+        instances.push(VariableInstance {
+            name,
+            family: family.to_string(),
+            lower,
+            upper,
+            kind,
+        });
+    }
+    Ok(instances)
+}
+
+/// Resolve values for a single index. Checks the signature's explicit domain
+/// binding first, then falls back to known index names ("a" -> assets,
+/// "t" -> time), and finally looks up any set matching the index name in
+/// the registry.
+fn resolve_single_index_domain(
+    index_name: &str,
+    signature: &FamilySignature,
+    program: &SemanticProgram,
+    inputs: &ScenarioInputs,
+    family: &str,
+    entrypoint: &Path,
+) -> Result<Vec<String>, LoweringError> {
+    // Check explicit domain binding from IndexDecl.
+    if let Some(domain) = signature.index_domains.get(index_name) {
+        if domain == "time" {
+            return Ok((1..=program.sets.time.steps)
+                .map(|t| t.to_string())
+                .collect());
+        }
+        if domain == "assets" {
+            return Ok(inputs.assets.iter().map(|a| a.name.clone()).collect());
+        }
+        if let Some(set) = program.set_registry.get(domain.as_str()) {
+            return Ok(set.values.clone());
+        }
+        return Err(LoweringError::InvalidFormulation {
+            message: format!(
+                "index `{index_name}` in `{family}` references unknown set `{domain}`"
+            ),
+            path: entrypoint.to_path_buf(),
+        });
+    }
+
+    // Fallback: infer from conventional index names.
+    match index_name {
+        "a" => Ok(inputs.assets.iter().map(|a| a.name.clone()).collect()),
+        "t" => Ok((1..=program.sets.time.steps)
+            .map(|t| t.to_string())
+            .collect()),
+        _ => {
+            // Last resort: check if the index name itself is a set in the registry.
+            if let Some(set) = program.set_registry.get(index_name) {
+                return Ok(set.values.clone());
+            }
+            Err(LoweringError::InvalidFormulation {
+                message: format!("unsupported variable family domain `{family}`"),
+                path: entrypoint.to_path_buf(),
+            })
+        }
+    }
+}
+
+fn variable_instance_from_signature(
+    family: &str,
+    signature: &FamilySignature,
+    asset: Option<&AssetInputs>,
+    time: Option<usize>,
+    overrides: Option<&VariableDeclOverrides>,
+    entrypoint: &Path,
+) -> Result<VariableInstance, LoweringError> {
+    let (lower, upper, kind) =
+        variable_domain_policy(&signature.target, asset, overrides, entrypoint)?;
+    let name = match (asset, time) {
+        (Some(asset), Some(time)) => indexed_name(&signature.target, &asset.name, time),
+        (Some(asset), None) => asset_indexed_name(&signature.target, &asset.name),
+        (None, Some(time)) => time_name(&signature.target, time),
+        (None, None) => signature.target.clone(),
+    };
+    Ok(VariableInstance {
+        name,
+        family: family.to_string(),
+        lower,
+        upper,
+        kind,
+    })
+}
+
+fn variable_domain_policy(
+    target: &str,
+    asset: Option<&AssetInputs>,
+    overrides: Option<&VariableDeclOverrides>,
+    path: &Path,
+) -> Result<(f64, Option<f64>, VariableKind), LoweringError> {
+    let (mut lower, mut upper, mut kind) = match target {
+        "build" => (
+            0.0,
+            Some(asset_parameter(
+                asset.ok_or_else(|| LoweringError::InvalidFormulation {
+                    message: "`build[a]` requires an asset scope".to_string(),
+                    path: path.to_path_buf(),
+                })?,
+                "max_build",
+                path,
+            )?),
+            VariableKind::Continuous,
+        ),
+        "unserved_energy" => (0.0, None, VariableKind::Continuous),
+        "charge" | "discharge" | "generation" => (0.0, None, VariableKind::Continuous),
+        "dispatch" => (
+            if asset.is_some_and(|asset| has_asset_parameter(asset, "energy_mwh")) {
+                f64::NEG_INFINITY
+            } else {
+                0.0
+            },
+            None,
+            VariableKind::Continuous,
+        ),
+        "commit" | "start" | "shutdown" => (0.0, Some(1.0), VariableKind::Binary),
+        _ => (f64::NEG_INFINITY, None, VariableKind::Continuous),
+    };
+
+    if let Some(overrides) = overrides {
+        if let Some(decl_kind) = &overrides.kind {
+            kind = match decl_kind {
+                VariableKindDecl::Continuous => VariableKind::Continuous,
+                VariableKindDecl::Integer => VariableKind::Integer,
+                VariableKindDecl::Binary => VariableKind::Binary,
+            };
+        }
+        if let Some(bound) = &overrides.lower
+            && let Some(value) = literal_bound_to_f64(bound, path)?
+        {
+            lower = value;
+        }
+        if let Some(bound) = &overrides.upper
+            && let Some(value) = literal_bound_to_f64(bound, path)?
+        {
+            upper = Some(value);
+        }
+    }
+
+    Ok((lower, upper, kind))
+}
+
+fn variable_instance_is_active(target: &str, asset: Option<&AssetInputs>) -> bool {
+    match target {
+        "build" => asset.is_some_and(|asset| asset.candidate),
+        "unserved_energy" => true,
+        _ => asset.is_some_and(|asset| asset.families.contains(target)),
+    }
+}
+
+fn lower_constraint_instances(
+    program: &SemanticProgram,
+    inputs: &ScenarioInputs,
+    named_expressions: &BTreeMap<String, Expr>,
+    variable_signatures: &BTreeMap<String, FamilySignature>,
+    instantiated_names: &BTreeSet<String>,
+    entrypoint: &Path,
+) -> Result<Vec<LinearConstraint>, LoweringError> {
+    let mut constraints = Vec::new();
+    for constraint in &program.active_constraints {
+        if constraint.generation_bindings.is_empty() {
+            for bindings in
+                constraint_instance_bindings(constraint, inputs, program.sets.time.steps)
+            {
+                let asset = bindings_asset(&bindings, inputs);
+                let time = bindings_time(&bindings, entrypoint)?;
+                if let Some(filter) = &constraint.generation_filter
+                    && !evaluate_constraint_filter(
+                        filter,
+                        constraint,
+                        FilterScope { asset, time },
+                        inputs,
+                        entrypoint,
+                    )?
+                {
+                    continue;
+                }
+                constraints.extend(linearize_constraint_body(
+                    constraint,
+                    &bindings,
+                    program,
+                    inputs,
+                    named_expressions,
+                    variable_signatures,
+                    instantiated_names,
+                    entrypoint,
+                )?);
+            }
+        } else {
+            let generation_scopes = expand_generation_bindings(
+                &constraint.generation_bindings,
+                inputs,
+                program,
+                entrypoint,
+            )?;
+            for scope in generation_scopes {
+                if let Some(filter) = &constraint.generation_filter
+                    && !evaluate_reduction_filter(
+                        filter,
+                        &scope,
+                        program,
+                        inputs,
+                        named_expressions,
+                        variable_signatures,
+                        instantiated_names,
+                        entrypoint,
+                    )?
+                {
+                    continue;
+                }
+                constraints.extend(linearize_constraint_body(
+                    constraint,
+                    &scope,
+                    program,
+                    inputs,
+                    named_expressions,
+                    variable_signatures,
+                    instantiated_names,
+                    entrypoint,
+                )?);
+            }
+        }
+    }
+    Ok(constraints)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn linearize_constraint_body(
+    constraint: &ResolvedConstraint,
+    bindings: &LinearizationBindings,
+    program: &SemanticProgram,
+    inputs: &ScenarioInputs,
+    named_expressions: &BTreeMap<String, Expr>,
+    variable_signatures: &BTreeMap<String, FamilySignature>,
+    instantiated_names: &BTreeSet<String>,
+    entrypoint: &Path,
+) -> Result<Vec<LinearConstraint>, LoweringError> {
+    let suffix = constraint_binding_suffix(bindings, entrypoint)?;
+    match &constraint.expression {
+        ConstraintBody::Comparison { op, left, right } => Ok(vec![linearize_comparison(
+            format!("{}{}", constraint.name, suffix),
+            *op,
+            left,
+            right,
+            bindings,
+            program,
+            inputs,
+            named_expressions,
+            variable_signatures,
+            instantiated_names,
+            entrypoint,
+        )?]),
+        ConstraintBody::Range {
+            lower,
+            lower_op,
+            middle,
+            upper_op,
+            upper,
+        } => Ok(vec![
+            linearize_comparison(
+                format!("{}{}_lower", constraint.name, suffix),
+                *lower_op,
+                lower,
+                middle,
+                bindings,
+                program,
+                inputs,
+                named_expressions,
+                variable_signatures,
+                instantiated_names,
+                entrypoint,
+            )?,
+            linearize_comparison(
+                format!("{}{}_upper", constraint.name, suffix),
+                *upper_op,
+                middle,
+                upper,
+                bindings,
+                program,
+                inputs,
+                named_expressions,
+                variable_signatures,
+                instantiated_names,
+                entrypoint,
+            )?,
+        ]),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn linearize_comparison(
+    name: String,
+    op: ComparisonOp,
+    left: &Expr,
+    right: &Expr,
+    bindings: &LinearizationBindings,
+    program: &SemanticProgram,
+    inputs: &ScenarioInputs,
+    named_expressions: &BTreeMap<String, Expr>,
+    variable_signatures: &BTreeMap<String, FamilySignature>,
+    instantiated_names: &BTreeSet<String>,
+    entrypoint: &Path,
+) -> Result<LinearConstraint, LoweringError> {
+    let left = linearize_value_expr(
+        left,
+        bindings,
+        program,
+        inputs,
+        named_expressions,
+        variable_signatures,
+        instantiated_names,
+        entrypoint,
+    )?;
+    let right = linearize_value_expr(
+        right,
+        bindings,
+        program,
+        inputs,
+        named_expressions,
+        variable_signatures,
+        instantiated_names,
+        entrypoint,
+    )?;
+    let expression = left.subtract(right);
+    let sense = comparison_to_constraint_sense(op, entrypoint)?;
+    Ok(LinearConstraint {
+        name,
+        sense,
+        rhs: -expression.constant,
+        terms: expression.into_terms(),
+    })
+}
+
+fn comparison_to_constraint_sense(
+    op: ComparisonOp,
+    path: &Path,
+) -> Result<ConstraintSense, LoweringError> {
+    match op {
+        ComparisonOp::Equal | ComparisonOp::DoubleEqual => Ok(ConstraintSense::Equal),
+        ComparisonOp::LessEqual => Ok(ConstraintSense::LessEqual),
+        ComparisonOp::GreaterEqual => Ok(ConstraintSense::GreaterEqual),
+        ComparisonOp::Less | ComparisonOp::Greater | ComparisonOp::NotEqual => {
+            Err(LoweringError::InvalidFormulation {
+                message: format!(
+                    "strict or not-equal comparison `{op}` is not supported in linear constraints"
+                ),
+                path: path.to_path_buf(),
+            })
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn linearize_value_expr(
+    expr: &Expr,
+    bindings: &LinearizationBindings,
+    program: &SemanticProgram,
+    inputs: &ScenarioInputs,
+    named_expressions: &BTreeMap<String, Expr>,
+    variable_signatures: &BTreeMap<String, FamilySignature>,
+    instantiated_names: &BTreeSet<String>,
+    entrypoint: &Path,
+) -> Result<AffineExpr, LoweringError> {
+    match expr {
+        Expr::Number(value) => value.parse::<f64>().map(AffineExpr::constant).map_err(|_| {
+            LoweringError::InvalidFormulation {
+                message: format!("invalid numeric literal `{value}`"),
+                path: entrypoint.to_path_buf(),
+            }
+        }),
+        Expr::Identifier(name) => {
+            if let Some(binding) = bindings.values.get(name) {
+                return Ok(AffineExpr::constant(numeric_filter_value(
+                    binding,
+                    &synthetic_constraint(name),
+                    entrypoint,
+                )?));
+            }
+            if let Some(expression) = named_expressions.get(name) {
+                return linearize_value_expr(
+                    expression,
+                    bindings,
+                    program,
+                    inputs,
+                    named_expressions,
+                    variable_signatures,
+                    instantiated_names,
+                    entrypoint,
+                );
+            }
+            Err(LoweringError::InvalidFormulation {
+                message: format!("unresolved symbol `{name}` in linear expression"),
+                path: entrypoint.to_path_buf(),
+            })
+        }
+        Expr::Indexed { target, indices } => linearize_indexed_expr(
+            target,
+            indices,
+            bindings,
+            program,
+            inputs,
+            variable_signatures,
+            instantiated_names,
+            entrypoint,
+        ),
+        Expr::Unary { op, expr } => {
+            let value = linearize_value_expr(
+                expr,
+                bindings,
+                program,
+                inputs,
+                named_expressions,
+                variable_signatures,
+                instantiated_names,
+                entrypoint,
+            )?;
+            match op {
+                UnaryOp::Negate => Ok(value.scale(-1.0)),
+            }
+        }
+        Expr::Binary { op, left, right } => {
+            let left = linearize_value_expr(
+                left,
+                bindings,
+                program,
+                inputs,
+                named_expressions,
+                variable_signatures,
+                instantiated_names,
+                entrypoint,
+            )?;
+            let right = linearize_value_expr(
+                right,
+                bindings,
+                program,
+                inputs,
+                named_expressions,
+                variable_signatures,
+                instantiated_names,
+                entrypoint,
+            )?;
+            match op {
+                BinaryOp::Add => {
+                    let mut value = left;
+                    value.add_assign(right);
+                    Ok(value)
+                }
+                BinaryOp::Subtract => Ok(left.subtract(right)),
+                BinaryOp::Multiply => {
+                    if left.terms.is_empty() {
+                        Ok(right.scale(left.constant))
+                    } else if right.terms.is_empty() {
+                        Ok(left.scale(right.constant))
+                    } else {
+                        Err(LoweringError::InvalidFormulation {
+                            message: "non-linear multiplication is not supported".to_string(),
+                            path: entrypoint.to_path_buf(),
+                        })
+                    }
+                }
+                BinaryOp::Divide => {
+                    let denominator = right.as_scalar(entrypoint, "division denominator")?;
+                    Ok(left.scale(1.0 / denominator))
+                }
+            }
+        }
+        Expr::FunctionCall { name, args } => {
+            let evaluated_args = args
+                .iter()
+                .map(|arg| {
+                    let result = linearize_value_expr(
+                        arg,
+                        bindings,
+                        program,
+                        inputs,
+                        named_expressions,
+                        variable_signatures,
+                        instantiated_names,
+                        entrypoint,
+                    )?;
+                    result.as_scalar(entrypoint, &format!("{name}() argument"))
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            let value = evaluate_builtin_function(name, &evaluated_args, entrypoint)?;
+            Ok(AffineExpr::constant(value))
+        }
+        Expr::Reduction(reduction) => linearize_reduction(
+            reduction,
+            bindings,
+            program,
+            inputs,
+            named_expressions,
+            variable_signatures,
+            instantiated_names,
+            entrypoint,
+        ),
+        Expr::String(_) | Expr::Boolean(_) | Expr::Comparison { .. } => {
+            Err(LoweringError::InvalidFormulation {
+                message: "boolean and string expressions cannot appear in linear algebra"
+                    .to_string(),
+                path: entrypoint.to_path_buf(),
+            })
+        }
+    }
+}
+
+fn evaluate_builtin_function(
+    name: &str,
+    args: &[f64],
+    entrypoint: &Path,
+) -> Result<f64, LoweringError> {
+    match (name, args.len()) {
+        ("sqrt", 1) => Ok(args[0].sqrt()),
+        ("abs", 1) => Ok(args[0].abs()),
+        ("exp", 1) => Ok(args[0].exp()),
+        ("ln", 1) => Ok(args[0].ln()),
+        ("pow", 2) => Ok(args[0].powf(args[1])),
+        (name, n) => Err(LoweringError::InvalidFormulation {
+            message: format!(
+                "{name}() received {n} argument(s), expected {}",
+                if name == "pow" { 2 } else { 1 }
+            ),
+            path: entrypoint.to_path_buf(),
+        }),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn linearize_reduction(
+    reduction: &crate::algebra::ReductionExpr,
+    bindings: &LinearizationBindings,
+    program: &SemanticProgram,
+    inputs: &ScenarioInputs,
+    named_expressions: &BTreeMap<String, Expr>,
+    variable_signatures: &BTreeMap<String, FamilySignature>,
+    instantiated_names: &BTreeSet<String>,
+    entrypoint: &Path,
+) -> Result<AffineExpr, LoweringError> {
+    let expanded =
+        expand_reduction_bindings(&reduction.bindings, bindings, inputs, program, entrypoint)?;
+    let mut total = AffineExpr::default();
+    'outer: for scope in expanded {
+        for filter in &reduction.filters {
+            if !evaluate_reduction_filter(
+                filter,
+                &scope,
+                program,
+                inputs,
+                named_expressions,
+                variable_signatures,
+                instantiated_names,
+                entrypoint,
+            )? {
+                continue 'outer;
+            }
+        }
+        total.add_assign(linearize_value_expr(
+            &reduction.body,
+            &scope,
+            program,
+            inputs,
+            named_expressions,
+            variable_signatures,
+            instantiated_names,
+            entrypoint,
+        )?);
+    }
+    Ok(total)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn evaluate_reduction_filter(
+    filter: &Expr,
+    bindings: &LinearizationBindings,
+    program: &SemanticProgram,
+    inputs: &ScenarioInputs,
+    named_expressions: &BTreeMap<String, Expr>,
+    variable_signatures: &BTreeMap<String, FamilySignature>,
+    instantiated_names: &BTreeSet<String>,
+    entrypoint: &Path,
+) -> Result<bool, LoweringError> {
+    match filter {
+        Expr::Comparison { op, left, right } => {
+            let left_affine = linearize_value_expr(
+                left,
+                bindings,
+                program,
+                inputs,
+                named_expressions,
+                variable_signatures,
+                instantiated_names,
+                entrypoint,
+            )?;
+            let right_affine = linearize_value_expr(
+                right,
+                bindings,
+                program,
+                inputs,
+                named_expressions,
+                variable_signatures,
+                instantiated_names,
+                entrypoint,
+            )?;
+            let left_value = left_affine.as_scalar(entrypoint, "reduction filter operand")?;
+            let right_value = right_affine.as_scalar(entrypoint, "reduction filter operand")?;
+            Ok(match op {
+                ComparisonOp::Equal | ComparisonOp::DoubleEqual => {
+                    (left_value - right_value).abs() < 1e-12
+                }
+                ComparisonOp::NotEqual => (left_value - right_value).abs() >= 1e-12,
+                ComparisonOp::Less => left_value < right_value,
+                ComparisonOp::LessEqual => left_value <= right_value,
+                ComparisonOp::Greater => left_value > right_value,
+                ComparisonOp::GreaterEqual => left_value >= right_value,
+            })
+        }
+        _ => Err(LoweringError::InvalidFormulation {
+            message: "reduction filter must be a comparison expression".to_string(),
+            path: entrypoint.to_path_buf(),
+        }),
+    }
+}
+
+fn expand_reduction_bindings(
+    bindings: &[crate::algebra::Binding],
+    current: &LinearizationBindings,
+    inputs: &ScenarioInputs,
+    program: &SemanticProgram,
+    entrypoint: &Path,
+) -> Result<Vec<LinearizationBindings>, LoweringError> {
+    let mut scopes = vec![current.clone()];
+    for binding in bindings {
+        let values = reduction_domain_values(&binding.domain, inputs, program, entrypoint)?;
+        let mut next = Vec::new();
+        for scope in &scopes {
+            match &binding.pattern {
+                crate::algebra::BindingPattern::Name(name) => {
+                    for value in &values {
+                        let mut scope = scope.clone();
+                        scope.values.insert(name.clone(), value.clone());
+                        next.push(scope);
+                    }
+                }
+                crate::algebra::BindingPattern::Tuple(_) => {
+                    return Err(LoweringError::InvalidFormulation {
+                        message: "tuple reduction bindings are not lowered yet".to_string(),
+                        path: entrypoint.to_path_buf(),
+                    });
+                }
+            }
+        }
+        scopes = next;
+    }
+    Ok(scopes)
+}
+
+fn expand_generation_bindings(
+    bindings: &[GenerationBinding],
+    inputs: &ScenarioInputs,
+    program: &SemanticProgram,
+    entrypoint: &Path,
+) -> Result<Vec<LinearizationBindings>, LoweringError> {
+    let mut scopes = vec![LinearizationBindings::default()];
+    for binding in bindings {
+        let values = reduction_domain_values(&binding.domain, inputs, program, entrypoint)?;
+        let mut next = Vec::new();
+        for scope in &scopes {
+            for value in &values {
+                let mut scope = scope.clone();
+                scope.values.insert(binding.variable.clone(), value.clone());
+                next.push(scope);
+            }
+        }
+        scopes = next;
+    }
+    Ok(scopes)
+}
+
+fn reduction_domain_values(
+    domain: &str,
+    inputs: &ScenarioInputs,
+    program: &SemanticProgram,
+    entrypoint: &Path,
+) -> Result<Vec<FilterValue>, LoweringError> {
+    match domain {
+        "assets" => Ok(inputs
+            .assets
+            .iter()
+            .map(|asset| FilterValue::String(asset.name.clone()))
+            .collect()),
+        "candidate_assets" => Ok(inputs
+            .assets
+            .iter()
+            .filter(|asset| asset.candidate)
+            .map(|asset| FilterValue::String(asset.name.clone()))
+            .collect()),
+        "time" => Ok((1..=program.sets.time.steps)
+            .map(|time| FilterValue::Number(time as f64))
+            .collect()),
+        _ => {
+            if let Some(set) = program.set_registry.get(domain) {
+                Ok(set
+                    .values
+                    .iter()
+                    .map(|v| FilterValue::String(v.clone()))
+                    .collect())
+            } else {
+                Err(LoweringError::InvalidFormulation {
+                    message: format!("unsupported reduction domain `{domain}`"),
+                    path: entrypoint.to_path_buf(),
+                })
+            }
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn linearize_indexed_expr(
+    target: &str,
+    indices: &[Expr],
+    bindings: &LinearizationBindings,
+    program: &SemanticProgram,
+    inputs: &ScenarioInputs,
+    variable_signatures: &BTreeMap<String, FamilySignature>,
+    instantiated_names: &BTreeSet<String>,
+    entrypoint: &Path,
+) -> Result<AffineExpr, LoweringError> {
+    let resolved = indices
+        .iter()
+        .map(|index| resolve_index_expr(index, bindings, entrypoint))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    // Compute the candidate instance name using the same conventions as
+    // instantiate_variable_instances / resolve_custom_index_domains.
+    let candidate = candidate_instance_name(target, &resolved, entrypoint)?;
+
+    if instantiated_names.contains(&candidate) {
+        return Ok(AffineExpr::variable(candidate, 1.0));
+    }
+
+    // The candidate was not found in the instantiated set. Before falling
+    // through to parameter lookup, handle chronology boundary cases for
+    // [String, Number] references where the time index is out of range.
+    if let [FilterValue::String(_), FilterValue::Number(_)] = resolved.as_slice() {
+        let synthetic = synthetic_constraint(target);
+        let asset_name = string_filter_value(&resolved[0], &synthetic, entrypoint)?;
+        let time = integer_time_index(&resolved[1], entrypoint)?;
+
+        // Only attempt chronology handling when the time is out of the
+        // normal 1..=steps range AND a variable family with matching
+        // arity exists (so we know this target is a variable, not a
+        // parameter that happens to be missing).
+        if !(1..=program.sets.time.steps as i64).contains(&time)
+            && find_variable_family(target, resolved.len(), variable_signatures).is_some()
+        {
+            if let Some(value) =
+                chronology_boundary_value(target, &asset_name, time, program, inputs, entrypoint)?
+            {
+                return Ok(AffineExpr::constant(value));
+            }
+            return Err(LoweringError::InvalidFormulation {
+                message: format!("time index `{time}` is out of range for `{target}`"),
+                path: entrypoint.to_path_buf(),
+            });
+        }
+    }
+
+    if let [FilterValue::Number(_)] = resolved.as_slice() {
+        let time = integer_time_index(&resolved[0], entrypoint)?;
+        if !(1..=program.sets.time.steps as i64).contains(&time)
+            && find_variable_family(target, resolved.len(), variable_signatures).is_some()
+        {
+            return Err(LoweringError::InvalidFormulation {
+                message: format!("time index `{time}` is out of range for `{target}`"),
+                path: entrypoint.to_path_buf(),
+            });
+        }
+    }
+
+    parameter_reference_expr(target, &resolved, inputs, entrypoint)
+}
+
+/// Compute the instance name that `instantiate_variable_instances` would
+/// produce for a given target and resolved index values.
+fn candidate_instance_name(
+    target: &str,
+    resolved: &[FilterValue],
+    entrypoint: &Path,
+) -> Result<String, LoweringError> {
+    match resolved {
+        [FilterValue::String(a), FilterValue::Number(_)] => {
+            let time = integer_time_index(&resolved[1], entrypoint)?;
+            Ok(indexed_name(target, a, time as usize))
+        }
+        [FilterValue::String(a)] => Ok(asset_indexed_name(target, a)),
+        [FilterValue::Number(_)] => {
+            let time = integer_time_index(&resolved[0], entrypoint)?;
+            Ok(time_name(target, time as usize))
+        }
+        _ => {
+            // General case for custom index domains: join all values as
+            // strings, matching the format in resolve_custom_index_domains.
+            let parts: Vec<String> = resolved
+                .iter()
+                .map(|v| match v {
+                    FilterValue::String(s) => Ok(s.clone()),
+                    FilterValue::Number(n) => {
+                        if n.fract() == 0.0 {
+                            Ok((*n as i64).to_string())
+                        } else {
+                            Ok(n.to_string())
+                        }
+                    }
+                    FilterValue::Boolean(_) => Err(LoweringError::InvalidFormulation {
+                        message: format!("unsupported boolean index in reference to `{target}`"),
+                        path: entrypoint.to_path_buf(),
+                    }),
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            Ok(format!("{}[{}]", target, parts.join(",")))
+        }
+    }
+}
+
+/// Find the variable family key in the signatures map by matching target
+/// name and index arity. Used for traceability and to detect whether a
+/// target is a known variable family.
+fn find_variable_family<'a>(
+    target: &str,
+    arity: usize,
+    variable_signatures: &'a BTreeMap<String, FamilySignature>,
+) -> Option<&'a str> {
+    variable_signatures
+        .iter()
+        .find(|(_key, sig)| sig.target == target && sig.indices.len() == arity)
+        .map(|(key, _)| key.as_str())
+}
+
+fn parameter_reference_expr(
+    target: &str,
+    resolved: &[FilterValue],
+    inputs: &ScenarioInputs,
+    entrypoint: &Path,
+) -> Result<AffineExpr, LoweringError> {
+    let value = match resolved {
+        [index] => {
+            if let FilterValue::String(name) = index {
+                if find_asset(inputs, name).is_some() {
+                    asset_parameter_value(inputs, target, name)
+                        .or_else(|| {
+                            inputs
+                                .asset_data
+                                .get(target)
+                                .and_then(|values| values.get(name))
+                                .copied()
+                        })
+                        .unwrap_or(0.0)
+                } else if let Some(member_params) = inputs.set_params.get(name) {
+                    member_params.get(target).copied().unwrap_or(0.0)
+                } else {
+                    return Err(LoweringError::MissingAsset {
+                        name: name.clone(),
+                        path: entrypoint.to_path_buf(),
+                    });
+                }
+            } else {
+                let time = integer_time_index(index, entrypoint)? as usize;
+                series_value(&inputs.series, target, time, entrypoint)?
+            }
+        }
+        [asset_name, time] => {
+            let asset_name =
+                string_filter_value(asset_name, &synthetic_constraint(target), entrypoint)?;
+            let time = integer_time_index(time, entrypoint)? as usize;
+            indexed_value(&inputs.indexed, target, &asset_name, time, entrypoint)?
+        }
+        _ => {
+            return Err(LoweringError::InvalidFormulation {
+                message: format!("unsupported parameter reference `{target}`"),
+                path: entrypoint.to_path_buf(),
+            });
+        }
+    };
+    Ok(AffineExpr::constant(value))
+}
+
+fn chronology_boundary_value(
+    target: &str,
+    asset_name: &str,
+    time: i64,
+    program: &SemanticProgram,
+    inputs: &ScenarioInputs,
+    entrypoint: &Path,
+) -> Result<Option<f64>, LoweringError> {
+    if time == 0 && target == "soc" && program.chronology.initial_boundary.is_some() {
+        let asset = find_asset(inputs, asset_name).ok_or_else(|| LoweringError::MissingAsset {
+            name: asset_name.to_string(),
+            path: entrypoint.to_path_buf(),
+        })?;
+        return asset_parameter(asset, "initial_soc_mwh", entrypoint).map(Some);
+    }
+    if time == 0 && target == "commit" && program.chronology.initial_commitment_boundary.is_some() {
+        return asset_data_value(
+            &inputs.asset_data,
+            "initial_commitment",
+            asset_name,
+            entrypoint,
+        )
+        .map(Some);
+    }
+    if time == 0
+        && target == "generation"
+        && program.chronology.initial_commitment_boundary.is_some()
+    {
+        let asset = find_asset(inputs, asset_name).ok_or_else(|| LoweringError::MissingAsset {
+            name: asset_name.to_string(),
+            path: entrypoint.to_path_buf(),
+        })?;
+        let p_min = asset_parameter(asset, "p_min", entrypoint)?;
+        let initial_commitment = asset_data_value(
+            &inputs.asset_data,
+            "initial_commitment",
+            asset_name,
+            entrypoint,
+        )?;
+        return Ok(Some(p_min * initial_commitment));
+    }
+    Ok(None)
+}
+
+fn emit_terminal_boundary_constraints(
+    program: &SemanticProgram,
+    inputs: &ScenarioInputs,
+    variable_signatures: &BTreeMap<String, FamilySignature>,
+    entrypoint: &Path,
+) -> Result<Vec<LinearConstraint>, LoweringError> {
+    if program.chronology.terminal_boundary.is_none()
+        || !variable_signatures.contains_key("soc[a,t]")
+    {
+        return Ok(Vec::new());
+    }
+
+    let mut constraints = Vec::new();
+    for asset in &inputs.assets {
+        if !asset.families.contains("soc") {
+            continue;
+        }
+        constraints.push(LinearConstraint {
+            name: format!("terminal_soc[{}]", asset.name),
+            sense: ConstraintSense::Equal,
+            rhs: asset_parameter(asset, "terminal_soc_mwh", entrypoint)?,
+            terms: vec![term(
+                &indexed_name("soc", &asset.name, program.sets.time.steps),
+                1.0,
+            )],
+        });
+    }
+    Ok(constraints)
+}
+
+fn constraint_instance_bindings(
+    constraint: &ResolvedConstraint,
+    inputs: &ScenarioInputs,
+    steps: usize,
+) -> Vec<LinearizationBindings> {
+    let binds_asset = constraint_uses_free_index(&constraint.expression, "a");
+    let binds_time = constraint_uses_free_index(&constraint.expression, "t");
+    let assets = if binds_asset {
+        relevant_constraint_assets(constraint, inputs)
+            .into_iter()
+            .map(|asset| asset.name.clone())
+            .collect::<Vec<_>>()
+    } else {
+        vec![String::new()]
+    };
+    let times = if binds_time {
+        (1..=steps).collect::<Vec<_>>()
+    } else {
+        vec![0]
+    };
+
+    let mut bindings = Vec::new();
+    for asset in &assets {
+        for time in &times {
+            let mut scope = LinearizationBindings::default();
+            if binds_asset {
+                scope
+                    .values
+                    .insert("a".to_string(), FilterValue::String(asset.clone()));
+            }
+            if binds_time {
+                scope
+                    .values
+                    .insert("t".to_string(), FilterValue::Number(*time as f64));
+            }
+            bindings.push(scope);
+        }
+    }
+    bindings
+}
+
+fn relevant_constraint_assets<'a>(
+    constraint: &ResolvedConstraint,
+    inputs: &'a ScenarioInputs,
+) -> Vec<&'a AssetInputs> {
+    if constraint.source_kind == "operation" {
+        return inputs
+            .assets
+            .iter()
+            .filter(|asset| asset.operation.as_deref() == Some(constraint.source_name.as_str()))
+            .collect();
+    }
+    inputs.assets.iter().collect()
+}
+
+fn constraint_uses_free_index(body: &ConstraintBody, name: &str) -> bool {
+    match body {
+        ConstraintBody::Comparison { left, right, .. } => {
+            expr_uses_free_index(left, name, &mut BTreeSet::new())
+                || expr_uses_free_index(right, name, &mut BTreeSet::new())
+        }
+        ConstraintBody::Range {
+            lower,
+            middle,
+            upper,
+            ..
+        } => {
+            expr_uses_free_index(lower, name, &mut BTreeSet::new())
+                || expr_uses_free_index(middle, name, &mut BTreeSet::new())
+                || expr_uses_free_index(upper, name, &mut BTreeSet::new())
+        }
+    }
+}
+
+fn expr_uses_free_index(expr: &Expr, name: &str, bound: &mut BTreeSet<String>) -> bool {
+    match expr {
+        Expr::Identifier(identifier) => identifier == name && !bound.contains(identifier),
+        Expr::Indexed { indices, .. } => indices
+            .iter()
+            .any(|index| expr_uses_free_index(index, name, bound)),
+        Expr::Unary { expr, .. } => expr_uses_free_index(expr, name, bound),
+        Expr::Binary { left, right, .. } | Expr::Comparison { left, right, .. } => {
+            expr_uses_free_index(left, name, bound) || expr_uses_free_index(right, name, bound)
+        }
+        Expr::Reduction(reduction) => {
+            let mut local_bound = bound.clone();
+            for binding in &reduction.bindings {
+                match &binding.pattern {
+                    crate::algebra::BindingPattern::Name(identifier) => {
+                        local_bound.insert(identifier.clone());
+                    }
+                    crate::algebra::BindingPattern::Tuple(identifiers) => {
+                        local_bound.extend(identifiers.iter().cloned());
+                    }
+                }
+            }
+            expr_uses_free_index(&reduction.body, name, &mut local_bound)
+                || reduction
+                    .filters
+                    .iter()
+                    .any(|filter| expr_uses_free_index(filter, name, &mut local_bound))
+        }
+        Expr::FunctionCall { args, .. } => args
+            .iter()
+            .any(|arg| expr_uses_free_index(arg, name, bound)),
+        Expr::Number(_) | Expr::String(_) | Expr::Boolean(_) => false,
+    }
+}
+
+fn bindings_asset<'a>(
+    bindings: &LinearizationBindings,
+    inputs: &'a ScenarioInputs,
+) -> Option<&'a AssetInputs> {
+    bindings.values.get("a").and_then(|value| match value {
+        FilterValue::String(name) => find_asset(inputs, name),
+        _ => None,
+    })
+}
+
+fn bindings_time(
+    bindings: &LinearizationBindings,
+    entrypoint: &Path,
+) -> Result<Option<usize>, LoweringError> {
+    bindings
+        .values
+        .get("t")
+        .map(|value| integer_time_index(value, entrypoint).map(|time| time as usize))
+        .transpose()
+}
+
+fn constraint_binding_suffix(
+    bindings: &LinearizationBindings,
+    entrypoint: &Path,
+) -> Result<String, LoweringError> {
+    let mut indices = Vec::new();
+    if let Some(value) = bindings.values.get("a") {
+        indices.push(string_filter_value(
+            value,
+            &synthetic_constraint("constraint"),
+            entrypoint,
+        )?);
+    }
+    if let Some(value) = bindings.values.get("t") {
+        indices.push(integer_time_index(value, entrypoint)?.to_string());
+    }
+    // Include any custom binding variables (e.g. "b" from `over "b" in="periods"`)
+    for (name, value) in &bindings.values {
+        if name == "a" || name == "t" {
+            continue;
+        }
+        match value {
+            FilterValue::String(s) => indices.push(s.clone()),
+            FilterValue::Number(n) => {
+                if n.fract() == 0.0 {
+                    indices.push((*n as i64).to_string());
+                } else {
+                    indices.push(n.to_string());
+                }
+            }
+            FilterValue::Boolean(b) => indices.push(b.to_string()),
+        }
+    }
+    if indices.is_empty() {
+        Ok(String::new())
+    } else {
+        Ok(format!("[{}]", indices.join(",")))
+    }
+}
+
+fn integer_time_index(value: &FilterValue, entrypoint: &Path) -> Result<i64, LoweringError> {
+    let number = numeric_filter_value(value, &synthetic_constraint("time"), entrypoint)?;
+    if number.fract() == 0.0 {
+        Ok(number as i64)
+    } else {
+        Err(LoweringError::InvalidFormulation {
+            message: format!("time index `{number}` must be integral"),
+            path: entrypoint.to_path_buf(),
+        })
+    }
+}
+
+fn resolve_index_expr(
+    expr: &Expr,
+    bindings: &LinearizationBindings,
+    entrypoint: &Path,
+) -> Result<FilterValue, LoweringError> {
+    match expr {
+        Expr::Identifier(name) => {
+            bindings
+                .values
+                .get(name)
+                .cloned()
+                .ok_or_else(|| LoweringError::InvalidFormulation {
+                    message: format!("unbound index identifier `{name}`"),
+                    path: entrypoint.to_path_buf(),
+                })
+        }
+        Expr::Number(value) => value.parse::<f64>().map(FilterValue::Number).map_err(|_| {
+            LoweringError::InvalidFormulation {
+                message: format!("invalid numeric index `{value}`"),
+                path: entrypoint.to_path_buf(),
+            }
+        }),
+        Expr::String(value) => Ok(FilterValue::String(value.clone())),
+        Expr::Unary { op, expr } => match op {
+            UnaryOp::Negate => Ok(FilterValue::Number(-numeric_filter_value(
+                &resolve_index_expr(expr, bindings, entrypoint)?,
+                &synthetic_constraint("index"),
+                entrypoint,
+            )?)),
+        },
+        Expr::Binary { op, left, right } => {
+            let left = resolve_index_expr(left, bindings, entrypoint)?;
+            let right = resolve_index_expr(right, bindings, entrypoint)?;
+            let left = numeric_filter_value(&left, &synthetic_constraint("index"), entrypoint)?;
+            let right = numeric_filter_value(&right, &synthetic_constraint("index"), entrypoint)?;
+            Ok(FilterValue::Number(match op {
+                BinaryOp::Add => left + right,
+                BinaryOp::Subtract => left - right,
+                BinaryOp::Multiply => left * right,
+                BinaryOp::Divide => left / right,
+            }))
+        }
+        _ => Err(LoweringError::InvalidFormulation {
+            message: "unsupported index expression during lowering".to_string(),
+            path: entrypoint.to_path_buf(),
+        }),
+    }
+}
+
+fn synthetic_constraint(name: &str) -> ResolvedConstraint {
+    ResolvedConstraint {
+        name: name.to_string(),
+        source_kind: "lowering".to_string(),
+        source_name: "synthetic".to_string(),
+        expression_text: String::new(),
+        expression: ConstraintBody::Comparison {
+            op: ComparisonOp::Equal,
+            left: Expr::Number("0".to_string()),
+            right: Expr::Number("0".to_string()),
+        },
+        generation_bindings: Vec::new(),
+        generation_filter_text: None,
+        generation_filter: None,
+    }
+}
+
+fn read_csv_rows(path: &Path) -> Result<Vec<HashMap<String, String>>, LoweringError> {
+    let mut reader = csv::Reader::from_path(path).map_err(|source| LoweringError::Csv {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    let headers = reader
+        .headers()
+        .map_err(|source| LoweringError::Csv {
+            path: path.to_path_buf(),
+            source,
+        })?
+        .clone();
+
+    reader
+        .records()
+        .map(|record| {
+            let record = record.map_err(|source| LoweringError::Csv {
+                path: path.to_path_buf(),
+                source,
+            })?;
+            record_to_map(path, &headers, record)
+        })
+        .collect()
+}
+
+fn record_to_map(
+    path: &Path,
+    headers: &StringRecord,
+    record: StringRecord,
+) -> Result<HashMap<String, String>, LoweringError> {
+    let mut row = HashMap::with_capacity(headers.len());
+    for i in 0..headers.len() {
+        if let Some(value) = record.get(i) {
+            row.insert(headers[i].to_string(), value.to_string());
+        }
+    }
+    if row.is_empty() {
+        return Err(LoweringError::MissingData {
+            name: "csv".to_string(),
+            path: path.to_path_buf(),
+        });
+    }
+    Ok(row)
+}
+
+fn parse_usize_field(
+    row: &HashMap<String, String>,
+    field: &str,
+    path: &Path,
+) -> Result<usize, LoweringError> {
+    let raw = row
+        .get(field)
+        .cloned()
+        .ok_or_else(|| LoweringError::MissingColumn {
+            column: field.to_string(),
+            path: path.to_path_buf(),
+        })?;
+    raw.parse::<usize>()
+        .map_err(|_| LoweringError::InvalidNumber {
+            value: raw,
+            field: field.to_string(),
+            path: path.to_path_buf(),
+        })
+}
+
+fn parse_data_value(
+    row: &HashMap<String, String>,
+    name: &str,
+    path: &Path,
+) -> Result<f64, LoweringError> {
+    let raw = row
+        .get(name)
+        .cloned()
+        .ok_or_else(|| LoweringError::MissingColumn {
+            column: name.to_string(),
+            path: path.to_path_buf(),
+        })?;
+    raw.parse::<f64>()
+        .map_err(|_| LoweringError::InvalidNumber {
+            value: raw,
+            field: name.to_string(),
+            path: path.to_path_buf(),
+        })
+}
+
+/// Convert a `BoundExpr::Literal` to `f64`. Returns `None` for
+/// `BoundExpr::Formula` (parameter-based bounds need a linearization context
+/// that isn't available yet).
+fn literal_bound_to_f64(bound: &BoundExpr, path: &Path) -> Result<Option<f64>, LoweringError> {
+    match bound {
+        BoundExpr::Literal(literal) => literal_to_f64("bound", literal, path).map(Some),
+        BoundExpr::Formula(_) => Ok(None),
+    }
+}
+
+fn literal_to_f64(name: &str, value: &LiteralValue, path: &Path) -> Result<f64, LoweringError> {
+    match value {
+        LiteralValue::Integer(value) => Ok(*value as f64),
+        LiteralValue::Decimal(value) | LiteralValue::String(value) => {
+            value
+                .parse::<f64>()
+                .map_err(|_| LoweringError::InvalidNumber {
+                    value: value.clone(),
+                    field: name.to_string(),
+                    path: path.to_path_buf(),
+                })
+        }
+        LiteralValue::Boolean(value) => Ok(if *value { 1.0 } else { 0.0 }),
+    }
+}
+
+fn asset_parameter(asset: &AssetInputs, name: &str, path: &Path) -> Result<f64, LoweringError> {
+    asset
+        .parameters
+        .get(name)
+        .copied()
+        .ok_or_else(|| LoweringError::MissingParameter {
+            name: name.to_string(),
+            asset: asset.name.clone(),
+            path: path.to_path_buf(),
+        })
+}
+
+fn has_asset_parameter(asset: &AssetInputs, name: &str) -> bool {
+    asset.parameters.contains_key(name)
+}
+
+fn series_value(
+    series: &BTreeMap<String, BTreeMap<usize, f64>>,
+    name: &str,
+    time: usize,
+    path: &Path,
+) -> Result<f64, LoweringError> {
+    series
+        .get(name)
+        .ok_or_else(|| LoweringError::MissingData {
+            name: name.to_string(),
+            path: path.to_path_buf(),
+        })?
+        .get(&time)
+        .copied()
+        .ok_or_else(|| LoweringError::MissingDataPoint {
+            name: name.to_string(),
+            key: time.to_string(),
+            path: path.to_path_buf(),
+        })
+}
+
+fn indexed_value(
+    indexed: &BTreeMap<String, BTreeMap<(String, usize), f64>>,
+    name: &str,
+    asset_name: &str,
+    time: usize,
+    path: &Path,
+) -> Result<f64, LoweringError> {
+    indexed
+        .get(name)
+        .ok_or_else(|| LoweringError::MissingData {
+            name: name.to_string(),
+            path: path.to_path_buf(),
+        })?
+        .get(&(asset_name.to_string(), time))
+        .copied()
+        .ok_or_else(|| LoweringError::MissingDataPoint {
+            name: name.to_string(),
+            key: format!("{asset_name},{time}"),
+            path: path.to_path_buf(),
+        })
+}
+
+fn asset_data_value(
+    asset_data: &BTreeMap<String, BTreeMap<String, f64>>,
+    name: &str,
+    asset_name: &str,
+    path: &Path,
+) -> Result<f64, LoweringError> {
+    asset_data
+        .get(name)
+        .ok_or_else(|| LoweringError::MissingData {
+            name: name.to_string(),
+            path: path.to_path_buf(),
+        })?
+        .get(asset_name)
+        .copied()
+        .ok_or_else(|| LoweringError::MissingDataPoint {
+            name: name.to_string(),
+            key: asset_name.to_string(),
+            path: path.to_path_buf(),
+        })
+}
+
+fn objective_sense(value: &str) -> ObjectiveSense {
+    match value {
+        "maximize" => ObjectiveSense::Maximize,
+        _ => ObjectiveSense::Minimize,
+    }
+}
+
+fn term(variable_name: &str, coefficient: f64) -> LinearTerm {
+    LinearTerm {
+        variable_name: variable_name.to_string(),
+        coefficient,
+    }
+}
+
+fn indexed_name(family: &str, asset_name: &str, time: usize) -> String {
+    format!("{family}[{asset_name},{time}]")
+}
+
+fn time_name(family: &str, time: usize) -> String {
+    format!("{family}[{time}]")
+}
+
+fn asset_indexed_name(target: &str, asset: &str) -> String {
+    format!("{target}[{asset}]")
+}

--- a/crates/arco-kdl/src/normalize.rs
+++ b/crates/arco-kdl/src/normalize.rs
@@ -1,0 +1,494 @@
+use crate::source::{
+    ConstraintDecl, ControlDecl, DataBindingDecl, HorizonDecl, IndexDecl, ObjectiveDecl, ParamDecl,
+    ScenarioDecl, SetDecl, SourceProgram,
+};
+use miette::Diagnostic;
+use std::collections::BTreeSet;
+use std::fmt::Display;
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CanonicalProgram {
+    pub models: Vec<CanonicalModel>,
+    pub scenarios: Vec<CanonicalScenario>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CanonicalModel {
+    pub name: String,
+    pub sets: Vec<SetDecl>,
+    pub parameters: Vec<ParamDecl>,
+    pub controls: Vec<ControlDecl>,
+    pub constraints: Vec<ConstraintDecl>,
+    pub optimize: ObjectiveDecl,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CanonicalScenario {
+    pub name: String,
+    pub horizon: HorizonDecl,
+    pub data: Vec<DataBindingDecl>,
+    pub model: String,
+}
+
+#[derive(Debug, Error)]
+pub enum NormalizeError {
+    #[error("missing declaration `{kind}` named `{name}` in {path}")]
+    MissingDeclaration {
+        kind: &'static str,
+        name: String,
+        path: PathBuf,
+    },
+    #[error("scenario `{scenario}` does not bind a model or template in {path}")]
+    MissingScenarioModel { scenario: String, path: PathBuf },
+}
+
+impl Diagnostic for NormalizeError {
+    fn code<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
+        let code = match self {
+            Self::MissingDeclaration { .. } => "arco::normalize::missing_declaration",
+            Self::MissingScenarioModel { .. } => "arco::normalize::missing_scenario_model",
+        };
+        Some(Box::new(code))
+    }
+}
+
+pub fn normalize_program(
+    program: &SourceProgram,
+    path: &Path,
+) -> Result<CanonicalProgram, NormalizeError> {
+    let mut models = program
+        .models
+        .iter()
+        .map(normalize_model_decl)
+        .collect::<Vec<_>>();
+
+    for scenario in &program.scenarios {
+        if scenario.model_use.is_none() && has_direct_wiring(scenario) {
+            models.push(normalize_direct_wiring_to_model(program, scenario, path)?);
+        }
+    }
+
+    models.sort_by_key(|model| model.name.clone());
+
+    let mut scenarios = program
+        .scenarios
+        .iter()
+        .map(|scenario| normalize_scenario_decl(scenario, path))
+        .collect::<Result<Vec<_>, _>>()?;
+    scenarios.sort_by_key(|scenario| scenario.name.clone());
+
+    Ok(CanonicalProgram { models, scenarios })
+}
+
+fn normalize_model_decl(model: &crate::source::ModelDecl) -> CanonicalModel {
+    CanonicalModel {
+        name: model.name.clone(),
+        sets: model.sets.clone(),
+        parameters: model.parameters.clone(),
+        controls: model.controls.clone(),
+        constraints: model.constraints.clone(),
+        optimize: model.optimize.clone(),
+    }
+}
+
+fn normalize_direct_wiring_to_model(
+    program: &SourceProgram,
+    scenario: &ScenarioDecl,
+    path: &Path,
+) -> Result<CanonicalModel, NormalizeError> {
+    let mut controls = Vec::new();
+    let mut constraints = Vec::new();
+
+    // Auto-wire: collect technology and operation names from assets and
+    // instances when the scenario doesn't list them explicitly.
+    let tech_names = infer_technology_names(program, scenario);
+    let op_names = infer_operation_names(program, scenario);
+    let rule_names = infer_rule_names(program, scenario);
+
+    for tech_name in &tech_names {
+        let technology =
+            program
+                .technology(tech_name)
+                .ok_or_else(|| NormalizeError::MissingDeclaration {
+                    kind: "technology",
+                    name: tech_name.clone(),
+                    path: path.to_path_buf(),
+                })?;
+        for invest in &technology.investments {
+            controls.push(ControlDecl {
+                name: invest.name.clone(),
+                indices: vec![IndexDecl {
+                    name: "a".to_string(),
+                    domain: None,
+                }],
+                lower: invest.lower.clone(),
+                upper: invest.upper.clone(),
+                kind: invest.kind,
+            });
+        }
+        for control in &technology.controls {
+            controls.push(ControlDecl {
+                name: control.name.clone(),
+                indices: vec![
+                    IndexDecl {
+                        name: "a".to_string(),
+                        domain: None,
+                    },
+                    IndexDecl {
+                        name: "t".to_string(),
+                        domain: None,
+                    },
+                ],
+                lower: control.lower.clone(),
+                upper: control.upper.clone(),
+                kind: control.kind,
+            });
+        }
+    }
+
+    for op_name in &op_names {
+        let operation =
+            program
+                .operation(op_name)
+                .ok_or_else(|| NormalizeError::MissingDeclaration {
+                    kind: "operation",
+                    name: op_name.clone(),
+                    path: path.to_path_buf(),
+                })?;
+        constraints.extend(operation.constraints.iter().cloned());
+    }
+
+    for rule_name in &rule_names {
+        let rule = program
+            .rule(rule_name)
+            .ok_or_else(|| NormalizeError::MissingDeclaration {
+                kind: "rule",
+                name: rule_name.clone(),
+                path: path.to_path_buf(),
+            })?;
+        constraints.extend(rule.constraints.iter().cloned());
+    }
+
+    let objective_name =
+        scenario
+            .objective
+            .clone()
+            .ok_or_else(|| NormalizeError::MissingDeclaration {
+                kind: "objective",
+                name: direct_wiring_model_name(&scenario.name),
+                path: path.to_path_buf(),
+            })?;
+    let objective = program
+        .objective(&objective_name)
+        .ok_or_else(|| NormalizeError::MissingDeclaration {
+            kind: "objective",
+            name: objective_name,
+            path: path.to_path_buf(),
+        })?
+        .clone();
+
+    controls.sort_by_key(render_control_signature);
+    constraints.sort_by_key(|constraint| constraint.name.clone());
+
+    Ok(CanonicalModel {
+        name: direct_wiring_model_name(&scenario.name),
+        sets: Vec::new(),
+        parameters: Vec::new(),
+        controls,
+        constraints,
+        optimize: objective,
+    })
+}
+
+fn normalize_scenario_decl(
+    scenario: &ScenarioDecl,
+    path: &Path,
+) -> Result<CanonicalScenario, NormalizeError> {
+    let model = scenario
+        .model_use
+        .clone()
+        .or_else(|| {
+            if has_direct_wiring(scenario) {
+                Some(direct_wiring_model_name(&scenario.name))
+            } else {
+                None
+            }
+        })
+        .ok_or_else(|| NormalizeError::MissingScenarioModel {
+            scenario: scenario.name.clone(),
+            path: path.to_path_buf(),
+        })?;
+
+    Ok(CanonicalScenario {
+        name: scenario.name.clone(),
+        horizon: scenario.horizon.clone(),
+        data: scenario.data.clone(),
+        model,
+    })
+}
+
+fn has_direct_wiring(scenario: &ScenarioDecl) -> bool {
+    !scenario.technologies.is_empty()
+        || !scenario.operations.is_empty()
+        || !scenario.rules.is_empty()
+        || !scenario.instances.is_empty()
+        || !scenario.assets.is_empty()
+}
+
+fn direct_wiring_model_name(scenario_name: &str) -> String {
+    format!("{scenario_name}Model")
+}
+
+fn render_control_signature(control: &ControlDecl) -> String {
+    if control.indices.is_empty() {
+        return control.name.clone();
+    }
+    let names = control
+        .indices
+        .iter()
+        .map(|idx| idx.name.as_str())
+        .collect::<Vec<_>>()
+        .join(",");
+    format!("{}[{}]", control.name, names)
+}
+
+pub fn normalize_surface_syntax(text: &str) -> String {
+    let math_keywords = [
+        "constraint",
+        "expression",
+        "minimize",
+        "maximize",
+        "expr",
+        "lower",
+        "upper",
+    ];
+    let mut normalized = String::with_capacity(text.len());
+    let bytes = text.as_bytes();
+    let mut index = 0;
+
+    while index < bytes.len() {
+        let rewritten = math_keywords
+            .iter()
+            .find_map(|keyword| rewrite_math_block(text, index, keyword));
+        if let Some((replacement, end)) = rewritten {
+            normalized.push_str(&replacement);
+            index = end;
+            continue;
+        }
+
+        normalized.push(bytes[index] as char);
+        index += 1;
+    }
+
+    normalized
+}
+
+fn rewrite_math_block(text: &str, start: usize, keyword: &str) -> Option<(String, usize)> {
+    if !matches_keyword_at(text, start, keyword) {
+        return None;
+    }
+
+    let bytes = text.as_bytes();
+    let mut index = start + keyword.len();
+    let mut in_string = false;
+    let mut escaped = false;
+    let mut opening_brace = None;
+
+    while index < bytes.len() {
+        let byte = bytes[index];
+        if in_string {
+            if escaped {
+                escaped = false;
+            } else if byte == b'\\' {
+                escaped = true;
+            } else if byte == b'"' {
+                in_string = false;
+            }
+            index += 1;
+            continue;
+        }
+
+        match byte {
+            b'"' => in_string = true,
+            b'{' => {
+                opening_brace = Some(index);
+                break;
+            }
+            b'\n' => return None,
+            _ => {}
+        }
+        index += 1;
+    }
+
+    let opening_brace = opening_brace?;
+
+    // For constraint blocks, peek at the body content. If it starts with
+    // over/when/expr, this is a generation-style constraint with proper KDL
+    // children, not bare math. Skip the rewrite so only inner `expr` blocks
+    // get their math rewritten.
+    if keyword == "constraint" && body_starts_with_generation_keyword(text, opening_brace) {
+        return None;
+    }
+
+    let mut closing_index = opening_brace + 1;
+    let mut brace_depth = 1usize;
+    in_string = false;
+    escaped = false;
+
+    while closing_index < bytes.len() {
+        let byte = bytes[closing_index];
+        if in_string {
+            if escaped {
+                escaped = false;
+            } else if byte == b'\\' {
+                escaped = true;
+            } else if byte == b'"' {
+                in_string = false;
+            }
+            closing_index += 1;
+            continue;
+        }
+
+        match byte {
+            b'"' => in_string = true,
+            b'{' => brace_depth += 1,
+            b'}' => {
+                brace_depth -= 1;
+                if brace_depth == 0 {
+                    break;
+                }
+            }
+            _ => {}
+        }
+        closing_index += 1;
+    }
+
+    if brace_depth != 0 {
+        return None;
+    }
+
+    let header = text[start..opening_brace].trim_end();
+    let body = normalize_math_body(&text[opening_brace + 1..closing_index]);
+    let encoded_body = encode_kdl_string(&body);
+
+    let replacement = match keyword {
+        "constraint" => format!("{header} expression={encoded_body}"),
+        "expression" => format!("{header} {{ formula {encoded_body} }}"),
+        "minimize" | "maximize" => format!("{header} expression={encoded_body}"),
+        "expr" => format!("{header} expression={encoded_body}"),
+        "lower" | "upper" => format!("{header} expression={encoded_body}"),
+        _ => return None,
+    };
+
+    Some((replacement, closing_index + 1))
+}
+
+fn body_starts_with_generation_keyword(text: &str, opening_brace: usize) -> bool {
+    let trimmed = text[opening_brace + 1..].trim_start();
+    for keyword in ["over", "when", "expr"] {
+        let Some(rest) = trimmed.strip_prefix(keyword) else {
+            continue;
+        };
+        if rest.starts_with([' ', '\t', '{']) {
+            return true;
+        }
+    }
+    false
+}
+
+fn matches_keyword_at(text: &str, start: usize, keyword: &str) -> bool {
+    let bytes = text.as_bytes();
+    let end = start + keyword.len();
+
+    if end > bytes.len() || &bytes[start..end] != keyword.as_bytes() {
+        return false;
+    }
+
+    let previous_ok = start == 0 || is_keyword_boundary(bytes[start - 1] as char);
+    let next_ok = end >= bytes.len() || is_keyword_boundary(bytes[end] as char);
+    previous_ok && next_ok
+}
+
+fn is_keyword_boundary(character: char) -> bool {
+    character.is_ascii_whitespace() || matches!(character, '{' | '}')
+}
+
+fn normalize_math_body(body: &str) -> String {
+    body.lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn encode_kdl_string(value: &str) -> String {
+    let mut encoded = String::with_capacity(value.len() + 2);
+    encoded.push('"');
+    for character in value.chars() {
+        match character {
+            '\\' => encoded.push_str("\\\\"),
+            '"' => encoded.push_str("\\\""),
+            '\n' => encoded.push_str("\\n"),
+            '\r' => encoded.push_str("\\r"),
+            '\t' => encoded.push_str("\\t"),
+            _ => encoded.push(character),
+        }
+    }
+    encoded.push('"');
+    encoded
+}
+
+/// When the scenario lists technologies explicitly, use those. Otherwise walk
+/// the scenario's asset and instances declarations to discover which
+/// technologies are in use.
+fn infer_technology_names(program: &SourceProgram, scenario: &ScenarioDecl) -> Vec<String> {
+    if !scenario.technologies.is_empty() {
+        return scenario.technologies.clone();
+    }
+    let mut names = BTreeSet::new();
+    for asset_name in &scenario.assets {
+        if let Some(asset) = program.asset(asset_name) {
+            names.insert(asset.technology.clone());
+        }
+    }
+    for instances_name in &scenario.instances {
+        if let Some(inst) = program.instances(instances_name) {
+            names.insert(inst.technology.clone());
+        }
+    }
+    names.into_iter().collect()
+}
+
+/// When the scenario lists operations explicitly, use those. Otherwise collect
+/// operations from asset and instances declarations.
+fn infer_operation_names(program: &SourceProgram, scenario: &ScenarioDecl) -> Vec<String> {
+    if !scenario.operations.is_empty() {
+        return scenario.operations.clone();
+    }
+    let mut names = BTreeSet::new();
+    for asset_name in &scenario.assets {
+        if let Some(op) = program.asset(asset_name).and_then(|a| a.operation.clone()) {
+            names.insert(op);
+        }
+    }
+    for instances_name in &scenario.instances {
+        if let Some(op) = program
+            .instances(instances_name)
+            .and_then(|i| i.operation.clone())
+        {
+            names.insert(op);
+        }
+    }
+    names.into_iter().collect()
+}
+
+/// When the scenario lists rules explicitly, use those. Otherwise include
+/// every declared rule in the program.
+fn infer_rule_names(program: &SourceProgram, scenario: &ScenarioDecl) -> Vec<String> {
+    if !scenario.rules.is_empty() {
+        return scenario.rules.clone();
+    }
+    program.rules.iter().map(|r| r.name.clone()).collect()
+}

--- a/crates/arco-kdl/src/pipeline.rs
+++ b/crates/arco-kdl/src/pipeline.rs
@@ -1,0 +1,126 @@
+use crate::lowering::{LoweredProblem, LoweringError, lower_program};
+use crate::normalize::{NormalizeError, normalize_program};
+use crate::semantic::{SemanticError, SemanticProgram, validate_program};
+use crate::source::{SourceError, parse_program_file};
+use miette::Diagnostic;
+use std::path::{Path, PathBuf};
+use std::{fmt::Display, time::Duration, time::Instant};
+use thiserror::Error;
+
+#[derive(Debug)]
+pub struct CompiledProgram {
+    pub entrypoint: PathBuf,
+    pub semantic_program: SemanticProgram,
+    pub lowered_problem: LoweredProblem,
+    pub timing: PipelineTiming,
+}
+
+#[derive(Debug)]
+pub struct ValidatedProgram {
+    pub entrypoint: PathBuf,
+    pub semantic_program: SemanticProgram,
+}
+
+#[derive(Debug)]
+struct ValidatedSource {
+    entrypoint: PathBuf,
+    parsed_source: crate::source::ParsedSource,
+    semantic_program: SemanticProgram,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct PipelineTiming {
+    pub parse: Duration,
+    pub validate: Duration,
+    pub lower: Duration,
+}
+
+#[derive(Debug, Error)]
+pub enum PipelineError {
+    #[error(transparent)]
+    Source(#[from] SourceError),
+    #[error(transparent)]
+    Normalize(#[from] NormalizeError),
+    #[error(transparent)]
+    Semantic(#[from] SemanticError),
+    #[error(transparent)]
+    Lowering(#[from] LoweringError),
+}
+
+impl Diagnostic for PipelineError {
+    fn code<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
+        None
+    }
+
+    fn diagnostic_source(&self) -> Option<&dyn Diagnostic> {
+        match self {
+            Self::Source(error) => Some(error),
+            Self::Normalize(error) => Some(error),
+            Self::Semantic(error) => Some(error),
+            Self::Lowering(error) => Some(error),
+        }
+    }
+}
+
+pub fn compile_file(path: &Path) -> Result<CompiledProgram, PipelineError> {
+    let parse_start = Instant::now();
+    let parsed_source = parse_program_file(path)?;
+    let parse = parse_start.elapsed();
+
+    let validate_start = Instant::now();
+    let semantic_program = validate_parsed_source(&parsed_source, path)?;
+    let validate = validate_start.elapsed();
+
+    let validated = ValidatedSource {
+        entrypoint: path.to_path_buf(),
+        parsed_source,
+        semantic_program,
+    };
+
+    let lower_start = Instant::now();
+    let lowered_problem = lower_program(
+        &validated.semantic_program,
+        &validated.parsed_source.program,
+        &validated.entrypoint,
+    )?;
+    let lower = lower_start.elapsed();
+
+    Ok(CompiledProgram {
+        entrypoint: validated.entrypoint,
+        semantic_program: validated.semantic_program,
+        lowered_problem,
+        timing: PipelineTiming {
+            parse,
+            validate,
+            lower,
+        },
+    })
+}
+
+pub fn validate_file(path: &Path) -> Result<ValidatedProgram, PipelineError> {
+    let validated = validate_source_file(path)?;
+
+    Ok(ValidatedProgram {
+        entrypoint: validated.entrypoint,
+        semantic_program: validated.semantic_program,
+    })
+}
+
+fn validate_source_file(path: &Path) -> Result<ValidatedSource, PipelineError> {
+    let parsed_source = parse_program_file(path)?;
+    let semantic_program = validate_parsed_source(&parsed_source, path)?;
+
+    Ok(ValidatedSource {
+        entrypoint: path.to_path_buf(),
+        parsed_source,
+        semantic_program,
+    })
+}
+
+fn validate_parsed_source(
+    parsed_source: &crate::source::ParsedSource,
+    path: &Path,
+) -> Result<SemanticProgram, PipelineError> {
+    normalize_program(&parsed_source.program, path)?;
+    validate_program(&parsed_source.program, path).map_err(Into::into)
+}

--- a/crates/arco-kdl/src/semantic.rs
+++ b/crates/arco-kdl/src/semantic.rs
@@ -1,0 +1,1529 @@
+// thiserror's Display derive triggers unused_assignments in edition 2024
+// because derive-generated code no longer inherits item-level #[allow].
+#![allow(unused_assignments)]
+
+use crate::algebra::{
+    ConstraintBody, Expr, collect_named_expression_dependencies, constraint_mentions_previous_time,
+};
+use crate::source::{
+    BoundExpr, ConstraintDecl, DataBindingDecl, GenerationBinding, InstancesDecl, ScenarioDecl,
+    SourceProgram, VariableKindDecl,
+};
+use csv::StringRecord;
+use miette::Diagnostic;
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+use tracing::{debug, info};
+
+struct DataBindingContext<'a> {
+    expected_steps: usize,
+    asset_count: usize,
+    series: &'a mut BTreeSet<String>,
+    indexed: &'a mut BTreeSet<String>,
+    asset: &'a mut BTreeSet<String>,
+}
+
+/// A structured variable family declaration: a target name and its index
+/// dimensions. For example, `dispatch[a,t]` is represented as
+/// `FamilySignature { target: "dispatch", indices: ["a", "t"] }`.
+///
+/// When an index is explicitly bound to a set domain via `in="set_name"`,
+/// the mapping is stored in `index_domains`. This lets the lowering phase
+/// iterate over user-defined sets instead of relying solely on the
+/// hardcoded "a" = assets, "t" = time convention.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct FamilySignature {
+    pub target: String,
+    pub indices: Vec<String>,
+    pub index_domains: BTreeMap<String, String>,
+}
+
+impl FamilySignature {
+    pub fn new(
+        target: impl Into<String>,
+        indices: impl IntoIterator<Item = impl Into<String>>,
+    ) -> Self {
+        Self {
+            target: target.into(),
+            indices: indices.into_iter().map(Into::into).collect(),
+            index_domains: BTreeMap::new(),
+        }
+    }
+
+    /// Build a signature from `IndexDecl` entries, preserving explicit
+    /// domain bindings from `in="..."` properties.
+    pub fn from_index_decls(target: impl Into<String>, decls: &[crate::source::IndexDecl]) -> Self {
+        let mut index_domains = BTreeMap::new();
+        let indices = decls
+            .iter()
+            .map(|idx| {
+                if let Some(domain) = &idx.domain {
+                    index_domains.insert(idx.name.clone(), domain.clone());
+                }
+                idx.name.clone()
+            })
+            .collect();
+        Self {
+            target: target.into(),
+            indices,
+            index_domains,
+        }
+    }
+
+    /// Render the canonical string form, e.g. `"dispatch[a,t]"`.
+    pub fn render(&self) -> String {
+        if self.indices.is_empty() {
+            return self.target.clone();
+        }
+        format!("{}[{}]", self.target, self.indices.join(","))
+    }
+}
+
+/// Declared overrides for a variable family's domain: kind, lower bound,
+/// and upper bound. When present these take precedence over the hardcoded
+/// name-based defaults in `variable_domain_policy`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct VariableDeclOverrides {
+    pub kind: Option<VariableKindDecl>,
+    pub lower: Option<BoundExpr>,
+    pub upper: Option<BoundExpr>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SemanticProgram {
+    pub active_scenario: String,
+    pub sets: ResolvedSets,
+    pub set_registry: BTreeMap<String, ResolvedSet>,
+    pub set_params: BTreeMap<String, BTreeMap<String, f64>>,
+    pub parameters: ResolvedParameters,
+    pub variable_families: Vec<FamilySignature>,
+    pub variable_overrides: BTreeMap<String, VariableDeclOverrides>,
+    pub chronology: ResolvedChronology,
+    pub active_constraints: Vec<ResolvedConstraint>,
+    pub active_expressions: Vec<ResolvedExpression>,
+    pub active_objective: ResolvedObjective,
+    pub active_reports: Vec<ResolvedReport>,
+    pub lowering_rules: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedSets {
+    pub assets: Vec<String>,
+    pub candidate_assets: Vec<String>,
+    pub time: ResolvedTimeSet,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedTimeSet {
+    pub steps: usize,
+    pub resolution: String,
+}
+
+/// A named set of string values for use in reductions and index domains.
+/// Built-in sets (assets, candidate_assets, time) are populated automatically;
+/// user-declared sets in scenarios extend the registry alongside them.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ResolvedSet {
+    pub values: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ResolvedParameters {
+    pub series: Vec<String>,
+    pub indexed: Vec<String>,
+    pub asset: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ResolvedChronology {
+    pub initial_boundary: Option<String>,
+    pub terminal_boundary: Option<String>,
+    pub initial_commitment_boundary: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedConstraint {
+    pub name: String,
+    pub source_kind: String,
+    pub source_name: String,
+    pub expression_text: String,
+    pub expression: ConstraintBody,
+    pub generation_bindings: Vec<GenerationBinding>,
+    pub generation_filter_text: Option<String>,
+    pub generation_filter: Option<Expr>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedExpression {
+    pub name: String,
+    pub formula_text: String,
+    pub formula: Expr,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedObjective {
+    pub name: String,
+    pub sense: String,
+    pub expression_text: String,
+    pub expression: Expr,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedReport {
+    pub name: String,
+    pub formula_text: String,
+    pub formula: Expr,
+}
+
+#[derive(Debug, Error, Diagnostic)]
+pub enum SemanticError {
+    #[error("no scenario is available for semantic validation in {path}")]
+    #[diagnostic(
+        code(arco::semantic::missing_scenario),
+        help("add a `scenario` declaration")
+    )]
+    MissingScenario { path: PathBuf },
+    #[error("missing declaration `{kind}` named `{name}` in {path}")]
+    #[diagnostic(
+        code(arco::semantic::missing_declaration),
+        help("add the missing declaration or update the reference to an existing one")
+    )]
+    MissingDeclaration {
+        kind: &'static str,
+        name: String,
+        path: PathBuf,
+    },
+    #[error("duplicate scenario data binding `{name}` in {path}")]
+    #[diagnostic(
+        code(arco::semantic::duplicate_data_binding),
+        help("rename or remove the duplicate data binding")
+    )]
+    DuplicateDataBinding { name: String, path: PathBuf },
+    #[error("duplicate asset identifier `{asset}` in {path}")]
+    #[diagnostic(
+        code(arco::semantic::duplicate_asset),
+        help("ensure each asset name is unique within the resolved scenario")
+    )]
+    DuplicateAsset { asset: String, path: PathBuf },
+    #[error("missing required column `{column}` in {path}")]
+    #[diagnostic(
+        code(arco::semantic::missing_column),
+        help("add the missing CSV column or update the instances mapping")
+    )]
+    MissingColumn { column: String, path: PathBuf },
+    #[error("missing required value in column `{column}` at row {row} in {path}")]
+    #[diagnostic(
+        code(arco::semantic::missing_cell),
+        help("fill in the missing value in the input table")
+    )]
+    MissingCell {
+        column: String,
+        row: usize,
+        path: PathBuf,
+    },
+    #[error("time series `{name}` in {path} has {actual_steps} steps, expected {expected_steps}")]
+    #[diagnostic(
+        code(arco::semantic::time_series_length),
+        help("make the series length match the scenario horizon")
+    )]
+    TimeSeriesLength {
+        name: String,
+        path: PathBuf,
+        expected_steps: usize,
+        actual_steps: usize,
+    },
+    #[error(
+        "asset-scoped data `{name}` in {path} has {actual_assets} rows, expected {expected_assets}"
+    )]
+    #[diagnostic(
+        code(arco::semantic::asset_data_length),
+        help("make the asset-scoped data row count match the resolved asset set")
+    )]
+    AssetDataLength {
+        name: String,
+        path: PathBuf,
+        expected_assets: usize,
+        actual_assets: usize,
+    },
+    #[error("indexed data `{name}` in {path} has {actual_rows} rows, expected {expected_rows}")]
+    #[diagnostic(
+        code(arco::semantic::indexed_data_length),
+        help("make the indexed data row count match assets x time")
+    )]
+    IndexedDataLength {
+        name: String,
+        path: PathBuf,
+        expected_rows: usize,
+        actual_rows: usize,
+    },
+    #[error("chronology-dependent expressions require an explicit initial boundary in {path}")]
+    #[diagnostic(
+        code(arco::semantic::missing_initial_boundary),
+        help(
+            "provide an initial state or commitment boundary for chronology-dependent constraints"
+        )
+    )]
+    MissingInitialBoundary { path: PathBuf },
+    #[error("failed to read csv {path}: {source}")]
+    #[diagnostic(
+        code(arco::semantic::csv),
+        help("verify the CSV path exists and is readable")
+    )]
+    Csv {
+        path: PathBuf,
+        #[source]
+        source: csv::Error,
+    },
+}
+
+pub fn validate_program(
+    program: &SourceProgram,
+    entrypoint: &Path,
+) -> Result<SemanticProgram, SemanticError> {
+    info!("validating program");
+    if !program.models.is_empty() {
+        return validate_canonical_model_program(program, entrypoint);
+    }
+
+    let scenario = resolve_scenario(program, entrypoint)?;
+
+    let mut seen_data = BTreeSet::new();
+    for binding in &scenario.data {
+        if !seen_data.insert(binding.name.clone()) {
+            return Err(SemanticError::DuplicateDataBinding {
+                name: binding.name.clone(),
+                path: entrypoint.to_path_buf(),
+            });
+        }
+    }
+
+    let entry_dir = entrypoint
+        .parent()
+        .ok_or_else(|| SemanticError::MissingScenario {
+            path: entrypoint.to_path_buf(),
+        })?;
+
+    let mut assets = BTreeSet::new();
+    let mut candidate_assets = BTreeSet::new();
+    let mut asset_parameters = BTreeSet::new();
+    let mut technology_names = BTreeSet::new();
+    let mut operation_names = BTreeSet::new();
+    // Maps the set key (technology.set_name or technology.name) -> asset names.
+    let mut technology_assets: BTreeMap<String, Vec<String>> = BTreeMap::new();
+
+    for asset_name in &scenario.assets {
+        let asset = program
+            .asset(asset_name)
+            .ok_or_else(|| SemanticError::MissingDeclaration {
+                kind: "asset",
+                name: asset_name.clone(),
+                path: entrypoint.to_path_buf(),
+            })?;
+        if !assets.insert(asset.name.clone()) {
+            return Err(SemanticError::DuplicateAsset {
+                asset: asset.name.clone(),
+                path: entrypoint.to_path_buf(),
+            });
+        }
+        technology_names.insert(asset.technology.clone());
+        let set_key = technology_set_key(program, &asset.technology);
+        technology_assets
+            .entry(set_key)
+            .or_default()
+            .push(asset.name.clone());
+        if let Some(operation) = &asset.operation {
+            operation_names.insert(operation.clone());
+        }
+        for parameter_name in asset.parameters.keys() {
+            asset_parameters.insert(format!("{parameter_name}[a]"));
+        }
+    }
+
+    for instances_name in &scenario.instances {
+        let instances =
+            program
+                .instances(instances_name)
+                .ok_or_else(|| SemanticError::MissingDeclaration {
+                    kind: "instances",
+                    name: instances_name.clone(),
+                    path: entrypoint.to_path_buf(),
+                })?;
+        technology_names.insert(instances.technology.clone());
+        if let Some(operation) = &instances.operation {
+            operation_names.insert(operation.clone());
+        }
+        let csv_path = entry_dir.join(&instances.source);
+        let rows = read_csv_rows(&csv_path)?;
+        let name_column = instances_name_column(instances, &csv_path)?;
+
+        for row in &rows {
+            let asset_name = required_cell(row, &name_column, 0, &csv_path)?;
+            if !assets.insert(asset_name.clone()) {
+                return Err(SemanticError::DuplicateAsset {
+                    asset: asset_name,
+                    path: csv_path.clone(),
+                });
+            }
+            let set_key = technology_set_key(program, &instances.technology);
+            technology_assets
+                .entry(set_key)
+                .or_default()
+                .push(asset_name);
+        }
+
+        if instances.columns.is_empty() {
+            // Auto-map: every CSV column except the identity column becomes a
+            // parameter with the same name.
+            if let Some(first_row) = rows.first() {
+                for col_name in first_row.keys() {
+                    if col_name != &name_column {
+                        asset_parameters.insert(format!("{col_name}[a]"));
+                    }
+                }
+            }
+        } else {
+            for target in instances
+                .columns
+                .iter()
+                .filter(|column| column.target != "name")
+                .map(|column| column.target.as_str())
+            {
+                asset_parameters.insert(format!("{target}[a]"));
+            }
+        }
+
+        if instances.name.starts_with("Candidate") {
+            for row in &rows {
+                candidate_assets.insert(required_cell(row, &name_column, 0, &csv_path)?);
+            }
+        }
+    }
+
+    let asset_count = assets.len();
+    let mut series_parameters = BTreeSet::new();
+    let mut indexed_parameters = BTreeSet::new();
+
+    for binding in &scenario.data {
+        let csv_path = entry_dir.join(&binding.source);
+        let rows = read_csv_rows(&csv_path)?;
+        let mut context = DataBindingContext {
+            expected_steps: scenario.horizon.steps,
+            asset_count,
+            series: &mut series_parameters,
+            indexed: &mut indexed_parameters,
+            asset: &mut asset_parameters,
+        };
+        classify_data_binding(binding, &csv_path, &rows, &mut context)?;
+    }
+
+    let mut variable_families =
+        technology_variable_families(program, &technology_names, entrypoint)?;
+
+    // Derive extra variable families from the problem structure rather than
+    // relying on a mode string. If candidate assets exist, the problem needs
+    // a build decision variable. If unserved_energy appears in constraints,
+    // objectives, or expressions, it needs its own family.
+    if !candidate_assets.is_empty() {
+        variable_families.insert(FamilySignature::new("build", ["a"]));
+    }
+
+    let active_objective_name =
+        scenario
+            .objective
+            .clone()
+            .ok_or_else(|| SemanticError::MissingDeclaration {
+                kind: "objective",
+                name: "active objective".to_string(),
+                path: entrypoint.to_path_buf(),
+            })?;
+    let active_objective_decl = program.objective(&active_objective_name).ok_or_else(|| {
+        SemanticError::MissingDeclaration {
+            kind: "objective",
+            name: active_objective_name.clone(),
+            path: entrypoint.to_path_buf(),
+        }
+    })?;
+
+    // Auto-wire rules: when the scenario doesn't list any rules explicitly,
+    // include every declared rule. When it does list rules, use that subset.
+    let active_rule_names: Vec<String> = if scenario.rules.is_empty() {
+        program.rules.iter().map(|r| r.name.clone()).collect()
+    } else {
+        scenario.rules.clone()
+    };
+
+    // Scan all algebra sources for implicit variable families not covered
+    // by declared technologies (e.g. unserved_energy).
+    let implicit_families = collect_implicit_variable_families(
+        program,
+        &operation_names,
+        &active_rule_names,
+        active_objective_decl,
+        &scenario.reports,
+        &variable_families,
+    );
+    variable_families.extend(implicit_families);
+
+    let chronology = ResolvedChronology {
+        initial_boundary: contains_parameter(&asset_parameters, "initial_soc_mwh[a]"),
+        terminal_boundary: contains_parameter(&asset_parameters, "terminal_soc_mwh[a]"),
+        initial_commitment_boundary: contains_parameter(&asset_parameters, "initial_commitment[a]"),
+    };
+
+    let active_constraints = resolve_direct_wiring_constraints(
+        program,
+        &operation_names,
+        &active_rule_names,
+        entrypoint,
+    )?;
+    if active_constraints
+        .iter()
+        .any(|constraint| constraint_mentions_previous_time(&constraint.expression))
+        && chronology.initial_boundary.is_none()
+        && chronology.initial_commitment_boundary.is_none()
+    {
+        return Err(SemanticError::MissingInitialBoundary {
+            path: entrypoint.to_path_buf(),
+        });
+    }
+
+    let active_objective = ResolvedObjective {
+        name: active_objective_decl.name.clone(),
+        sense: active_objective_decl.sense.clone(),
+        expression_text: active_objective_decl.expression.clone(),
+        expression: active_objective_decl.parsed_expression.clone(),
+    };
+    let active_reports = resolve_scenario_reports(program, scenario, entrypoint)?;
+    let active_expressions =
+        resolve_active_expressions(program, &active_objective, &active_reports, entrypoint)?;
+
+    let lowering_rules = if candidate_assets.is_empty() {
+        Vec::new()
+    } else {
+        vec![
+            "build[a] is a decision family over candidate_assets".to_string(),
+            "build[a] is fixed to zero for non-candidate assets".to_string(),
+        ]
+    };
+
+    let resolved_sets = ResolvedSets {
+        assets: assets.into_iter().collect(),
+        candidate_assets: candidate_assets.into_iter().collect(),
+        time: ResolvedTimeSet {
+            steps: scenario.horizon.steps,
+            resolution: scenario.horizon.resolution.clone(),
+        },
+    };
+    let mut set_registry = build_set_registry(&resolved_sets, &scenario.custom_sets);
+    for (technology_name, asset_names) in technology_assets {
+        set_registry
+            .entry(technology_name)
+            .or_insert_with(|| ResolvedSet {
+                values: asset_names,
+            });
+    }
+
+    let mut set_params: BTreeMap<String, BTreeMap<String, f64>> = BTreeMap::new();
+    for set_binding in &scenario.set_bindings {
+        let csv_path = entry_dir.join(&set_binding.source);
+        let set_csv = load_set_csv(&csv_path)?;
+        set_registry.insert(
+            set_binding.name.clone(),
+            ResolvedSet {
+                values: set_csv.members,
+            },
+        );
+        set_params.extend(set_csv.params);
+    }
+
+    Ok(SemanticProgram {
+        active_scenario: scenario.name.clone(),
+        sets: resolved_sets,
+        set_registry,
+        set_params,
+        parameters: ResolvedParameters {
+            series: series_parameters.into_iter().collect(),
+            indexed: indexed_parameters.into_iter().collect(),
+            asset: asset_parameters.into_iter().collect(),
+        },
+        variable_families: variable_families.into_iter().collect(),
+        variable_overrides: collect_technology_overrides(program, &technology_names, entrypoint)?,
+        chronology,
+        active_constraints,
+        active_expressions,
+        active_objective,
+        active_reports,
+        lowering_rules,
+    })
+    .inspect(|semantic_program| {
+        debug!(
+            "resolved {} assets, {} constraints, {} variable families",
+            semantic_program.sets.assets.len(),
+            semantic_program.active_constraints.len(),
+            semantic_program.variable_families.len()
+        );
+    })
+}
+
+fn validate_canonical_model_program(
+    program: &SourceProgram,
+    entrypoint: &Path,
+) -> Result<SemanticProgram, SemanticError> {
+    let scenario = resolve_scenario(program, entrypoint)?;
+    let model_name =
+        scenario
+            .model_use
+            .clone()
+            .ok_or_else(|| SemanticError::MissingDeclaration {
+                kind: "model",
+                name: "active model".to_string(),
+                path: entrypoint.to_path_buf(),
+            })?;
+    let model = program
+        .model(&model_name)
+        .ok_or_else(|| SemanticError::MissingDeclaration {
+            kind: "model",
+            name: model_name,
+            path: entrypoint.to_path_buf(),
+        })?;
+
+    let mut asset_names = scenario.assets.iter().cloned().collect::<BTreeSet<_>>();
+    if asset_names.is_empty() {
+        for set_decl in &model.sets {
+            if set_decl.name == "assets" {
+                asset_names.insert("assets".to_string());
+            }
+        }
+    }
+
+    let mut series_parameters = BTreeSet::new();
+    let mut indexed_parameters = BTreeSet::new();
+    let mut asset_parameters = BTreeSet::new();
+    for parameter in &model.parameters {
+        classify_parameter_indices(
+            &parameter.name,
+            &parameter.indices,
+            &mut series_parameters,
+            &mut indexed_parameters,
+            &mut asset_parameters,
+        );
+    }
+
+    let active_constraints = model
+        .constraints
+        .iter()
+        .map(|constraint| ResolvedConstraint {
+            name: constraint.name.clone(),
+            source_kind: "model".to_string(),
+            source_name: model.name.clone(),
+            expression_text: constraint.expression.clone(),
+            expression: constraint.parsed_expression.clone(),
+            generation_bindings: constraint.generation_bindings.clone(),
+            generation_filter_text: constraint.generation_filter.clone(),
+            generation_filter: constraint.parsed_generation_filter.clone(),
+        })
+        .collect::<Vec<_>>();
+
+    let chronology = detect_model_chronology(&asset_parameters, scenario);
+    if active_constraints
+        .iter()
+        .any(|constraint| constraint_mentions_previous_time(&constraint.expression))
+        && chronology.initial_boundary.is_none()
+        && chronology.initial_commitment_boundary.is_none()
+    {
+        return Err(SemanticError::MissingInitialBoundary {
+            path: entrypoint.to_path_buf(),
+        });
+    }
+
+    let active_objective = ResolvedObjective {
+        name: model.optimize.name.clone(),
+        sense: model.optimize.sense.clone(),
+        expression_text: model.optimize.expression.clone(),
+        expression: model.optimize.parsed_expression.clone(),
+    };
+    let active_reports = resolve_scenario_reports(program, scenario, entrypoint)?;
+    let active_expressions =
+        resolve_active_expressions(program, &active_objective, &active_reports, entrypoint)?;
+
+    let resolved_sets = ResolvedSets {
+        assets: asset_names.into_iter().collect(),
+        candidate_assets: Vec::new(),
+        time: ResolvedTimeSet {
+            steps: scenario.horizon.steps,
+            resolution: scenario.horizon.resolution.clone(),
+        },
+    };
+    let mut set_registry = build_set_registry(&resolved_sets, &scenario.custom_sets);
+
+    let mut set_params: BTreeMap<String, BTreeMap<String, f64>> = BTreeMap::new();
+    if let Some(entry_dir) = entrypoint.parent() {
+        for set_binding in &scenario.set_bindings {
+            let csv_path = entry_dir.join(&set_binding.source);
+            let set_csv = load_set_csv(&csv_path)?;
+            set_registry.insert(
+                set_binding.name.clone(),
+                ResolvedSet {
+                    values: set_csv.members,
+                },
+            );
+            set_params.extend(set_csv.params);
+        }
+    }
+
+    Ok(SemanticProgram {
+        active_scenario: scenario.name.clone(),
+        sets: resolved_sets,
+        set_registry,
+        set_params,
+        parameters: ResolvedParameters {
+            series: series_parameters.into_iter().collect(),
+            indexed: indexed_parameters.into_iter().collect(),
+            asset: asset_parameters.into_iter().collect(),
+        },
+        variable_families: model
+            .controls
+            .iter()
+            .map(|control| FamilySignature::from_index_decls(&control.name, &control.indices))
+            .collect(),
+        variable_overrides: collect_control_overrides(
+            model
+                .controls
+                .iter()
+                .map(|c| (c.name.as_str(), c.kind, c.lower.as_ref(), c.upper.as_ref())),
+        ),
+        chronology,
+        active_constraints,
+        active_expressions,
+        active_objective,
+        active_reports,
+        lowering_rules: Vec::new(),
+    })
+}
+
+fn classify_parameter_indices(
+    name: &str,
+    indices: &[String],
+    series_parameters: &mut BTreeSet<String>,
+    indexed_parameters: &mut BTreeSet<String>,
+    asset_parameters: &mut BTreeSet<String>,
+) {
+    let normalized_indices = indices
+        .iter()
+        .map(|index| index.trim().replace(' ', ""))
+        .collect::<Vec<_>>();
+
+    if normalized_indices.is_empty() {
+        let _ = asset_parameters.insert(render_signature(name, &normalized_indices));
+        return;
+    }
+
+    let signature = render_signature(name, &normalized_indices);
+
+    if normalized_indices.len() == 1 {
+        let index = &normalized_indices[0];
+        if index.contains('t') || index.contains("time") {
+            let _ = series_parameters.insert(signature);
+        } else {
+            let _ = asset_parameters.insert(signature);
+        }
+    } else {
+        let _ = indexed_parameters.insert(signature);
+    }
+}
+
+fn render_signature(name: &str, indices: &[String]) -> String {
+    if indices.is_empty() {
+        return name.to_string();
+    }
+
+    let normalized = indices.join(",");
+    format!("{name}[{normalized}]")
+}
+
+fn resolve_scenario<'a>(
+    program: &'a SourceProgram,
+    entrypoint: &Path,
+) -> Result<&'a ScenarioDecl, SemanticError> {
+    program
+        .first_scenario()
+        .ok_or_else(|| SemanticError::MissingScenario {
+            path: entrypoint.to_path_buf(),
+        })
+}
+
+fn resolve_direct_wiring_constraints(
+    program: &SourceProgram,
+    operation_names: &BTreeSet<String>,
+    rule_names: &[String],
+    entrypoint: &Path,
+) -> Result<Vec<ResolvedConstraint>, SemanticError> {
+    let mut constraints = Vec::new();
+
+    for operation_name in operation_names {
+        let operation =
+            program
+                .operation(operation_name)
+                .ok_or_else(|| SemanticError::MissingDeclaration {
+                    kind: "operation",
+                    name: operation_name.clone(),
+                    path: entrypoint.to_path_buf(),
+                })?;
+        append_constraints(
+            &mut constraints,
+            "operation",
+            &operation.name,
+            &operation.constraints,
+        );
+    }
+
+    for rule_name in rule_names {
+        let rule = program
+            .rule(rule_name)
+            .ok_or_else(|| SemanticError::MissingDeclaration {
+                kind: "rule",
+                name: rule_name.clone(),
+                path: entrypoint.to_path_buf(),
+            })?;
+        append_constraints(&mut constraints, "rule", &rule.name, &rule.constraints);
+    }
+
+    constraints.sort_by_key(|constraint| {
+        (
+            constraint.source_kind.clone(),
+            constraint.source_name.clone(),
+            constraint.name.clone(),
+        )
+    });
+    Ok(constraints)
+}
+
+fn append_constraints(
+    target: &mut Vec<ResolvedConstraint>,
+    source_kind: &str,
+    source_name: &str,
+    constraints: &[ConstraintDecl],
+) {
+    for constraint in constraints {
+        target.push(ResolvedConstraint {
+            name: constraint.name.clone(),
+            source_kind: source_kind.to_string(),
+            source_name: source_name.to_string(),
+            expression_text: constraint.expression.clone(),
+            expression: constraint.parsed_expression.clone(),
+            generation_bindings: constraint.generation_bindings.clone(),
+            generation_filter_text: constraint.generation_filter.clone(),
+            generation_filter: constraint.parsed_generation_filter.clone(),
+        });
+    }
+}
+
+fn resolve_scenario_reports(
+    program: &SourceProgram,
+    scenario: &ScenarioDecl,
+    entrypoint: &Path,
+) -> Result<Vec<ResolvedReport>, SemanticError> {
+    let mut reports = Vec::new();
+    for report_name in &scenario.reports {
+        let expression =
+            program
+                .expression(report_name)
+                .ok_or_else(|| SemanticError::MissingDeclaration {
+                    kind: "expression",
+                    name: report_name.clone(),
+                    path: entrypoint.to_path_buf(),
+                })?;
+        reports.push(ResolvedReport {
+            name: expression.name.clone(),
+            formula_text: expression.formula.clone(),
+            formula: expression.parsed_formula.clone(),
+        });
+    }
+    Ok(reports)
+}
+
+fn resolve_active_expressions(
+    program: &SourceProgram,
+    objective: &ResolvedObjective,
+    reports: &[ResolvedReport],
+    entrypoint: &Path,
+) -> Result<Vec<ResolvedExpression>, SemanticError> {
+    let mut names = BTreeSet::new();
+    let mut expressions = Vec::new();
+
+    resolve_expression_dependencies(program, &objective.expression, &mut names, entrypoint)?;
+    for report in reports {
+        names.insert(report.name.clone());
+        resolve_expression_dependencies(program, &report.formula, &mut names, entrypoint)?;
+    }
+
+    for name in names {
+        let expression =
+            program
+                .expression(&name)
+                .ok_or_else(|| SemanticError::MissingDeclaration {
+                    kind: "expression",
+                    name: name.clone(),
+                    path: entrypoint.to_path_buf(),
+                })?;
+        expressions.push(ResolvedExpression {
+            name: expression.name.clone(),
+            formula_text: expression.formula.clone(),
+            formula: expression.parsed_formula.clone(),
+        });
+    }
+    expressions.sort_by_key(|expression| expression.name.clone());
+    Ok(expressions)
+}
+
+fn resolve_expression_dependencies(
+    program: &SourceProgram,
+    expression: &Expr,
+    names: &mut BTreeSet<String>,
+    entrypoint: &Path,
+) -> Result<(), SemanticError> {
+    for dependency in collect_named_expression_dependencies(expression) {
+        let declaration =
+            program
+                .expression(&dependency)
+                .ok_or_else(|| SemanticError::MissingDeclaration {
+                    kind: "expression",
+                    name: dependency.clone(),
+                    path: entrypoint.to_path_buf(),
+                })?;
+        if names.insert(dependency) {
+            resolve_expression_dependencies(
+                program,
+                &declaration.parsed_formula,
+                names,
+                entrypoint,
+            )?;
+        }
+    }
+    Ok(())
+}
+
+fn contains_parameter(parameters: &BTreeSet<String>, name: &str) -> Option<String> {
+    parameters.contains(name).then(|| name.to_string())
+}
+
+/// Detect chronology boundaries for the model path. Unlike the high-level
+/// path which checks for exact signatures like `initial_soc_mwh[a]`, the
+/// model path uses custom index letters. We check if the parameter name
+/// prefix matches regardless of the index letter used. Data bindings
+/// from the scenario are also checked as a fallback since model-path
+/// parameters commonly arrive via CSV data rather than inline `param`
+/// declarations.
+fn detect_model_chronology(
+    asset_parameters: &BTreeSet<String>,
+    scenario: &ScenarioDecl,
+) -> ResolvedChronology {
+    let has_param = |name: &str| -> Option<String> {
+        // Check model param declarations (any index letter)
+        if asset_parameters
+            .iter()
+            .any(|p| p == name || p.starts_with(&format!("{name}[")))
+        {
+            return Some(name.to_string());
+        }
+        // Check scenario data bindings (CSV-provided parameters)
+        if scenario.data.iter().any(|d| d.name == name) {
+            return Some(name.to_string());
+        }
+        None
+    };
+
+    ResolvedChronology {
+        initial_boundary: has_param("initial_soc_mwh"),
+        terminal_boundary: has_param("terminal_soc_mwh"),
+        initial_commitment_boundary: has_param("initial_commitment"),
+    }
+}
+
+struct SetCsvData {
+    members: Vec<String>,
+    params: BTreeMap<String, BTreeMap<String, f64>>,
+}
+
+/// Load a CSV file that defines a set. The first column must be `name` and
+/// contains the member identifiers. Remaining columns are numeric parameters
+/// keyed by member name.
+fn load_set_csv(path: &Path) -> Result<SetCsvData, SemanticError> {
+    let mut reader = csv::Reader::from_path(path).map_err(|source| SemanticError::Csv {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    let headers = reader
+        .headers()
+        .map_err(|source| SemanticError::Csv {
+            path: path.to_path_buf(),
+            source,
+        })?
+        .clone();
+
+    let name_index =
+        headers
+            .iter()
+            .position(|h| h == "name")
+            .ok_or_else(|| SemanticError::MissingColumn {
+                column: "name".to_string(),
+                path: path.to_path_buf(),
+            })?;
+
+    let param_columns: Vec<(usize, String)> = headers
+        .iter()
+        .enumerate()
+        .filter(|(i, _)| *i != name_index)
+        .map(|(i, h)| (i, h.to_string()))
+        .collect();
+
+    let mut members = Vec::new();
+    let mut member_params = BTreeMap::new();
+
+    for (row_index, record) in reader.records().enumerate() {
+        let record = record.map_err(|source| SemanticError::Csv {
+            path: path.to_path_buf(),
+            source,
+        })?;
+        let member_name = record
+            .get(name_index)
+            .filter(|v| !v.is_empty())
+            .ok_or_else(|| SemanticError::MissingCell {
+                column: "name".to_string(),
+                row: row_index + 1,
+                path: path.to_path_buf(),
+            })?
+            .to_string();
+
+        let mut params = BTreeMap::new();
+        for (col_index, col_name) in &param_columns {
+            let raw = record
+                .get(*col_index)
+                .filter(|v| !v.is_empty())
+                .ok_or_else(|| SemanticError::MissingCell {
+                    column: col_name.clone(),
+                    row: row_index + 1,
+                    path: path.to_path_buf(),
+                })?;
+            let value = raw.parse::<f64>().map_err(|_| SemanticError::MissingCell {
+                column: col_name.clone(),
+                row: row_index + 1,
+                path: path.to_path_buf(),
+            })?;
+            params.insert(col_name.clone(), value);
+        }
+        members.push(member_name.clone());
+        member_params.insert(member_name, params);
+    }
+
+    Ok(SetCsvData {
+        members,
+        params: member_params,
+    })
+}
+
+fn read_csv_rows(path: &Path) -> Result<Vec<BTreeMap<String, String>>, SemanticError> {
+    let mut reader = csv::Reader::from_path(path).map_err(|source| SemanticError::Csv {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    let headers = reader
+        .headers()
+        .map_err(|source| SemanticError::Csv {
+            path: path.to_path_buf(),
+            source,
+        })?
+        .clone();
+
+    reader
+        .records()
+        .enumerate()
+        .map(|(index, record)| {
+            let record = record.map_err(|source| SemanticError::Csv {
+                path: path.to_path_buf(),
+                source,
+            })?;
+            record_to_map(path, &headers, index + 1, record)
+        })
+        .collect()
+}
+
+fn record_to_map(
+    path: &Path,
+    headers: &StringRecord,
+    row_index: usize,
+    record: StringRecord,
+) -> Result<BTreeMap<String, String>, SemanticError> {
+    let mut row = BTreeMap::new();
+    for (header, value) in headers.iter().zip(record.iter()) {
+        if value.is_empty() {
+            return Err(SemanticError::MissingCell {
+                column: header.to_string(),
+                row: row_index,
+                path: path.to_path_buf(),
+            });
+        }
+        row.insert(header.to_string(), value.to_string());
+    }
+    Ok(row)
+}
+
+fn instances_name_column(instances: &InstancesDecl, path: &Path) -> Result<String, SemanticError> {
+    if instances.columns.is_empty() {
+        // Auto-map: convention is "asset_name" as the identity column.
+        return Ok("asset_name".to_string());
+    }
+    instances
+        .columns
+        .iter()
+        .find(|column| column.target == "name")
+        .map(|column| column.source.clone())
+        .ok_or_else(|| SemanticError::MissingColumn {
+            column: "name".to_string(),
+            path: path.to_path_buf(),
+        })
+}
+
+fn required_cell(
+    row: &BTreeMap<String, String>,
+    column: &str,
+    row_index: usize,
+    path: &Path,
+) -> Result<String, SemanticError> {
+    row.get(column)
+        .cloned()
+        .ok_or_else(|| SemanticError::MissingCell {
+            column: column.to_string(),
+            row: row_index,
+            path: path.to_path_buf(),
+        })
+}
+
+fn classify_data_binding(
+    binding: &DataBindingDecl,
+    path: &Path,
+    rows: &[BTreeMap<String, String>],
+    context: &mut DataBindingContext<'_>,
+) -> Result<(), SemanticError> {
+    let Some(first_row) = rows.first() else {
+        return Err(SemanticError::MissingCell {
+            column: binding.name.clone(),
+            row: 0,
+            path: path.to_path_buf(),
+        });
+    };
+    let headers = first_row.keys().cloned().collect::<BTreeSet<_>>();
+
+    if headers.contains("asset_name") && headers.contains("t") {
+        let actual_steps = unique_count(rows, "t");
+        if actual_steps != context.expected_steps {
+            return Err(SemanticError::TimeSeriesLength {
+                name: binding.name.clone(),
+                path: path.to_path_buf(),
+                expected_steps: context.expected_steps,
+                actual_steps,
+            });
+        }
+        let expected_rows = context.expected_steps.saturating_mul(context.asset_count);
+        if rows.len() != expected_rows {
+            return Err(SemanticError::IndexedDataLength {
+                name: binding.name.clone(),
+                path: path.to_path_buf(),
+                expected_rows,
+                actual_rows: rows.len(),
+            });
+        }
+        asset_name_rows_unique(rows, path)?;
+        context.indexed.insert(format!("{}[a,t]", binding.name));
+        return Ok(());
+    }
+
+    if headers.contains("asset_name") {
+        if rows.len() != context.asset_count {
+            return Err(SemanticError::AssetDataLength {
+                name: binding.name.clone(),
+                path: path.to_path_buf(),
+                expected_assets: context.asset_count,
+                actual_assets: rows.len(),
+            });
+        }
+        asset_name_rows_unique(rows, path)?;
+        context.asset.insert(format!("{}[a]", binding.name));
+        return Ok(());
+    }
+
+    if headers.contains("t") {
+        let actual_steps = unique_count(rows, "t");
+        if actual_steps != context.expected_steps {
+            return Err(SemanticError::TimeSeriesLength {
+                name: binding.name.clone(),
+                path: path.to_path_buf(),
+                expected_steps: context.expected_steps,
+                actual_steps,
+            });
+        }
+        context.series.insert(format!("{}[t]", binding.name));
+        return Ok(());
+    }
+
+    Err(SemanticError::MissingColumn {
+        column: "asset_name or t".to_string(),
+        path: path.to_path_buf(),
+    })
+}
+
+fn asset_name_rows_unique(
+    rows: &[BTreeMap<String, String>],
+    path: &Path,
+) -> Result<(), SemanticError> {
+    let mut seen = BTreeSet::new();
+    for row in rows {
+        if let Some(asset_name) = row.get("asset_name")
+            && !seen.insert(asset_name.clone())
+            && !row.contains_key("t")
+        {
+            return Err(SemanticError::DuplicateAsset {
+                asset: asset_name.clone(),
+                path: path.to_path_buf(),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn unique_count(rows: &[BTreeMap<String, String>], key: &str) -> usize {
+    rows.iter()
+        .filter_map(|row| row.get(key).cloned())
+        .collect::<BTreeSet<_>>()
+        .len()
+}
+
+/// Scan constraint, objective, and expression ASTs for indexed references that
+/// look like variable families but are not covered by the declared technology
+/// controls/states. This replaces the old mode-based variable family injection
+/// (e.g. capacity_expansion added build[a] and unserved_energy[t]).
+///
+/// We use a conservative allowlist: only well-known implicit variable families
+/// that the old mode system used to inject are recognized. Everything else is
+/// assumed to be a parameter.
+fn collect_implicit_variable_families(
+    program: &SourceProgram,
+    operation_names: &BTreeSet<String>,
+    rule_names: &[String],
+    objective: &crate::source::ObjectiveDecl,
+    report_names: &[String],
+    known_families: &BTreeSet<FamilySignature>,
+) -> BTreeSet<FamilySignature> {
+    let known_targets: BTreeSet<String> = known_families
+        .iter()
+        .map(|family| family.target.clone())
+        .collect();
+
+    let mut all_targets = BTreeSet::new();
+
+    // Collect from operation constraints
+    for op_name in operation_names {
+        if let Some(operation) = program.operation(op_name) {
+            for constraint in &operation.constraints {
+                collect_indexed_targets_from_constraint_body(
+                    &constraint.parsed_expression,
+                    &mut all_targets,
+                );
+            }
+        }
+    }
+
+    // Collect from rule constraints
+    for rule_name in rule_names {
+        if let Some(rule) = program.rule(rule_name) {
+            for constraint in &rule.constraints {
+                collect_indexed_targets_from_constraint_body(
+                    &constraint.parsed_expression,
+                    &mut all_targets,
+                );
+            }
+        }
+    }
+
+    // Collect from objective and expression ASTs (transitively)
+    let mut visited = BTreeSet::new();
+    collect_all_targets_from_expr(
+        &objective.parsed_expression,
+        program,
+        &mut all_targets,
+        &mut visited,
+    );
+    for report_name in report_names {
+        if let Some(expression) = program.expression(report_name) {
+            collect_all_targets_from_expr(
+                &expression.parsed_formula,
+                program,
+                &mut all_targets,
+                &mut visited,
+            );
+        }
+    }
+
+    // Keep only targets that are:
+    // 1. Not already in technology-derived families
+    // 2. On the allowlist of known implicit variable targets
+    all_targets
+        .into_iter()
+        .filter(|(target, _)| !known_targets.contains(target))
+        .filter(|(target, _)| is_implicit_variable_target(target))
+        .map(|(target, index_sig)| {
+            FamilySignature::new(target, index_sig.split(',').map(str::trim))
+        })
+        .collect()
+}
+
+/// Returns true if a target name is a known implicit variable family that
+/// should be auto-discovered from DSL algebra rather than declared in a
+/// technology block. This is the conservative allowlist that replaces the
+/// old mode-based injection.
+fn is_implicit_variable_target(target: &str) -> bool {
+    matches!(target, "unserved_energy" | "build")
+}
+
+fn collect_indexed_targets_from_constraint_body(
+    body: &crate::algebra::ConstraintBody,
+    targets: &mut BTreeSet<(String, String)>,
+) {
+    match body {
+        crate::algebra::ConstraintBody::Comparison { left, right, .. } => {
+            collect_indexed_targets_from_expr(left, targets);
+            collect_indexed_targets_from_expr(right, targets);
+        }
+        crate::algebra::ConstraintBody::Range {
+            lower,
+            middle,
+            upper,
+            ..
+        } => {
+            collect_indexed_targets_from_expr(lower, targets);
+            collect_indexed_targets_from_expr(middle, targets);
+            collect_indexed_targets_from_expr(upper, targets);
+        }
+    }
+}
+
+fn collect_indexed_targets_from_expr(expr: &Expr, targets: &mut BTreeSet<(String, String)>) {
+    match expr {
+        Expr::Indexed { target, indices } => {
+            let index_sig = indices
+                .iter()
+                .map(infer_index_domain)
+                .collect::<Vec<_>>()
+                .join(",");
+            targets.insert((target.clone(), index_sig));
+            for index in indices {
+                collect_indexed_targets_from_expr(index, targets);
+            }
+        }
+        Expr::Unary { expr, .. } => collect_indexed_targets_from_expr(expr, targets),
+        Expr::Binary { left, right, .. } | Expr::Comparison { left, right, .. } => {
+            collect_indexed_targets_from_expr(left, targets);
+            collect_indexed_targets_from_expr(right, targets);
+        }
+        Expr::FunctionCall { args, .. } => {
+            for arg in args {
+                collect_indexed_targets_from_expr(arg, targets);
+            }
+        }
+        Expr::Reduction(reduction) => {
+            collect_indexed_targets_from_expr(&reduction.body, targets);
+            for filter in &reduction.filters {
+                collect_indexed_targets_from_expr(filter, targets);
+            }
+        }
+        Expr::Number(_) | Expr::String(_) | Expr::Boolean(_) | Expr::Identifier(_) => {}
+    }
+}
+
+fn infer_index_domain(expr: &Expr) -> &str {
+    match expr {
+        Expr::Identifier(name) => match name.as_str() {
+            "a" | "g" | "l" | "n" => "a",
+            "t" => "t",
+            _ => "a",
+        },
+        Expr::Binary { left, .. } => infer_index_domain(left),
+        _ => "t",
+    }
+}
+
+fn collect_all_targets_from_expr(
+    expr: &Expr,
+    program: &SourceProgram,
+    targets: &mut BTreeSet<(String, String)>,
+    visited: &mut BTreeSet<String>,
+) {
+    match expr {
+        Expr::Identifier(name) => {
+            if visited.insert(name.clone())
+                && let Some(expression) = program.expression(name)
+            {
+                collect_indexed_targets_from_expr(&expression.parsed_formula, targets);
+                collect_all_targets_from_expr(
+                    &expression.parsed_formula,
+                    program,
+                    targets,
+                    visited,
+                );
+            }
+        }
+        Expr::Indexed { indices, .. } => {
+            for index in indices {
+                collect_all_targets_from_expr(index, program, targets, visited);
+            }
+        }
+        Expr::Unary { expr, .. } => {
+            collect_all_targets_from_expr(expr, program, targets, visited);
+        }
+        Expr::Binary { left, right, .. } | Expr::Comparison { left, right, .. } => {
+            collect_all_targets_from_expr(left, program, targets, visited);
+            collect_all_targets_from_expr(right, program, targets, visited);
+        }
+        Expr::FunctionCall { args, .. } => {
+            for arg in args {
+                collect_all_targets_from_expr(arg, program, targets, visited);
+            }
+        }
+        Expr::Reduction(reduction) => {
+            collect_all_targets_from_expr(&reduction.body, program, targets, visited);
+        }
+        Expr::Number(_) | Expr::String(_) | Expr::Boolean(_) => {}
+    }
+}
+
+/// Returns the set registry key for a technology: the `as` alias if declared,
+/// otherwise the technology name itself.
+fn technology_set_key(program: &SourceProgram, technology_name: &str) -> String {
+    program
+        .technology(technology_name)
+        .and_then(|t| t.set_name.clone())
+        .unwrap_or_else(|| technology_name.to_string())
+}
+
+fn technology_variable_families(
+    program: &SourceProgram,
+    technology_names: &BTreeSet<String>,
+    entrypoint: &Path,
+) -> Result<BTreeSet<FamilySignature>, SemanticError> {
+    let mut families = BTreeSet::new();
+    for technology_name in technology_names {
+        let technology = program.technology(technology_name).ok_or_else(|| {
+            SemanticError::MissingDeclaration {
+                kind: "technology",
+                name: technology_name.clone(),
+                path: entrypoint.to_path_buf(),
+            }
+        })?;
+        for invest in &technology.investments {
+            families.insert(FamilySignature::new(&invest.name, ["a"]));
+        }
+        for control in &technology.controls {
+            families.insert(FamilySignature::new(&control.name, ["a", "t"]));
+        }
+        for state in &technology.states {
+            families.insert(FamilySignature::new(state, ["a", "t"]));
+        }
+    }
+    Ok(families)
+}
+
+/// Collect `VariableDeclOverrides` from technology `NamedVariableDecl`
+/// declarations (invest + control) across all referenced technologies.
+fn collect_technology_overrides(
+    program: &SourceProgram,
+    technology_names: &BTreeSet<String>,
+    entrypoint: &Path,
+) -> Result<BTreeMap<String, VariableDeclOverrides>, SemanticError> {
+    let mut decls = Vec::new();
+    for technology_name in technology_names {
+        let technology = program.technology(technology_name).ok_or_else(|| {
+            SemanticError::MissingDeclaration {
+                kind: "technology",
+                name: technology_name.clone(),
+                path: entrypoint.to_path_buf(),
+            }
+        })?;
+        for decl in technology.investments.iter().chain(&technology.controls) {
+            decls.push((
+                decl.name.as_str(),
+                decl.kind,
+                decl.lower.as_ref(),
+                decl.upper.as_ref(),
+            ));
+        }
+    }
+    Ok(collect_control_overrides(decls.into_iter()))
+}
+
+/// Collect `VariableDeclOverrides` from an iterator of
+/// `(name, kind, lower, upper)` tuples (used for canonical model controls).
+fn collect_control_overrides<'a>(
+    controls: impl Iterator<
+        Item = (
+            &'a str,
+            Option<VariableKindDecl>,
+            Option<&'a BoundExpr>,
+            Option<&'a BoundExpr>,
+        ),
+    >,
+) -> BTreeMap<String, VariableDeclOverrides> {
+    let mut overrides = BTreeMap::new();
+    for (name, kind, lower, upper) in controls {
+        if kind.is_some() || lower.is_some() || upper.is_some() {
+            overrides.insert(
+                name.to_string(),
+                VariableDeclOverrides {
+                    kind,
+                    lower: lower.cloned(),
+                    upper: upper.cloned(),
+                },
+            );
+        }
+    }
+    overrides
+}
+
+/// Build the set registry from the resolved built-in sets and any
+/// user-declared custom sets from the scenario. The registry mirrors
+/// assets, candidate_assets, and time as string vectors so that
+/// `reduction_domain_values` can fall back to a single lookup for both
+/// built-in and user-defined sets.
+fn build_set_registry(
+    sets: &ResolvedSets,
+    custom_sets: &BTreeMap<String, Vec<String>>,
+) -> BTreeMap<String, ResolvedSet> {
+    let mut registry = BTreeMap::new();
+    registry.insert(
+        "assets".to_string(),
+        ResolvedSet {
+            values: sets.assets.clone(),
+        },
+    );
+    registry.insert(
+        "candidate_assets".to_string(),
+        ResolvedSet {
+            values: sets.candidate_assets.clone(),
+        },
+    );
+    registry.insert(
+        "time".to_string(),
+        ResolvedSet {
+            values: (1..=sets.time.steps).map(|step| step.to_string()).collect(),
+        },
+    );
+    for (name, members) in custom_sets {
+        registry.insert(
+            name.clone(),
+            ResolvedSet {
+                values: members.clone(),
+            },
+        );
+    }
+    registry
+}

--- a/crates/arco-kdl/src/source.rs
+++ b/crates/arco-kdl/src/source.rs
@@ -1,0 +1,1161 @@
+use crate::algebra::{ConstraintBody, Expr, parse_constraint_formula, parse_value_formula};
+use crate::normalize::normalize_surface_syntax;
+use kdl::{KdlDocument, KdlNode, KdlValue};
+use miette::{Diagnostic, LabeledSpan, NamedSource, SourceCode, SourceSpan};
+use std::collections::BTreeMap;
+use std::fmt::Display;
+use std::fs;
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+use tracing::info;
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SourceProgram {
+    pub models: Vec<ModelDecl>,
+    pub sets: Vec<SetDecl>,
+    pub technologies: Vec<TechnologyDecl>,
+    pub operations: Vec<OperationDecl>,
+    pub assets: Vec<AssetDecl>,
+    pub instances: Vec<InstancesDecl>,
+    pub rules: Vec<RuleDecl>,
+    pub expressions: Vec<ExpressionDecl>,
+    pub objectives: Vec<ObjectiveDecl>,
+    pub scenarios: Vec<ScenarioDecl>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ModelDecl {
+    pub name: String,
+    pub sets: Vec<SetDecl>,
+    pub parameters: Vec<ParamDecl>,
+    pub controls: Vec<ControlDecl>,
+    pub constraints: Vec<ConstraintDecl>,
+    pub optimize: ObjectiveDecl,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SetDecl {
+    pub name: String,
+    pub alias: Option<String>,
+    pub source: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParamDecl {
+    pub name: String,
+    pub indices: Vec<String>,
+    pub value: Option<LiteralValue>,
+}
+
+/// A single index dimension in a control declaration, optionally bound to a
+/// named set domain via `in="set_name"`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IndexDecl {
+    pub name: String,
+    pub domain: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ControlDecl {
+    pub name: String,
+    pub indices: Vec<IndexDecl>,
+    pub lower: Option<BoundExpr>,
+    pub upper: Option<BoundExpr>,
+    pub kind: Option<VariableKindDecl>,
+}
+
+/// A named variable declaration with optional kind and bounds, used for both
+/// `invest` and `control` entries inside a `technology` block.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NamedVariableDecl {
+    pub name: String,
+    pub kind: Option<VariableKindDecl>,
+    pub lower: Option<BoundExpr>,
+    pub upper: Option<BoundExpr>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TechnologyDecl {
+    pub name: String,
+    /// Optional set alias: `technology "CoupledStorage" as="storage_techs"`.
+    /// When present, the technology's asset set is registered under this name
+    /// instead of the technology name, making set references in constraints
+    /// explicit and greppable.
+    pub set_name: Option<String>,
+    pub investments: Vec<NamedVariableDecl>,
+    pub controls: Vec<NamedVariableDecl>,
+    pub states: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OperationDecl {
+    pub name: String,
+    pub constraints: Vec<ConstraintDecl>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GenerationBinding {
+    pub variable: String,
+    pub domain: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConstraintDecl {
+    pub name: String,
+    pub expression: String,
+    pub parsed_expression: ConstraintBody,
+    pub generation_bindings: Vec<GenerationBinding>,
+    pub generation_filter: Option<String>,
+    pub parsed_generation_filter: Option<Expr>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AssetDecl {
+    pub name: String,
+    pub technology: String,
+    pub operation: Option<String>,
+    pub parameters: BTreeMap<String, LiteralValue>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LiteralValue {
+    String(String),
+    Integer(i128),
+    Decimal(String),
+    Boolean(bool),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VariableKindDecl {
+    Continuous,
+    Integer,
+    Binary,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BoundExpr {
+    Literal(LiteralValue),
+    Formula(Expr),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InstancesDecl {
+    pub name: String,
+    pub source: String,
+    pub technology: String,
+    pub operation: Option<String>,
+    pub columns: Vec<ColumnMappingDecl>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ColumnMappingDecl {
+    pub source: String,
+    pub target: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuleDecl {
+    pub name: String,
+    pub constraints: Vec<ConstraintDecl>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExpressionDecl {
+    pub name: String,
+    pub formula: String,
+    pub parsed_formula: Expr,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ObjectiveDecl {
+    pub name: String,
+    pub sense: String,
+    pub expression: String,
+    pub parsed_expression: Expr,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScenarioDecl {
+    pub name: String,
+    pub horizon: HorizonDecl,
+    pub data: Vec<DataBindingDecl>,
+    pub set_bindings: Vec<SetBindingDecl>,
+    pub assets: Vec<String>,
+    pub instances: Vec<String>,
+    pub technologies: Vec<String>,
+    pub operations: Vec<String>,
+    pub rules: Vec<String>,
+    pub model_use: Option<String>,
+    pub objective: Option<String>,
+    pub reports: Vec<String>,
+    /// User-declared sets whose members are listed inline in the scenario.
+    /// E.g. `generators { "gen1"; "gen2" }` produces `("generators", ["gen1", "gen2"])`.
+    pub custom_sets: BTreeMap<String, Vec<String>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HorizonDecl {
+    pub steps: usize,
+    pub resolution: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DataBindingDecl {
+    pub name: String,
+    pub source: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SetBindingDecl {
+    pub name: String,
+    pub source: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedSource {
+    pub program: SourceProgram,
+    pub source_text: NamedSource<String>,
+}
+
+struct ParseContext<'a> {
+    path: &'a Path,
+    source_text: &'a NamedSource<String>,
+}
+
+#[derive(Debug, Error)]
+pub enum SourceError {
+    #[error("failed to read {path}: {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("failed to parse kdl {path}: {source}")]
+    Kdl {
+        path: PathBuf,
+        #[source]
+        source: kdl::KdlError,
+    },
+    #[error("missing required node `{name}` in {path}")]
+    MissingNode {
+        name: &'static str,
+        path: PathBuf,
+        source_text: Box<NamedSource<String>>,
+        span: SourceSpan,
+    },
+    #[error("missing required argument {index} on node `{node}` in {path}")]
+    MissingArgument {
+        node: String,
+        index: usize,
+        path: PathBuf,
+        source_text: Box<NamedSource<String>>,
+        span: SourceSpan,
+    },
+    #[error("missing required property `{property}` on node `{node}` in {path}")]
+    MissingProperty {
+        node: String,
+        property: &'static str,
+        path: PathBuf,
+        source_text: Box<NamedSource<String>>,
+        span: SourceSpan,
+    },
+    #[error("unexpected value for `{field}` on node `{node}` in {path}")]
+    InvalidValue {
+        node: String,
+        field: String,
+        path: PathBuf,
+        source_text: Box<NamedSource<String>>,
+        span: SourceSpan,
+    },
+    #[error("unsupported declaration `{name}` in {path}")]
+    UnsupportedDeclaration {
+        name: String,
+        path: PathBuf,
+        source_text: Box<NamedSource<String>>,
+        span: SourceSpan,
+    },
+    #[error("invalid algebra in `{node}` in {path}: {reason}")]
+    InvalidAlgebra {
+        node: String,
+        reason: String,
+        path: PathBuf,
+        source_text: Box<NamedSource<String>>,
+        span: SourceSpan,
+    },
+}
+
+impl SourceProgram {
+    pub fn first_scenario(&self) -> Option<&ScenarioDecl> {
+        self.scenarios.first()
+    }
+
+    pub fn technology(&self, name: &str) -> Option<&TechnologyDecl> {
+        self.technologies.iter().find(|decl| decl.name == name)
+    }
+
+    pub fn model(&self, name: &str) -> Option<&ModelDecl> {
+        self.models.iter().find(|decl| decl.name == name)
+    }
+
+    pub fn operation(&self, name: &str) -> Option<&OperationDecl> {
+        self.operations.iter().find(|decl| decl.name == name)
+    }
+
+    pub fn asset(&self, name: &str) -> Option<&AssetDecl> {
+        self.assets.iter().find(|decl| decl.name == name)
+    }
+
+    pub fn instances(&self, name: &str) -> Option<&InstancesDecl> {
+        self.instances.iter().find(|decl| decl.name == name)
+    }
+
+    pub fn rule(&self, name: &str) -> Option<&RuleDecl> {
+        self.rules.iter().find(|decl| decl.name == name)
+    }
+
+    pub fn expression(&self, name: &str) -> Option<&ExpressionDecl> {
+        self.expressions.iter().find(|decl| decl.name == name)
+    }
+
+    pub fn objective(&self, name: &str) -> Option<&ObjectiveDecl> {
+        self.objectives.iter().find(|decl| decl.name == name)
+    }
+
+    pub fn scenario(&self, name: &str) -> Option<&ScenarioDecl> {
+        self.scenarios.iter().find(|decl| decl.name == name)
+    }
+}
+
+impl Diagnostic for SourceError {
+    fn code<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
+        let code = match self {
+            Self::Io { .. } => "arco::source::io",
+            Self::Kdl { .. } => "arco::source::kdl",
+            Self::MissingNode { .. } => "arco::source::missing_node",
+            Self::MissingArgument { .. } => "arco::source::missing_argument",
+            Self::MissingProperty { .. } => "arco::source::missing_property",
+            Self::InvalidValue { .. } => "arco::source::invalid_value",
+            Self::UnsupportedDeclaration { .. } => "arco::source::unsupported_declaration",
+            Self::InvalidAlgebra { .. } => "arco::source::invalid_algebra",
+        };
+        Some(Box::new(code))
+    }
+
+    fn help<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
+        match self {
+            Self::MissingNode { name, .. } => Some(Box::new(format!(
+                "add a `{name}` child declaration to this block"
+            ))),
+            Self::MissingArgument { index, .. } => Some(Box::new(format!(
+                "add argument {index} to this declaration"
+            ))),
+            Self::MissingProperty { property, .. } => Some(Box::new(format!(
+                "add a `{property}` property to this declaration"
+            ))),
+            Self::InvalidValue { field, .. } => Some(Box::new(format!(
+                "replace `{field}` with a value of the expected type"
+            ))),
+            Self::UnsupportedDeclaration { .. } => Some(Box::new(
+                "remove the declaration or add parser support for it",
+            )),
+            Self::InvalidAlgebra { .. } => Some(Box::new(
+                "fix the algebra syntax so the expression can be parsed into the DSL AST",
+            )),
+            Self::Io { .. } | Self::Kdl { .. } => None,
+        }
+    }
+
+    fn source_code(&self) -> Option<&dyn SourceCode> {
+        match self {
+            Self::MissingNode { source_text, .. }
+            | Self::MissingArgument { source_text, .. }
+            | Self::MissingProperty { source_text, .. }
+            | Self::InvalidValue { source_text, .. }
+            | Self::UnsupportedDeclaration { source_text, .. }
+            | Self::InvalidAlgebra { source_text, .. } => Some(source_text.as_ref()),
+            Self::Io { .. } | Self::Kdl { .. } => None,
+        }
+    }
+
+    fn labels(&self) -> Option<Box<dyn Iterator<Item = LabeledSpan> + '_>> {
+        let labeled = match self {
+            Self::MissingNode { span, .. }
+            | Self::MissingArgument { span, .. }
+            | Self::MissingProperty { span, .. }
+            | Self::InvalidValue { span, .. }
+            | Self::UnsupportedDeclaration { span, .. }
+            | Self::InvalidAlgebra { span, .. } => Some(LabeledSpan::new_with_span(
+                Some("this declaration".to_string()),
+                *span,
+            )),
+            Self::Io { .. } | Self::Kdl { .. } => None,
+        }?;
+        Some(Box::new(std::iter::once(labeled)))
+    }
+
+    fn diagnostic_source(&self) -> Option<&dyn Diagnostic> {
+        match self {
+            Self::Kdl { source, .. } => Some(source),
+            Self::Io { .. }
+            | Self::MissingNode { .. }
+            | Self::MissingArgument { .. }
+            | Self::MissingProperty { .. }
+            | Self::InvalidValue { .. }
+            | Self::UnsupportedDeclaration { .. }
+            | Self::InvalidAlgebra { .. } => None,
+        }
+    }
+}
+
+pub fn parse_program_file(path: &Path) -> Result<ParsedSource, SourceError> {
+    info!("parsing {}", path.display());
+    let text = fs::read_to_string(path).map_err(|source| SourceError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    parse_program_text(&text, path)
+}
+
+pub fn parse_program_text(text: &str, path: &Path) -> Result<ParsedSource, SourceError> {
+    let normalized = normalize_surface_syntax(text);
+    let source_text =
+        NamedSource::new(path.display().to_string(), normalized.clone()).with_language("kdl");
+    let document: KdlDocument = normalized.parse().map_err(|source| SourceError::Kdl {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    let context = ParseContext {
+        path,
+        source_text: &source_text,
+    };
+    let program = parse_document(&document, &context)?;
+
+    Ok(ParsedSource {
+        program,
+        source_text,
+    })
+}
+
+fn parse_document(
+    document: &KdlDocument,
+    context: &ParseContext<'_>,
+) -> Result<SourceProgram, SourceError> {
+    let mut program = SourceProgram::default();
+
+    for node in document.nodes() {
+        match node.name().value() {
+            "model" => program.models.push(parse_model(node, context)?),
+            "set" => program.sets.push(parse_set(node, context)?),
+            "technology" => program.technologies.push(parse_technology(node, context)?),
+            "operation" => program.operations.push(parse_operation(node, context)?),
+            "asset" => program.assets.push(parse_asset(node, context)?),
+            "instances" => program.instances.push(parse_instances(node, context)?),
+            "rule" => program.rules.push(parse_rule(node, context)?),
+            "expression" => program.expressions.push(parse_expression(node, context)?),
+            "minimize" => program
+                .objectives
+                .push(parse_optimize(node, "minimize", context)?),
+            "maximize" => program
+                .objectives
+                .push(parse_optimize(node, "maximize", context)?),
+            "scenario" => program.scenarios.push(parse_scenario(node, context)?),
+            other => {
+                return Err(SourceError::UnsupportedDeclaration {
+                    name: other.to_string(),
+                    path: context.path.to_path_buf(),
+                    source_text: Box::new(context.source_text.clone()),
+                    span: node.span(),
+                });
+            }
+        }
+    }
+
+    Ok(program)
+}
+
+fn parse_model(node: &KdlNode, context: &ParseContext<'_>) -> Result<ModelDecl, SourceError> {
+    let mut sets = Vec::new();
+    let mut parameters = Vec::new();
+    let mut controls = Vec::new();
+    let constraints = parse_constraints(node, context)?;
+    let mut optimize = None;
+
+    for child in node.iter_children() {
+        match child.name().value() {
+            "set" => sets.push(parse_set(child, context)?),
+            "param" => parameters.push(ParamDecl {
+                name: first_arg_string(child, 0, context)?,
+                indices: declaration_indices(child)
+                    .into_iter()
+                    .map(|idx| idx.name)
+                    .collect(),
+                value: positional_value(child, context)?,
+            }),
+            "control" => controls.push(parse_control(child, context)?),
+            "minimize" => optimize = Some(parse_optimize(child, "minimize", context)?),
+            "maximize" => optimize = Some(parse_optimize(child, "maximize", context)?),
+            _ => {}
+        }
+    }
+
+    Ok(ModelDecl {
+        name: first_arg_string(node, 0, context)?,
+        sets,
+        parameters,
+        controls,
+        constraints,
+        optimize: optimize
+            .ok_or_else(|| missing_node_error("minimize_or_maximize", node, context))?,
+    })
+}
+
+fn parse_set(node: &KdlNode, context: &ParseContext<'_>) -> Result<SetDecl, SourceError> {
+    Ok(SetDecl {
+        name: first_arg_string(node, 0, context)?,
+        alias: node
+            .get("alias")
+            .and_then(KdlValue::as_string)
+            .map(ToString::to_string),
+        source: optional_property_string(node, "from", context)?,
+    })
+}
+
+fn parse_control(node: &KdlNode, context: &ParseContext<'_>) -> Result<ControlDecl, SourceError> {
+    let kind = optional_property_string(node, "kind", context)?
+        .map(|value| parse_variable_kind_decl(node, &value, context))
+        .transpose()?;
+
+    let mut lower = optional_property_literal(node, "lower", context)?.map(BoundExpr::Literal);
+    let mut upper = optional_property_literal(node, "upper", context)?.map(BoundExpr::Literal);
+
+    // Child nodes named "lower" or "upper" carry algebra formulas and override
+    // literal properties when present.
+    for child in node.iter_children() {
+        match child.name().value() {
+            "lower" => {
+                let formula_text = property_string(child, "expression", context)?;
+                lower = Some(BoundExpr::Formula(
+                    parse_value_formula(&formula_text)
+                        .map_err(|e| algebra_error(child, e.to_string(), context))?,
+                ));
+            }
+            "upper" => {
+                let formula_text = property_string(child, "expression", context)?;
+                upper = Some(BoundExpr::Formula(
+                    parse_value_formula(&formula_text)
+                        .map_err(|e| algebra_error(child, e.to_string(), context))?,
+                ));
+            }
+            _ => {}
+        }
+    }
+
+    Ok(ControlDecl {
+        name: first_arg_string(node, 0, context)?,
+        indices: declaration_indices(node),
+        lower,
+        upper,
+        kind,
+    })
+}
+
+fn parse_variable_kind_decl(
+    node: &KdlNode,
+    value: &str,
+    context: &ParseContext<'_>,
+) -> Result<VariableKindDecl, SourceError> {
+    match value {
+        "continuous" => Ok(VariableKindDecl::Continuous),
+        "integer" => Ok(VariableKindDecl::Integer),
+        "binary" => Ok(VariableKindDecl::Binary),
+        _ => Err(invalid_value_error(node, "kind".to_string(), context)),
+    }
+}
+
+fn declaration_indices(node: &KdlNode) -> Vec<IndexDecl> {
+    let mut indices = Vec::new();
+    for child in node.iter_children() {
+        match child.name().value() {
+            "lower" | "upper" => {}
+            name => {
+                let domain = child
+                    .get("in")
+                    .and_then(KdlValue::as_string)
+                    .map(ToString::to_string);
+                indices.push(IndexDecl {
+                    name: name.to_string(),
+                    domain,
+                });
+            }
+        }
+    }
+    indices
+}
+
+fn positional_value(
+    node: &KdlNode,
+    context: &ParseContext<'_>,
+) -> Result<Option<LiteralValue>, SourceError> {
+    if declaration_indices(node).is_empty() {
+        return node
+            .get(1)
+            .map(|value| literal_from_arg(node, value, context))
+            .transpose();
+    }
+
+    Ok(None)
+}
+
+fn literal_from_arg(
+    node: &KdlNode,
+    value: &KdlValue,
+    context: &ParseContext<'_>,
+) -> Result<LiteralValue, SourceError> {
+    if let Some(string) = value.as_string() {
+        return Ok(LiteralValue::String(string.to_string()));
+    }
+    if let Some(integer) = value.as_integer() {
+        return Ok(LiteralValue::Integer(integer));
+    }
+    if let Some(boolean) = value.as_bool() {
+        return Ok(LiteralValue::Boolean(boolean));
+    }
+    if let Some(decimal) = value.as_float() {
+        return Ok(LiteralValue::Decimal(decimal.to_string()));
+    }
+
+    Err(invalid_value_error(
+        node,
+        "argument value".to_string(),
+        context,
+    ))
+}
+
+fn parse_optimize(
+    node: &KdlNode,
+    sense: &str,
+    context: &ParseContext<'_>,
+) -> Result<ObjectiveDecl, SourceError> {
+    let expression = property_string(node, "expression", context)?;
+    Ok(ObjectiveDecl {
+        name: first_arg_string(node, 0, context)?,
+        sense: sense.to_string(),
+        parsed_expression: parse_value_formula(&expression)
+            .map_err(|error| algebra_error(node, error.to_string(), context))?,
+        expression,
+    })
+}
+
+fn parse_technology(
+    node: &KdlNode,
+    context: &ParseContext<'_>,
+) -> Result<TechnologyDecl, SourceError> {
+    let mut investments = Vec::new();
+    let mut controls = Vec::new();
+    let mut states = Vec::new();
+    for child in node.iter_children() {
+        match child.name().value() {
+            "invest" => investments.push(parse_named_variable_decl(child, context)?),
+            "control" => controls.push(parse_named_variable_decl(child, context)?),
+            "state" => states.push(first_arg_string(child, 0, context)?),
+            _ => {}
+        }
+    }
+
+    let set_name = node
+        .get("as")
+        .and_then(KdlValue::as_string)
+        .map(ToString::to_string);
+
+    Ok(TechnologyDecl {
+        name: first_arg_string(node, 0, context)?,
+        set_name,
+        investments,
+        controls,
+        states,
+    })
+}
+
+/// Parse a named variable declaration with optional `kind`, `lower`, and
+/// `upper` literal properties. Used for both `invest` and `control` children
+/// inside a `technology` block.
+fn parse_named_variable_decl(
+    node: &KdlNode,
+    context: &ParseContext<'_>,
+) -> Result<NamedVariableDecl, SourceError> {
+    let kind = optional_property_string(node, "kind", context)?
+        .map(|value| parse_variable_kind_decl(node, &value, context))
+        .transpose()?;
+    Ok(NamedVariableDecl {
+        name: first_arg_string(node, 0, context)?,
+        kind,
+        lower: optional_property_literal(node, "lower", context)?.map(BoundExpr::Literal),
+        upper: optional_property_literal(node, "upper", context)?.map(BoundExpr::Literal),
+    })
+}
+
+fn parse_operation(
+    node: &KdlNode,
+    context: &ParseContext<'_>,
+) -> Result<OperationDecl, SourceError> {
+    Ok(OperationDecl {
+        name: first_arg_string(node, 0, context)?,
+        constraints: parse_constraints(node, context)?,
+    })
+}
+
+fn parse_asset(node: &KdlNode, context: &ParseContext<'_>) -> Result<AssetDecl, SourceError> {
+    let mut technology = None;
+    let mut operation = None;
+    let mut parameters = BTreeMap::new();
+
+    for child in node.iter_children() {
+        match child.name().value() {
+            "technology" => technology = Some(first_arg_string(child, 0, context)?),
+            "operation" => operation = Some(first_arg_string(child, 0, context)?),
+            name => {
+                parameters.insert(name.to_string(), first_arg_literal(child, context)?);
+            }
+        }
+    }
+
+    Ok(AssetDecl {
+        name: first_arg_string(node, 0, context)?,
+        technology: technology.ok_or_else(|| missing_node_error("technology", node, context))?,
+        operation,
+        parameters,
+    })
+}
+
+fn parse_instances(
+    node: &KdlNode,
+    context: &ParseContext<'_>,
+) -> Result<InstancesDecl, SourceError> {
+    let mut technology = None;
+    let mut operation = None;
+    let mut columns = Vec::new();
+
+    for child in node.iter_children() {
+        match child.name().value() {
+            "technology" => technology = Some(first_arg_string(child, 0, context)?),
+            "operation" => operation = Some(first_arg_string(child, 0, context)?),
+            "map" => columns.push(ColumnMappingDecl {
+                source: property_string(child, "from", context)?,
+                target: first_arg_string(child, 0, context)?,
+            }),
+            _ => {}
+        }
+    }
+
+    Ok(InstancesDecl {
+        name: first_arg_string(node, 0, context)?,
+        source: property_string(node, "from", context)?,
+        technology: technology.ok_or_else(|| missing_node_error("technology", node, context))?,
+        operation,
+        columns,
+    })
+}
+
+fn parse_rule(node: &KdlNode, context: &ParseContext<'_>) -> Result<RuleDecl, SourceError> {
+    Ok(RuleDecl {
+        name: first_arg_string(node, 0, context)?,
+        constraints: parse_constraints(node, context)?,
+    })
+}
+
+fn parse_expression(
+    node: &KdlNode,
+    context: &ParseContext<'_>,
+) -> Result<ExpressionDecl, SourceError> {
+    let formula = child_arg_string(node, "formula", 0, context)?;
+    Ok(ExpressionDecl {
+        name: first_arg_string(node, 0, context)?,
+        parsed_formula: parse_value_formula(&formula)
+            .map_err(|error| algebra_error(node, error.to_string(), context))?,
+        formula,
+    })
+}
+
+/// Keywords recognized as built-in scenario children. Anything else with
+/// child string arguments is treated as a user-declared custom set.
+const SCENARIO_KEYWORDS: &[&str] = &[
+    "data",
+    "set",
+    "asset",
+    "instances",
+    "technology",
+    "operation",
+    "rule",
+    "use",
+    "minimize",
+    "maximize",
+    "report",
+    "horizon",
+    "solver",
+];
+
+fn parse_scenario(node: &KdlNode, context: &ParseContext<'_>) -> Result<ScenarioDecl, SourceError> {
+    let horizon_node = child_node(node, "horizon", context)?;
+    let mut data = Vec::new();
+    let mut set_bindings = Vec::new();
+    let mut assets = Vec::new();
+    let mut instances = Vec::new();
+    let mut technologies = Vec::new();
+    let mut operations = Vec::new();
+    let mut rules = Vec::new();
+    let mut model_use = None;
+    let mut objective = None;
+    let mut reports = Vec::new();
+    let mut custom_sets: BTreeMap<String, Vec<String>> = BTreeMap::new();
+
+    for child in node.iter_children() {
+        match child.name().value() {
+            "data" => data.push(DataBindingDecl {
+                name: first_arg_string(child, 0, context)?,
+                source: property_string(child, "from", context)?,
+            }),
+            "set" => set_bindings.push(SetBindingDecl {
+                name: first_arg_string(child, 0, context)?,
+                source: property_string(child, "from", context)?,
+            }),
+            "asset" => assets.push(first_arg_string(child, 0, context)?),
+            "instances" => instances.push(first_arg_string(child, 0, context)?),
+            "technology" => technologies.push(first_arg_string(child, 0, context)?),
+            "operation" => operations.push(first_arg_string(child, 0, context)?),
+            "rule" => rules.push(first_arg_string(child, 0, context)?),
+            "use" => model_use = Some(first_arg_string(child, 0, context)?),
+            "minimize" | "maximize" => {
+                objective = Some(first_arg_string(child, 0, context)?);
+            }
+            "report" => reports.push(first_arg_string(child, 0, context)?),
+            name if !SCENARIO_KEYWORDS.contains(&name) => {
+                let members = parse_custom_set_members(child);
+                if !members.is_empty() {
+                    custom_sets
+                        .entry(name.to_string())
+                        .or_default()
+                        .extend(members);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    Ok(ScenarioDecl {
+        name: first_arg_string(node, 0, context)?,
+        horizon: HorizonDecl {
+            steps: property_usize(horizon_node, "steps", context)?,
+            resolution: property_string(horizon_node, "resolution", context)?,
+        },
+        data,
+        set_bindings,
+        assets,
+        instances,
+        technologies,
+        operations,
+        rules,
+        model_use,
+        objective,
+        reports,
+        custom_sets,
+    })
+}
+
+/// Extract string members from a custom set node. Members are child nodes
+/// whose names are string literals, e.g.:
+/// ```kdl
+/// generators {
+///     "gen1"
+///     "gen2"
+/// }
+/// ```
+fn parse_custom_set_members(node: &KdlNode) -> Vec<String> {
+    let mut members = Vec::new();
+    // Members as positional arguments on child nodes (each child is a string literal node name)
+    for child in node.iter_children() {
+        members.push(child.name().value().to_string());
+    }
+    // Also check for inline string arguments on the node itself
+    for entry in node.entries() {
+        if entry.name().is_none()
+            && let Some(s) = entry.value().as_string()
+        {
+            members.push(s.to_string());
+        }
+    }
+    members
+}
+
+fn parse_constraints(
+    node: &KdlNode,
+    context: &ParseContext<'_>,
+) -> Result<Vec<ConstraintDecl>, SourceError> {
+    let mut constraints = Vec::new();
+    for (index, child) in node
+        .iter_children()
+        .filter(|child| child.name().value() == "constraint")
+        .enumerate()
+    {
+        let has_generation_children = child
+            .iter_children()
+            .any(|grandchild| matches!(grandchild.name().value(), "over" | "when" | "expr"));
+
+        if has_generation_children {
+            constraints.push(parse_constraint_with_generation(child, index, context)?);
+        } else {
+            let expression = property_string(child, "expression", context)?;
+            let generation_filter = optional_property_string(child, "if", context)?;
+            constraints.push(ConstraintDecl {
+                name: constraint_name(child, index),
+                parsed_expression: parse_constraint_formula(&expression)
+                    .map_err(|error| algebra_error(child, error.to_string(), context))?,
+                generation_bindings: Vec::new(),
+                parsed_generation_filter: generation_filter
+                    .as_deref()
+                    .map(parse_value_formula)
+                    .transpose()
+                    .map_err(|error| algebra_error(child, error.to_string(), context))?,
+                generation_filter,
+                expression,
+            });
+        }
+    }
+    Ok(constraints)
+}
+
+fn parse_constraint_with_generation(
+    node: &KdlNode,
+    index: usize,
+    context: &ParseContext<'_>,
+) -> Result<ConstraintDecl, SourceError> {
+    let mut generation_bindings = Vec::new();
+    let mut generation_filter = None;
+    let mut expression = None;
+
+    for child in node.iter_children() {
+        match child.name().value() {
+            "over" => {
+                generation_bindings.push(GenerationBinding {
+                    variable: first_arg_string(child, 0, context)?,
+                    domain: property_string(child, "in", context)?,
+                });
+            }
+            "when" => {
+                generation_filter = Some(first_arg_string(child, 0, context)?);
+            }
+            "expr" => {
+                expression = Some(property_string(child, "expression", context)?);
+            }
+            _ => {}
+        }
+    }
+
+    let expression = expression.ok_or_else(|| missing_node_error("expr", node, context))?;
+    let parsed_generation_filter = generation_filter
+        .as_deref()
+        .map(parse_value_formula)
+        .transpose()
+        .map_err(|error| algebra_error(node, error.to_string(), context))?;
+
+    Ok(ConstraintDecl {
+        name: constraint_name(node, index),
+        parsed_expression: parse_constraint_formula(&expression)
+            .map_err(|error| algebra_error(node, error.to_string(), context))?,
+        generation_bindings,
+        parsed_generation_filter,
+        generation_filter,
+        expression,
+    })
+}
+
+fn constraint_name(node: &KdlNode, index: usize) -> String {
+    node.get("name")
+        .and_then(KdlValue::as_string)
+        .map(ToString::to_string)
+        .or_else(|| {
+            node.get(0)
+                .and_then(KdlValue::as_string)
+                .map(ToString::to_string)
+        })
+        .unwrap_or_else(|| format!("constraint_{}", index + 1))
+}
+
+fn child_node<'a>(
+    node: &'a KdlNode,
+    name: &'static str,
+    context: &ParseContext<'_>,
+) -> Result<&'a KdlNode, SourceError> {
+    node.children()
+        .and_then(|children| children.get(name))
+        .ok_or_else(|| missing_node_error(name, node, context))
+}
+
+fn child_arg_string(
+    node: &KdlNode,
+    child_name: &'static str,
+    index: usize,
+    context: &ParseContext<'_>,
+) -> Result<String, SourceError> {
+    let child = child_node(node, child_name, context)?;
+    first_arg_string(child, index, context)
+}
+
+fn first_arg_string(
+    node: &KdlNode,
+    index: usize,
+    context: &ParseContext<'_>,
+) -> Result<String, SourceError> {
+    node.get(index)
+        .and_then(KdlValue::as_string)
+        .map(ToString::to_string)
+        .or_else(|| {
+            node.get("name")
+                .and_then(KdlValue::as_string)
+                .map(ToString::to_string)
+        })
+        .ok_or_else(|| missing_argument_error(node, index, context))
+}
+
+fn first_arg_literal(
+    node: &KdlNode,
+    context: &ParseContext<'_>,
+) -> Result<LiteralValue, SourceError> {
+    let value = node
+        .get(0)
+        .ok_or_else(|| missing_argument_error(node, 0, context))?;
+
+    if let Some(string) = value.as_string() {
+        return Ok(LiteralValue::String(string.to_string()));
+    }
+    if let Some(integer) = value.as_integer() {
+        return Ok(LiteralValue::Integer(integer));
+    }
+    if let Some(boolean) = value.as_bool() {
+        return Ok(LiteralValue::Boolean(boolean));
+    }
+    if let Some(decimal) = value.as_float() {
+        return Ok(LiteralValue::Decimal(decimal.to_string()));
+    }
+
+    Err(invalid_value_error(node, "argument 0".to_string(), context))
+}
+
+fn property_string(
+    node: &KdlNode,
+    property: &'static str,
+    context: &ParseContext<'_>,
+) -> Result<String, SourceError> {
+    node.get(property)
+        .and_then(KdlValue::as_string)
+        .map(ToString::to_string)
+        .ok_or_else(|| missing_property_error(node, property, context))
+}
+
+fn optional_property_string(
+    node: &KdlNode,
+    property: &'static str,
+    context: &ParseContext<'_>,
+) -> Result<Option<String>, SourceError> {
+    let Some(value) = node.get(property) else {
+        return Ok(None);
+    };
+    value
+        .as_string()
+        .map(|text| Some(text.to_string()))
+        .ok_or_else(|| invalid_value_error(node, property.to_string(), context))
+}
+
+fn optional_property_literal(
+    node: &KdlNode,
+    property: &'static str,
+    context: &ParseContext<'_>,
+) -> Result<Option<LiteralValue>, SourceError> {
+    let Some(value) = node.get(property) else {
+        return Ok(None);
+    };
+
+    if let Some(string) = value.as_string() {
+        return Ok(Some(LiteralValue::String(string.to_string())));
+    }
+    if let Some(integer) = value.as_integer() {
+        return Ok(Some(LiteralValue::Integer(integer)));
+    }
+    if let Some(boolean) = value.as_bool() {
+        return Ok(Some(LiteralValue::Boolean(boolean)));
+    }
+    if let Some(decimal) = value.as_float() {
+        return Ok(Some(LiteralValue::Decimal(decimal.to_string())));
+    }
+
+    Err(invalid_value_error(node, property.to_string(), context))
+}
+
+fn property_usize(
+    node: &KdlNode,
+    property: &'static str,
+    context: &ParseContext<'_>,
+) -> Result<usize, SourceError> {
+    let integer = node
+        .get(property)
+        .and_then(KdlValue::as_integer)
+        .ok_or_else(|| missing_property_error(node, property, context))?;
+
+    usize::try_from(integer).map_err(|_| invalid_value_error(node, property.to_string(), context))
+}
+
+fn missing_node_error(
+    name: &'static str,
+    node: &KdlNode,
+    context: &ParseContext<'_>,
+) -> SourceError {
+    SourceError::MissingNode {
+        name,
+        path: context.path.to_path_buf(),
+        source_text: Box::new(context.source_text.clone()),
+        span: node.span(),
+    }
+}
+
+fn missing_argument_error(node: &KdlNode, index: usize, context: &ParseContext<'_>) -> SourceError {
+    SourceError::MissingArgument {
+        node: node.name().value().to_string(),
+        index,
+        path: context.path.to_path_buf(),
+        source_text: Box::new(context.source_text.clone()),
+        span: node.span(),
+    }
+}
+
+fn missing_property_error(
+    node: &KdlNode,
+    property: &'static str,
+    context: &ParseContext<'_>,
+) -> SourceError {
+    SourceError::MissingProperty {
+        node: node.name().value().to_string(),
+        property,
+        path: context.path.to_path_buf(),
+        source_text: Box::new(context.source_text.clone()),
+        span: node.span(),
+    }
+}
+
+fn invalid_value_error(node: &KdlNode, field: String, context: &ParseContext<'_>) -> SourceError {
+    SourceError::InvalidValue {
+        node: node.name().value().to_string(),
+        field,
+        path: context.path.to_path_buf(),
+        source_text: Box::new(context.source_text.clone()),
+        span: node.span(),
+    }
+}
+
+fn algebra_error(node: &KdlNode, reason: String, context: &ParseContext<'_>) -> SourceError {
+    SourceError::InvalidAlgebra {
+        node: node.name().value().to_string(),
+        reason,
+        path: context.path.to_path_buf(),
+        source_text: Box::new(context.source_text.clone()),
+        span: node.span(),
+    }
+}

--- a/crates/arco-kdl/tests/algebra_parser.rs
+++ b/crates/arco-kdl/tests/algebra_parser.rs
@@ -1,0 +1,134 @@
+use arco_kdl::algebra::{
+    BinaryOp, BindingPattern, ConstraintBody, Expr, parse_constraint_formula, parse_value_formula,
+};
+
+#[test]
+fn parses_filtered_tuple_reduction_expressions() -> Result<(), Box<dyn std::error::Error>> {
+    let expression = parse_value_formula(
+        "sum(flow[i,j,t] for (i,j) in arcs for t in time if region[i] == \"north\")",
+    )?;
+
+    let Expr::Reduction(ref reduction) = expression else {
+        return Err("expected reduction expression".into());
+    };
+
+    assert_eq!(reduction.bindings.len(), 2);
+    assert_eq!(
+        reduction.bindings[0].pattern,
+        BindingPattern::Tuple(vec!["i".to_string(), "j".to_string()])
+    );
+    assert_eq!(reduction.bindings[0].domain, "arcs");
+    assert_eq!(
+        reduction.bindings[1].pattern,
+        BindingPattern::Name("t".to_string())
+    );
+    assert_eq!(reduction.bindings[1].domain, "time");
+    assert_eq!(reduction.filters.len(), 1);
+    assert_eq!(
+        expression.to_string(),
+        "sum(flow[i,j,t] for (i, j) in arcs for t in time if region[i] == \"north\")"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn parses_chained_constraint_bounds() -> Result<(), Box<dyn std::error::Error>> {
+    let constraint = parse_constraint_formula("-power_mw[a] <= dispatch[a,t] <= power_mw[a]")?;
+
+    let ConstraintBody::Range {
+        ref lower,
+        ref middle,
+        ref upper,
+        ..
+    } = constraint
+    else {
+        return Err("expected range constraint".into());
+    };
+
+    assert_eq!(lower.to_string(), "-power_mw[a]");
+    assert_eq!(middle.to_string(), "dispatch[a,t]");
+    assert_eq!(upper.to_string(), "power_mw[a]");
+    assert_eq!(
+        constraint.to_string(),
+        "-power_mw[a] <= dispatch[a,t] <= power_mw[a]"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn parses_sqrt_function_call_with_indexed_argument() -> Result<(), Box<dyn std::error::Error>> {
+    let expression = parse_value_formula("sqrt(eta[j]) * charge[j,t]")?;
+
+    let Expr::Binary {
+        op: BinaryOp::Multiply,
+        ref left,
+        ref right,
+    } = expression
+    else {
+        return Err("expected binary multiply expression".into());
+    };
+
+    let Expr::FunctionCall { ref name, ref args } = **left else {
+        return Err("expected FunctionCall on lhs".into());
+    };
+    assert_eq!(name, "sqrt");
+    assert_eq!(args.len(), 1);
+    assert!(
+        matches!(&args[0], Expr::Indexed { target, indices } if target == "eta" && indices.len() == 1)
+    );
+
+    assert!(matches!(
+        right.as_ref(),
+        Expr::Indexed { target, indices } if target == "charge" && indices.len() == 2
+    ));
+
+    assert_eq!(expression.to_string(), "sqrt(eta[j]) * charge[j,t]");
+
+    Ok(())
+}
+
+#[test]
+fn parses_pow_function_call_with_two_arguments() -> Result<(), Box<dyn std::error::Error>> {
+    let expression = parse_value_formula("pow(1 + r, lifetime)")?;
+
+    let Expr::FunctionCall { ref name, ref args } = expression else {
+        return Err("expected FunctionCall".into());
+    };
+    assert_eq!(name, "pow");
+    assert_eq!(args.len(), 2);
+
+    // First arg is (1 + r).
+    assert!(
+        matches!(&args[0], Expr::Binary { op: BinaryOp::Add, left, right }
+            if matches!(left.as_ref(), Expr::Number(n) if n == "1")
+            && matches!(right.as_ref(), Expr::Identifier(id) if id == "r")
+        )
+    );
+
+    // Second arg is the identifier "lifetime".
+    assert!(matches!(&args[1], Expr::Identifier(id) if id == "lifetime"));
+
+    assert_eq!(expression.to_string(), "pow(1 + r, lifetime)");
+
+    Ok(())
+}
+
+#[test]
+fn parses_abs_function_call_with_indexed_argument() -> Result<(), Box<dyn std::error::Error>> {
+    let expression = parse_value_formula("abs(x[a,t])")?;
+
+    let Expr::FunctionCall { ref name, ref args } = expression else {
+        return Err("expected FunctionCall".into());
+    };
+    assert_eq!(name, "abs");
+    assert_eq!(args.len(), 1);
+    assert!(
+        matches!(&args[0], Expr::Indexed { target, indices } if target == "x" && indices.len() == 2)
+    );
+
+    assert_eq!(expression.to_string(), "abs(x[a,t])");
+
+    Ok(())
+}

--- a/crates/arco-kdl/tests/e2e/capacity-expansion/expected/e2e-summary.json
+++ b/crates/arco-kdl/tests/e2e/capacity-expansion/expected/e2e-summary.json
@@ -1,0 +1,12 @@
+{
+  "case_id": "capacity-expansion",
+  "expect_parse_success": true,
+  "expect_semantic_validation_success": true,
+  "expect_lowering_success": true,
+  "expect_solve_success": true,
+  "objective": {
+    "name": "ExpansionCost",
+    "sense": "minimize"
+  },
+  "reports": []
+}

--- a/crates/arco-kdl/tests/e2e/capacity-expansion/expected/semantic-program.json
+++ b/crates/arco-kdl/tests/e2e/capacity-expansion/expected/semantic-program.json
@@ -1,0 +1,26 @@
+{
+  "case_id": "capacity-expansion",
+  "active_scenario": "ExpansionCase",
+  "sets": {
+    "assets": ["CandidateCT1", "CandidateCT2", "ExistingCT1", "ExistingCT2"],
+    "candidate_assets": ["CandidateCT1", "CandidateCT2"],
+    "time": {
+      "steps": 24,
+      "resolution": "PT1H"
+    }
+  },
+  "parameters": {
+    "series": ["demand[t]", "voll[t]"],
+    "asset": [
+      "build_cost[a]",
+      "existing_capacity[a]",
+      "max_build[a]",
+      "variable_cost[a]"
+    ]
+  },
+  "variable_families": ["build[a]", "dispatch[a,t]", "unserved_energy[t]"],
+  "lowering_rules": [
+    "build[a] is a decision family over candidate_assets",
+    "build[a] is fixed to zero for non-candidate assets"
+  ]
+}

--- a/crates/arco-kdl/tests/e2e/capacity-expansion/input.kdl
+++ b/crates/arco-kdl/tests/e2e/capacity-expansion/input.kdl
@@ -1,0 +1,60 @@
+technology "GasCT" {
+  control "dispatch"
+}
+
+operation "ExpansionDispatch" {
+  constraint "dispatch_limit" {
+    dispatch[a,t] <= existing_capacity[a] + build[a]
+  }
+}
+
+instances "ExistingThermal" from="data/existing_thermal.csv" {
+  technology "GasCT"
+  operation "ExpansionDispatch"
+  map "name" from="asset_name"
+  map "existing_capacity" from="existing_capacity_mw"
+  map "variable_cost" from="variable_cost"
+}
+
+instances "CandidateGas" from="data/candidate_gas.csv" {
+  technology "GasCT"
+  operation "ExpansionDispatch"
+  map "name" from="asset_name"
+  map "max_build" from="max_build_mw"
+  map "build_cost" from="build_cost"
+  map "variable_cost" from="variable_cost"
+}
+
+rule "EnergyBalance" {
+  constraint "balance" {
+    sum(dispatch[a,t] for a in assets) + unserved_energy[t] = demand[t]
+  }
+}
+
+expression "InvestmentCost" {
+  sum(build_cost[a] * build[a] for a in candidate_assets)
+}
+
+expression "OperatingCost" {
+  sum(variable_cost[a] * dispatch[a,t] for a in assets for t in time)
+}
+
+expression "PenaltyCost" {
+  sum(voll[t] * unserved_energy[t] for t in time)
+}
+
+minimize "ExpansionCost" {
+  InvestmentCost + OperatingCost + PenaltyCost
+}
+
+scenario "ExpansionCase" {
+  horizon steps=24 resolution="PT1H"
+  technology "GasCT"
+  operation "ExpansionDispatch"
+  rule "EnergyBalance"
+  data "demand" from="data/demand.csv"
+  data "voll" from="data/voll.csv"
+  instances "ExistingThermal"
+  instances "CandidateGas"
+  minimize "ExpansionCost"
+}

--- a/crates/arco-kdl/tests/e2e/generalized-two-node-network/input.kdl
+++ b/crates/arco-kdl/tests/e2e/generalized-two-node-network/input.kdl
@@ -1,0 +1,58 @@
+technology "Generator" {
+  control "dispatch"
+}
+
+technology "Line" {
+  control "flow"
+}
+
+operation "Dispatch" {
+  constraint "capacity_limit" {
+    dispatch[g,t] <= capacity_mw[g]
+  }
+}
+
+operation "Transmission" {
+  constraint "forward_limit" {
+    -thermal_limit_mw[l] <= flow[l,t] <= thermal_limit_mw[l]
+  }
+}
+
+rule "NodeBalance" {
+  constraint "balance" {
+    sum(dispatch[g,t] for g in generators if generator_node[g] == n)
+    + sum(flow[l,t] for l in incoming_lines if line_to[l] == n)
+    - sum(flow[l,t] for l in outgoing_lines if line_from[l] == n)
+    = demand[n,t]
+  }
+}
+
+expression "GenerationCost" {
+  sum(variable_cost[g] * dispatch[g,t] for g in generators for t in time)
+}
+
+expression "LossPenalty" {
+  sum(loss_penalty[n,t] for n in nodes for t in time)
+}
+
+minimize "TotalCost" {
+  GenerationCost + LossPenalty
+}
+
+scenario "TwoNodeDispatch" {
+  horizon steps=24 resolution="PT1H"
+  technology "Generator"
+  technology "Line"
+  operation "Dispatch"
+  operation "Transmission"
+  rule "NodeBalance"
+  data "demand" from="data/demand.csv"
+  data "generator_node" from="data/generator_node.csv"
+  data "line_from" from="data/line_from.csv"
+  data "line_to" from="data/line_to.csv"
+  data "variable_cost" from="data/variable_cost.csv"
+  data "capacity_mw" from="data/capacity_mw.csv"
+  data "thermal_limit_mw" from="data/thermal_limit_mw.csv"
+  data "loss_penalty" from="data/loss_penalty.csv"
+  minimize "TotalCost"
+}

--- a/crates/arco-kdl/tests/e2e/generator-allocation/expected/e2e-summary.json
+++ b/crates/arco-kdl/tests/e2e/generator-allocation/expected/e2e-summary.json
@@ -1,0 +1,12 @@
+{
+  "case_id": "generator-allocation",
+  "expect_parse_success": true,
+  "expect_semantic_validation_success": true,
+  "expect_lowering_success": true,
+  "expect_solve_success": true,
+  "objective": {
+    "name": "TotalCost",
+    "sense": "minimize"
+  },
+  "reports": []
+}

--- a/crates/arco-kdl/tests/e2e/generator-allocation/expected/semantic-program.json
+++ b/crates/arco-kdl/tests/e2e/generator-allocation/expected/semantic-program.json
@@ -1,0 +1,15 @@
+{
+  "case_id": "generator-allocation",
+  "active_scenario": "GeneratorAllocationDay",
+  "sets": {
+    "assets": [],
+    "time": {
+      "steps": 3,
+      "resolution": "PT1H"
+    }
+  },
+  "parameters": {},
+  "variable_families": ["dispatch[a,t]"],
+  "chronology": {},
+  "lowering_rules": []
+}

--- a/crates/arco-kdl/tests/e2e/generator-allocation/input.kdl
+++ b/crates/arco-kdl/tests/e2e/generator-allocation/input.kdl
@@ -1,0 +1,19 @@
+model "GeneratorAllocation" {
+  control "dispatch" {
+    a
+    t
+  }
+
+  constraint "capacity_limit" {
+    dispatch[a,t] <= 10
+  }
+
+  minimize "TotalCost" {
+    sum(dispatch[a,t] for a in assets for t in time)
+  }
+}
+
+scenario "GeneratorAllocationDay" {
+  horizon steps=3 resolution="PT1H"
+  use "GeneratorAllocation"
+}

--- a/crates/arco-kdl/tests/e2e/manifest.json
+++ b/crates/arco-kdl/tests/e2e/manifest.json
@@ -1,0 +1,61 @@
+{
+  "version": 1,
+  "cases": [
+    {
+      "id": "price-taker-battery",
+      "description": "Single-asset battery arbitrage benchmark from RFD-0006.",
+      "entrypoint": "tests/e2e/price-taker-battery/input.kdl",
+      "expected_semantic_program": "tests/e2e/price-taker-battery/expected/semantic-program.json",
+      "expected_e2e_summary": "tests/e2e/price-taker-battery/expected/e2e-summary.json",
+      "solvable": true
+    },
+    {
+      "id": "capacity-expansion",
+      "description": "Copperplate capacity expansion benchmark from RFD-0006.",
+      "entrypoint": "tests/e2e/capacity-expansion/input.kdl",
+      "expected_semantic_program": "tests/e2e/capacity-expansion/expected/semantic-program.json",
+      "expected_e2e_summary": "tests/e2e/capacity-expansion/expected/e2e-summary.json",
+      "solvable": true
+    },
+    {
+      "id": "pcm",
+      "description": "Production cost model benchmark from RFD-0006.",
+      "entrypoint": "tests/e2e/pcm/input.kdl",
+      "expected_semantic_program": "tests/e2e/pcm/expected/semantic-program.json",
+      "expected_e2e_summary": "tests/e2e/pcm/expected/e2e-summary.json",
+      "solvable": true
+    },
+    {
+      "id": "simple-electricity-market-storage",
+      "description": "Single bidding zone with fixed load and storage over several periods, aligned to the PyPSA example.",
+      "entrypoint": "tests/e2e/simple-electricity-market-storage/input.kdl",
+      "expected_semantic_program": "tests/e2e/simple-electricity-market-storage/expected/semantic-program.json",
+      "expected_e2e_summary": "tests/e2e/simple-electricity-market-storage/expected/e2e-summary.json",
+      "solvable": true
+    },
+    {
+      "id": "generator-allocation",
+      "description": "Canonical model syntax smoke test for single-fleet generator allocation.",
+      "entrypoint": "tests/e2e/generator-allocation/input.kdl",
+      "expected_semantic_program": "tests/e2e/generator-allocation/expected/semantic-program.json",
+      "expected_e2e_summary": "tests/e2e/generator-allocation/expected/e2e-summary.json",
+      "solvable": true
+    },
+    {
+      "id": "sdom",
+      "description": "Storage Deployment Optimization Model: co-optimizes VRE investment, balancing, storage, and trade with clean-energy target.",
+      "entrypoint": "tests/e2e/sdom/input.kdl",
+      "expected_semantic_program": "tests/e2e/sdom/expected/semantic-program.json",
+      "expected_e2e_summary": "tests/e2e/sdom/expected/e2e-summary.json",
+      "solvable": true
+    },
+    {
+      "id": "sdom-canonical",
+      "description": "SDOM expressed with low-level model syntax and custom index sets.",
+      "entrypoint": "tests/e2e/sdom-canonical/input.kdl",
+      "expected_semantic_program": "tests/e2e/sdom-canonical/expected/semantic-program.json",
+      "expected_e2e_summary": "tests/e2e/sdom-canonical/expected/e2e-summary.json",
+      "solvable": true
+    }
+  ]
+}

--- a/crates/arco-kdl/tests/e2e/pcm/expected/e2e-summary.json
+++ b/crates/arco-kdl/tests/e2e/pcm/expected/e2e-summary.json
@@ -1,0 +1,12 @@
+{
+  "case_id": "pcm",
+  "expect_parse_success": true,
+  "expect_semantic_validation_success": true,
+  "expect_lowering_success": true,
+  "expect_solve_success": true,
+  "objective": {
+    "name": "SystemCost",
+    "sense": "minimize"
+  },
+  "reports": ["FuelCost", "StartupCost", "PenaltyCost"]
+}

--- a/crates/arco-kdl/tests/e2e/pcm/expected/semantic-program.json
+++ b/crates/arco-kdl/tests/e2e/pcm/expected/semantic-program.json
@@ -1,0 +1,33 @@
+{
+  "case_id": "pcm",
+  "active_scenario": "BaseCase",
+  "sets": {
+    "assets": ["Thermal1", "Thermal2"],
+    "time": {
+      "steps": 24,
+      "resolution": "PT1H"
+    }
+  },
+  "parameters": {
+    "series": ["demand[t]", "lol_penalty[t]"],
+    "indexed": ["fuel_cost[a,t]"],
+    "asset": [
+      "initial_commitment[a]",
+      "p_max[a]",
+      "p_min[a]",
+      "ramp_down[a]",
+      "ramp_up[a]",
+      "startup_cost[a]"
+    ]
+  },
+  "variable_families": [
+    "commit[a,t]",
+    "generation[a,t]",
+    "shutdown[a,t]",
+    "start[a,t]",
+    "unserved_energy[t]"
+  ],
+  "chronology": {
+    "initial_commitment_boundary": "initial_commitment[a]"
+  }
+}

--- a/crates/arco-kdl/tests/e2e/pcm/input.kdl
+++ b/crates/arco-kdl/tests/e2e/pcm/input.kdl
@@ -1,0 +1,73 @@
+technology "Thermal" {
+  control "generation"
+  state "commit"
+  state "start"
+  state "shutdown"
+}
+
+operation "StandardUC" {
+  constraint "commitment_transition" {
+    commit[a,t] - commit[a,t-1] = start[a,t] - shutdown[a,t]
+  }
+  constraint "min_output" {
+    generation[a,t] >= p_min[a] * commit[a,t]
+  }
+  constraint "max_output" {
+    generation[a,t] <= p_max[a] * commit[a,t]
+  }
+  constraint "ramp_up_limit" {
+    generation[a,t] - generation[a,t-1] <= ramp_up[a]
+  }
+  constraint "ramp_down_limit" {
+    generation[a,t-1] - generation[a,t] <= ramp_down[a]
+  }
+}
+
+instances "ThermalUnits" from="data/thermal_units.csv" {
+  technology "Thermal"
+  operation "StandardUC"
+  map "name" from="asset_name"
+  map "p_min" from="p_min_mw"
+  map "p_max" from="p_max_mw"
+  map "ramp_up" from="ramp_up"
+  map "ramp_down" from="ramp_down"
+  map "startup_cost" from="startup_cost"
+}
+
+rule "EnergyBalance" {
+  constraint "balance" {
+    sum(generation[a,t] for a in assets) + unserved_energy[t] = demand[t]
+  }
+}
+
+expression "FuelCost" {
+  sum(fuel_cost[a,t] * generation[a,t] for a in assets for t in time)
+}
+
+expression "StartupCost" {
+  sum(startup_cost[a] * start[a,t] for a in assets for t in time)
+}
+
+expression "PenaltyCost" {
+  sum(lol_penalty[t] * unserved_energy[t] for t in time)
+}
+
+minimize "SystemCost" {
+  FuelCost + StartupCost + PenaltyCost
+}
+
+scenario "BaseCase" {
+  horizon steps=24 resolution="PT1H"
+  technology "Thermal"
+  operation "StandardUC"
+  rule "EnergyBalance"
+  data "demand" from="data/demand.csv"
+  data "fuel_cost" from="data/fuel_cost.csv"
+  data "lol_penalty" from="data/lol_penalty.csv"
+  data "initial_commitment" from="data/initial_commitment.csv"
+  instances "ThermalUnits"
+  minimize "SystemCost"
+  report "FuelCost"
+  report "StartupCost"
+  report "PenaltyCost"
+}

--- a/crates/arco-kdl/tests/e2e/price-taker-battery/expected/e2e-summary.json
+++ b/crates/arco-kdl/tests/e2e/price-taker-battery/expected/e2e-summary.json
@@ -1,0 +1,12 @@
+{
+  "case_id": "price-taker-battery",
+  "expect_parse_success": true,
+  "expect_semantic_validation_success": true,
+  "expect_lowering_success": true,
+  "expect_solve_success": true,
+  "objective": {
+    "name": "ArbitrageProfit",
+    "sense": "maximize"
+  },
+  "reports": ["ArbitrageRevenue"]
+}

--- a/crates/arco-kdl/tests/e2e/price-taker-battery/expected/semantic-program.json
+++ b/crates/arco-kdl/tests/e2e/price-taker-battery/expected/semantic-program.json
@@ -1,0 +1,27 @@
+{
+  "case_id": "price-taker-battery",
+  "active_scenario": "BatteryArbitrageDay",
+  "sets": {
+    "assets": ["Battery1"],
+    "time": {
+      "steps": 24,
+      "resolution": "PT1H"
+    }
+  },
+  "parameters": {
+    "series": ["prices[t]"],
+    "asset": [
+      "charge_efficiency[a]",
+      "discharge_efficiency[a]",
+      "energy_mwh[a]",
+      "initial_soc_mwh[a]",
+      "power_mw[a]",
+      "terminal_soc_mwh[a]"
+    ]
+  },
+  "variable_families": ["charge[a,t]", "discharge[a,t]", "soc[a,t]"],
+  "chronology": {
+    "initial_boundary": "initial_soc_mwh[a]",
+    "terminal_boundary": "terminal_soc_mwh[a]"
+  }
+}

--- a/crates/arco-kdl/tests/e2e/price-taker-battery/input.kdl
+++ b/crates/arco-kdl/tests/e2e/price-taker-battery/input.kdl
@@ -1,0 +1,49 @@
+technology "Battery" {
+  control "charge"
+  control "discharge"
+  state "soc"
+}
+
+asset "Battery1" {
+  technology "Battery"
+  operation "PriceTakerBattery"
+  power_mw 100
+  energy_mwh 400
+  charge_efficiency 0.92
+  discharge_efficiency 0.92
+  initial_soc_mwh 200
+  terminal_soc_mwh 200
+}
+
+operation "PriceTakerBattery" {
+  constraint name="soc_balance" {
+    soc[a,t] = soc[a,t-1] + charge_efficiency[a] * charge[a,t] - discharge[a,t] / discharge_efficiency[a]
+  }
+  constraint "charge_limit" {
+    charge[a,t] <= power_mw[a]
+  }
+  constraint "discharge_limit" {
+    discharge[a,t] <= power_mw[a]
+  }
+  constraint "soc_bounds" {
+    0 <= soc[a,t] <= energy_mwh[a]
+  }
+}
+
+expression "ArbitrageRevenue" {
+  sum(prices[t] * (discharge[a,t] - charge[a,t]) for a in assets for t in time)
+}
+
+maximize "ArbitrageProfit" {
+  ArbitrageRevenue
+}
+
+scenario "BatteryArbitrageDay" {
+  horizon steps=24 resolution="PT1H"
+  technology "Battery"
+  operation "PriceTakerBattery"
+  data "prices" from="data/prices.csv"
+  asset "Battery1"
+  maximize "ArbitrageProfit"
+  report "ArbitrageRevenue"
+}

--- a/crates/arco-kdl/tests/e2e/sdom-canonical/data
+++ b/crates/arco-kdl/tests/e2e/sdom-canonical/data
@@ -1,0 +1,1 @@
+../sdom/data

--- a/crates/arco-kdl/tests/e2e/sdom-canonical/expected/e2e-summary.json
+++ b/crates/arco-kdl/tests/e2e/sdom-canonical/expected/e2e-summary.json
@@ -1,0 +1,12 @@
+{
+  "case_id": "sdom-canonical",
+  "expect_parse_success": true,
+  "expect_semantic_validation_success": true,
+  "expect_lowering_success": true,
+  "expect_solve_success": true,
+  "objective": {
+    "name": "SystemCost",
+    "sense": "minimize"
+  },
+  "reports": []
+}

--- a/crates/arco-kdl/tests/e2e/sdom-canonical/expected/semantic-program.json
+++ b/crates/arco-kdl/tests/e2e/sdom-canonical/expected/semantic-program.json
@@ -1,0 +1,47 @@
+{
+  "case_id": "sdom-canonical",
+  "active_scenario": "SDOMCanonical",
+  "sets": {
+    "assets": [
+      "DispatchableHydro",
+      "GasCT",
+      "LiIon",
+      "PV_North",
+      "PV_South",
+      "TradeNode",
+      "Wind_East"
+    ],
+    "candidate_assets": [],
+    "time": {
+      "steps": 24,
+      "resolution": "PT1H"
+    }
+  },
+  "parameters": {
+    "series": [],
+    "indexed": [],
+    "asset": []
+  },
+  "variable_families": [
+    "pv_fraction[p]",
+    "wind_fraction[w]",
+    "bal_capacity[k]",
+    "power_charge[j]",
+    "power_discharge[j]",
+    "energy_cap[j]",
+    "pv_dispatch[p,t]",
+    "wind_dispatch[w,t]",
+    "bal_dispatch[k,t]",
+    "charge[j,t]",
+    "discharge[j,t]",
+    "charge_indicator[j,t]",
+    "soc[j,t]",
+    "dispatch[h,t]",
+    "imports[n,t]",
+    "exports[n,t]"
+  ],
+  "chronology": {
+    "initial_boundary": "initial_soc_mwh"
+  },
+  "lowering_rules": []
+}

--- a/crates/arco-kdl/tests/e2e/sdom-canonical/input.kdl
+++ b/crates/arco-kdl/tests/e2e/sdom-canonical/input.kdl
@@ -1,0 +1,371 @@
+// ---------------------------------------------------------------------------
+// SDOM Canonical: Low-level model form of the SDOM fixture
+//
+// Expresses the exact same optimization problem as tests/e2e/sdom/input.kdl
+// using the canonical `model` block with explicit index sets instead of the
+// high-level technology/operation/rule pattern.
+//
+// Expected objective: ~$472,928.62 (must match within solver tolerance)
+// ---------------------------------------------------------------------------
+
+model "SDOM" {
+
+    // ===================================================================
+    // Investment variables (asset-only, one index)
+    // ===================================================================
+    control "pv_fraction" lower=0 upper=1 {
+        p in="pv_plants"
+    }
+    control "wind_fraction" lower=0 upper=1 {
+        w in="wind_plants"
+    }
+    control "bal_capacity" lower=0 {
+        k in="balancing_units"
+    }
+    control "power_charge" lower=0 {
+        j in="storage_techs"
+    }
+    control "power_discharge" lower=0 {
+        j in="storage_techs"
+    }
+    control "energy_cap" lower=0 {
+        j in="storage_techs"
+    }
+
+    // ===================================================================
+    // Dispatch variables (asset + time, two indices)
+    // ===================================================================
+    control "pv_dispatch" lower=0 {
+        p in="pv_plants"
+        t in="time"
+    }
+    control "wind_dispatch" lower=0 {
+        w in="wind_plants"
+        t in="time"
+    }
+    control "bal_dispatch" lower=0 {
+        k in="balancing_units"
+        t in="time"
+    }
+    control "charge" lower=0 {
+        j in="storage_techs"
+        t in="time"
+    }
+    control "discharge" lower=0 {
+        j in="storage_techs"
+        t in="time"
+    }
+    control "charge_indicator" kind="binary" lower=0 upper=1 {
+        j in="storage_techs"
+        t in="time"
+    }
+    control "soc" lower=0 {
+        j in="storage_techs"
+        t in="time"
+    }
+    control "dispatch" lower=0 {
+        h in="hydro_units"
+        t in="time"
+    }
+    control "imports" lower=0 {
+        n in="trade_nodes"
+        t in="time"
+    }
+    control "exports" lower=0 {
+        n in="trade_nodes"
+        t in="time"
+    }
+
+    // ===================================================================
+    // PV dispatch limit
+    // ===================================================================
+    constraint "pv_dispatch_limit" {
+        over "p" in="pv_plants"
+        over "t" in="time"
+        expr {
+            pv_dispatch[p,t] <= solar_cf[p,t] * pv_max_cap[p] * pv_fraction[p]
+        }
+    }
+
+    // ===================================================================
+    // Wind dispatch limit
+    // ===================================================================
+    constraint "wind_dispatch_limit" {
+        over "w" in="wind_plants"
+        over "t" in="time"
+        expr {
+            wind_dispatch[w,t] <= wind_cf[w,t] * wind_max_cap[w] * wind_fraction[w]
+        }
+    }
+
+    // ===================================================================
+    // Balancing unit constraints
+    // ===================================================================
+    constraint "dispatch_limit" {
+        over "k" in="balancing_units"
+        over "t" in="time"
+        expr { bal_dispatch[k,t] <= bal_capacity[k] }
+    }
+
+    constraint "capacity_lower" {
+        over "k" in="balancing_units"
+        expr { bal_capacity[k] >= min_bal_cap[k] }
+    }
+
+    constraint "capacity_upper" {
+        over "k" in="balancing_units"
+        expr { bal_capacity[k] <= max_bal_cap[k] }
+    }
+
+    // ===================================================================
+    // Storage constraints
+    // ===================================================================
+    constraint "coupled_power" {
+        over "j" in="storage_techs"
+        expr { power_charge[j] = power_discharge[j] }
+    }
+
+    constraint "charge_power_cap" {
+        over "j" in="storage_techs"
+        expr { power_charge[j] <= max_stor_power[j] }
+    }
+
+    constraint "discharge_power_cap" {
+        over "j" in="storage_techs"
+        expr { power_discharge[j] <= max_stor_power[j] }
+    }
+
+    constraint "charge_limit" {
+        over "j" in="storage_techs"
+        over "t" in="time"
+        expr { charge[j,t] <= power_charge[j] }
+    }
+
+    constraint "discharge_limit" {
+        over "j" in="storage_techs"
+        over "t" in="time"
+        expr { discharge[j,t] <= power_discharge[j] }
+    }
+
+    constraint "charge_big_m" {
+        over "j" in="storage_techs"
+        over "t" in="time"
+        expr { charge[j,t] <= max_stor_power[j] * charge_indicator[j,t] }
+    }
+
+    constraint "discharge_big_m" {
+        over "j" in="storage_techs"
+        over "t" in="time"
+        expr {
+            discharge[j,t] <= max_stor_power[j] - max_stor_power[j] * charge_indicator[j,t]
+        }
+    }
+
+    // SOC initial: handles t=1 explicitly so we don't reference soc[j,0]
+    constraint "soc_initial" {
+        over "j" in="storage_techs"
+        over "t" in="time"
+        when "t == 1"
+        expr {
+            soc[j,t] = initial_soc_mwh[j]
+                + sqrt(roundtrip_eff[j]) * charge[j,t]
+                - discharge[j,t] / sqrt(roundtrip_eff[j])
+        }
+    }
+
+    // SOC balance: t >= 2, references soc[j,t-1]
+    constraint "soc_balance" {
+        over "j" in="storage_techs"
+        over "t" in="time"
+        when "t >= 2"
+        expr {
+            soc[j,t] = soc[j,t-1]
+                + sqrt(roundtrip_eff[j]) * charge[j,t]
+                - discharge[j,t] / sqrt(roundtrip_eff[j])
+        }
+    }
+
+    constraint "soc_lower" {
+        over "j" in="storage_techs"
+        over "t" in="time"
+        expr { soc[j,t] >= 0 }
+    }
+
+    constraint "soc_upper" {
+        over "j" in="storage_techs"
+        over "t" in="time"
+        expr { soc[j,t] <= energy_cap[j] }
+    }
+
+    constraint "min_duration" {
+        over "j" in="storage_techs"
+        expr {
+            energy_cap[j] >= min_dur[j] * power_discharge[j] / sqrt(roundtrip_eff[j])
+        }
+    }
+
+    constraint "max_duration" {
+        over "j" in="storage_techs"
+        expr {
+            energy_cap[j] <= max_dur[j] * power_discharge[j] / sqrt(roundtrip_eff[j])
+        }
+    }
+
+    constraint "cycle_limit" {
+        over "j" in="storage_techs"
+        expr {
+            sum(discharge[j,t] for t in time) <= annualized_max_cycles[j] * energy_cap[j]
+        }
+    }
+
+    // ===================================================================
+    // Hydro constraints
+    // ===================================================================
+    constraint "hydro_min_bound" {
+        over "h" in="hydro_units"
+        over "t" in="time"
+        expr { dispatch[h,t] >= hydro_min[h,t] }
+    }
+
+    constraint "hydro_max_bound" {
+        over "h" in="hydro_units"
+        over "t" in="time"
+        expr { dispatch[h,t] <= hydro_max[h,t] }
+    }
+
+    constraint "energy_budget" {
+        over "b" in="budget_periods"
+        expr {
+            sum(dispatch[h,t] for h in hydro_units for t in time
+                if t >= budget_start[b] if t <= budget_end[b])
+            = energy_budget[b]
+        }
+    }
+
+    // ===================================================================
+    // Trade constraints
+    // ===================================================================
+    constraint "import_cap" {
+        over "n" in="trade_nodes"
+        over "t" in="time"
+        expr { imports[n,t] <= max_import[n] }
+    }
+
+    constraint "export_cap" {
+        over "n" in="trade_nodes"
+        over "t" in="time"
+        expr { exports[n,t] <= max_export[n] }
+    }
+
+    // ===================================================================
+    // System constraints
+    // ===================================================================
+    constraint "energy_balance" {
+        over "t" in="time"
+        expr {
+            sum(pv_dispatch[p,t] for p in pv_plants)
+            + sum(wind_dispatch[w,t] for w in wind_plants)
+            + sum(bal_dispatch[k,t] for k in balancing_units)
+            + sum(dispatch[h,t] for h in hydro_units)
+            + nuclear_gen[t]
+            + sum(discharge[j,t] for j in storage_techs)
+            + sum(imports[n,t] for n in trade_nodes)
+            = demand[t]
+            + sum(charge[j,t] for j in storage_techs)
+            + sum(exports[n,t] for n in trade_nodes)
+        }
+    }
+
+    constraint "clean_target" {
+        expr {
+            sum(bal_dispatch[k,t] for k in balancing_units for t in time)
+            <= 0.2 * (
+                sum(demand[t] for t in time)
+                + sum(charge[j,t] for j in storage_techs for t in time)
+                - sum(discharge[j,t] for j in storage_techs for t in time)
+            )
+        }
+    }
+
+    // ===================================================================
+    // Objective
+    // ===================================================================
+    minimize "SystemCost" {
+        sum(annualized_pv_cost[p] * pv_max_cap[p] * pv_fraction[p] for p in pv_plants)
+        + sum(annualized_wind_cost[w] * wind_max_cap[w] * wind_fraction[w] for w in wind_plants)
+        + sum(annualized_bal_invest[k] * bal_capacity[k] for k in balancing_units)
+        + sum(marginal_cost[k] * bal_dispatch[k,t] for k in balancing_units for t in time)
+        + sum(
+            power_discharge[j] * annualized_power_cost[j]
+            - cost_ratio[j] * power_discharge[j] * annualized_power_cost[j]
+            + cost_ratio[j] * power_charge[j] * annualized_power_cost[j]
+            + annualized_energy_cost[j] * energy_cap[j]
+          for j in storage_techs)
+        + sum(vom_stor[j] * discharge[j,t] for j in storage_techs for t in time)
+        + sum(import_price[t] * imports[n,t] for n in trade_nodes for t in time)
+        - sum(export_price[t] * exports[n,t] for n in trade_nodes for t in time)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Scenario: wire the model to data
+// ---------------------------------------------------------------------------
+
+scenario "SDOMCanonical" {
+    horizon steps=24 resolution="PT1H"
+    use "SDOM"
+
+    // Assets (all seven from the high-level fixture)
+    asset "PV_North"
+    asset "PV_South"
+    asset "Wind_East"
+    asset "GasCT"
+    asset "LiIon"
+    asset "DispatchableHydro"
+    asset "TradeNode"
+
+    // Custom sets mapping index letters to asset subsets
+    pv_plants { "PV_North"; "PV_South" }
+    wind_plants { "Wind_East" }
+    balancing_units { "GasCT" }
+    storage_techs { "LiIon" }
+    hydro_units { "DispatchableHydro" }
+    trade_nodes { "TradeNode" }
+
+    // Set with parameters (budget periods from CSV)
+    set "budget_periods" from="data/budget_periods.csv"
+
+    // Time-indexed data (t-only)
+    data "demand" from="data/demand.csv"
+    data "nuclear_gen" from="data/nuclear_gen.csv"
+    data "import_price" from="data/import_price.csv"
+    data "export_price" from="data/export_price.csv"
+
+    // Asset+time indexed data (asset_name, t)
+    data "solar_cf" from="data/solar_cf.csv"
+    data "wind_cf" from="data/wind_cf.csv"
+    data "hydro_min" from="data/hydro_min.csv"
+    data "hydro_max" from="data/hydro_max.csv"
+
+    // Asset-level parameters from instance CSVs (asset_name, no t)
+    data "pv_max_cap" from="data/pv_plants.csv"
+    data "annualized_pv_cost" from="data/pv_plants.csv"
+    data "wind_max_cap" from="data/wind_plants.csv"
+    data "annualized_wind_cost" from="data/wind_plants.csv"
+    data "min_bal_cap" from="data/balancing_units.csv"
+    data "max_bal_cap" from="data/balancing_units.csv"
+    data "annualized_bal_invest" from="data/balancing_units.csv"
+    data "marginal_cost" from="data/balancing_units.csv"
+    data "max_stor_power" from="data/storage_techs.csv"
+    data "annualized_power_cost" from="data/storage_techs.csv"
+    data "annualized_energy_cost" from="data/storage_techs.csv"
+    data "roundtrip_eff" from="data/storage_techs.csv"
+    data "min_dur" from="data/storage_techs.csv"
+    data "max_dur" from="data/storage_techs.csv"
+    data "vom_stor" from="data/storage_techs.csv"
+    data "annualized_max_cycles" from="data/storage_techs.csv"
+    data "cost_ratio" from="data/storage_techs.csv"
+    data "initial_soc_mwh" from="data/storage_techs.csv"
+    data "max_import" from="trade_nodes.csv"
+    data "max_export" from="trade_nodes.csv"
+}

--- a/crates/arco-kdl/tests/e2e/sdom/expected/e2e-summary.json
+++ b/crates/arco-kdl/tests/e2e/sdom/expected/e2e-summary.json
@@ -1,0 +1,12 @@
+{
+  "case_id": "sdom",
+  "expect_parse_success": true,
+  "expect_semantic_validation_success": true,
+  "expect_lowering_success": true,
+  "expect_solve_success": true,
+  "objective": {
+    "name": "SystemCost",
+    "sense": "minimize"
+  },
+  "reports": ["PVCost", "WindCost", "BalancingCost", "StorageCost", "TradeCost"]
+}

--- a/crates/arco-kdl/tests/e2e/sdom/expected/semantic-program.json
+++ b/crates/arco-kdl/tests/e2e/sdom/expected/semantic-program.json
@@ -1,0 +1,78 @@
+{
+  "case_id": "sdom",
+  "active_scenario": "SDOMCase",
+  "sets": {
+    "assets": [
+      "DispatchableHydro",
+      "GasCT",
+      "LiIon",
+      "PV_North",
+      "PV_South",
+      "TradeNode",
+      "Wind_East"
+    ],
+    "candidate_assets": [],
+    "time": {
+      "steps": 24,
+      "resolution": "PT1H"
+    }
+  },
+  "parameters": {
+    "series": [
+      "demand[t]",
+      "export_price[t]",
+      "import_price[t]",
+      "nuclear_gen[t]"
+    ],
+    "indexed": [
+      "hydro_max[a,t]",
+      "hydro_min[a,t]",
+      "solar_cf[a,t]",
+      "wind_cf[a,t]"
+    ],
+    "asset": [
+      "annualized_bal_invest[a]",
+      "annualized_energy_cost[a]",
+      "annualized_max_cycles[a]",
+      "annualized_power_cost[a]",
+      "annualized_pv_cost[a]",
+      "annualized_wind_cost[a]",
+      "cost_ratio[a]",
+      "initial_soc_mwh[a]",
+      "marginal_cost[a]",
+      "max_bal_cap[a]",
+      "max_dur[a]",
+      "max_export[a]",
+      "max_import[a]",
+      "max_stor_power[a]",
+      "min_bal_cap[a]",
+      "min_dur[a]",
+      "pv_max_cap[a]",
+      "roundtrip_eff[a]",
+      "vom_stor[a]",
+      "wind_max_cap[a]"
+    ]
+  },
+  "variable_families": [
+    "bal_capacity[a]",
+    "bal_dispatch[a,t]",
+    "charge[a,t]",
+    "charge_indicator[a,t]",
+    "discharge[a,t]",
+    "dispatch[a,t]",
+    "energy_cap[a]",
+    "exports[a,t]",
+    "imports[a,t]",
+    "power_charge[a]",
+    "power_discharge[a]",
+    "pv_dispatch[a,t]",
+    "pv_fraction[a]",
+    "soc[a,t]",
+    "wind_dispatch[a,t]",
+    "wind_fraction[a]"
+  ],
+  "chronology": {
+    "initial_boundary": "initial_soc_mwh[a]"
+  },
+  "lowering_rules": []
+}

--- a/crates/arco-kdl/tests/e2e/sdom/input.kdl
+++ b/crates/arco-kdl/tests/e2e/sdom/input.kdl
@@ -1,0 +1,212 @@
+// ---------------------------------------------------------------------------
+// SDOM: Storage Deployment Optimization Model
+//
+// Co-optimizes investment in renewable generation, balancing units, and
+// storage technologies while dispatching all resources to meet demand at
+// minimum annualized system cost subject to a clean-energy target.
+// ---------------------------------------------------------------------------
+
+// --- Technologies -----------------------------------------------------------
+// The as= property names the set of assets for each technology, making
+// constraint references like `for a in pv_plants` explicit and greppable.
+
+technology "PV" as="pv_plants" {
+    invest "pv_fraction" lower=0 upper=1
+    control "pv_dispatch" lower=0
+}
+
+technology "Wind" as="wind_plants" {
+    invest "wind_fraction" lower=0 upper=1
+    control "wind_dispatch" lower=0
+}
+
+technology "BalancingUnit" as="balancing_units" {
+    invest "bal_capacity" lower=0
+    control "bal_dispatch" lower=0
+}
+
+technology "CoupledStorage" as="storage_techs" {
+    invest "power_charge" lower=0
+    invest "power_discharge" lower=0
+    invest "energy_cap" lower=0
+    control "charge" lower=0
+    control "discharge" lower=0
+    control "charge_indicator" kind="binary"
+    state "soc"
+}
+
+technology "Hydro" as="hydro_units" {
+    control "dispatch" lower=0
+}
+
+technology "Trade" as="trade_nodes" {
+    control "imports" lower=0
+    control "exports" lower=0
+}
+
+// --- Operations (per-asset constraints) -------------------------------------
+
+operation "PVDispatch" {
+    constraint "pv_dispatch_limit" {
+        pv_dispatch[a,t] <= solar_cf[a,t] * pv_max_cap[a] * pv_fraction[a]
+    }
+}
+
+operation "WindDispatch" {
+    constraint "wind_dispatch_limit" {
+        wind_dispatch[a,t] <= wind_cf[a,t] * wind_max_cap[a] * wind_fraction[a]
+    }
+}
+
+operation "BalancingOp" {
+    constraint "dispatch_limit" { bal_dispatch[a,t] <= bal_capacity[a] }
+    constraint "capacity_lower" { bal_capacity[a] >= min_bal_cap[a] }
+    constraint "capacity_upper" { bal_capacity[a] <= max_bal_cap[a] }
+}
+
+operation "StorageOp" {
+    constraint "coupled_power" { power_charge[a] = power_discharge[a] }
+    constraint "charge_power_cap" { power_charge[a] <= max_stor_power[a] }
+    constraint "discharge_power_cap" { power_discharge[a] <= max_stor_power[a] }
+    constraint "charge_limit" { charge[a,t] <= power_charge[a] }
+    constraint "discharge_limit" { discharge[a,t] <= power_discharge[a] }
+    constraint "charge_big_m" { charge[a,t] <= max_stor_power[a] * charge_indicator[a,t] }
+    constraint "discharge_big_m" {
+        discharge[a,t] <= max_stor_power[a] - max_stor_power[a] * charge_indicator[a,t]
+    }
+    constraint "soc_balance" {
+        soc[a,t] = soc[a,t-1] + sqrt(roundtrip_eff[a]) * charge[a,t] - discharge[a,t] / sqrt(roundtrip_eff[a])
+    }
+    constraint "soc_lower" { soc[a,t] >= 0 }
+    constraint "soc_upper" { soc[a,t] <= energy_cap[a] }
+    constraint "min_duration" { energy_cap[a] >= min_dur[a] * power_discharge[a] / sqrt(roundtrip_eff[a]) }
+    constraint "max_duration" { energy_cap[a] <= max_dur[a] * power_discharge[a] / sqrt(roundtrip_eff[a]) }
+    constraint "cycle_limit" {
+        over "a" in="storage_techs"
+        expr { sum(discharge[a,t] for t in time) <= annualized_max_cycles[a] * energy_cap[a] }
+    }
+}
+
+operation "HydroOp" {
+    constraint "hydro_min_bound" { dispatch[a,t] >= hydro_min[a,t] }
+    constraint "hydro_max_bound" { dispatch[a,t] <= hydro_max[a,t] }
+}
+
+operation "TradeOp" {
+    constraint "import_cap" { imports[a,t] <= max_import[a] }
+    constraint "export_cap" { exports[a,t] <= max_export[a] }
+}
+
+// --- Rules (system-level constraints) ---------------------------------------
+
+rule "EnergyBalance" {
+    constraint "balance" {
+        sum(pv_dispatch[a,t] for a in pv_plants)
+        + sum(wind_dispatch[a,t] for a in wind_plants)
+        + sum(bal_dispatch[a,t] for a in balancing_units)
+        + sum(dispatch[a,t] for a in hydro_units)
+        + nuclear_gen[t]
+        + sum(discharge[a,t] for a in storage_techs)
+        + sum(imports[a,t] for a in trade_nodes)
+        = demand[t]
+        + sum(charge[a,t] for a in storage_techs)
+        + sum(exports[a,t] for a in trade_nodes)
+    }
+}
+
+rule "CleanEnergyTarget" {
+    constraint "clean_target" {
+        over "a" in="balancing_units"
+        expr {
+            sum(bal_dispatch[a,t] for a in balancing_units for t in time)
+            <= 0.2 * (
+                sum(demand[t] for t in time)
+                + sum(charge[a,t] for a in storage_techs for t in time)
+                - sum(discharge[a,t] for a in storage_techs for t in time)
+            )
+        }
+    }
+}
+
+rule "HydroBudget" {
+    constraint "energy_budget" {
+        over "b" in="budget_periods"
+        expr {
+            sum(dispatch[a,t] for a in hydro_units for t in time
+                if t >= budget_start[b] if t <= budget_end[b])
+            = energy_budget[b]
+        }
+    }
+}
+
+// --- Cost expressions -------------------------------------------------------
+
+expression "PVCost" {
+    sum(annualized_pv_cost[a] * pv_max_cap[a] * pv_fraction[a] for a in pv_plants)
+}
+
+expression "WindCost" {
+    sum(annualized_wind_cost[a] * wind_max_cap[a] * wind_fraction[a] for a in wind_plants)
+}
+
+expression "BalancingCost" {
+    sum(annualized_bal_invest[a] * bal_capacity[a] for a in balancing_units)
+    + sum(marginal_cost[a] * bal_dispatch[a,t] for a in balancing_units for t in time)
+}
+
+expression "StorageCost" {
+    sum(
+        annualized_power_cost[a] * power_discharge[a]
+        - annualized_power_cost[a] * cost_ratio[a] * power_discharge[a]
+        + annualized_power_cost[a] * cost_ratio[a] * power_charge[a]
+        + annualized_energy_cost[a] * energy_cap[a]
+    for a in storage_techs)
+    + sum(vom_stor[a] * discharge[a,t] for a in storage_techs for t in time)
+}
+
+expression "TradeCost" {
+    sum(import_price[t] * imports[a,t] for a in trade_nodes for t in time)
+    - sum(export_price[t] * exports[a,t] for a in trade_nodes for t in time)
+}
+
+minimize "SystemCost" { PVCost + WindCost + BalancingCost + StorageCost + TradeCost }
+
+// --- Instances and Assets ---------------------------------------------------
+// Auto-map: CSV columns auto-map to parameters by name (no map directives needed).
+
+instances "PVPlants" from="data/pv_plants.csv" { technology "PV"; operation "PVDispatch" }
+instances "WindPlants" from="data/wind_plants.csv" { technology "Wind"; operation "WindDispatch" }
+instances "BalancingUnits" from="data/balancing_units.csv" { technology "BalancingUnit"; operation "BalancingOp" }
+instances "StorageTechs" from="data/storage_techs.csv" { technology "CoupledStorage"; operation "StorageOp" }
+
+asset "DispatchableHydro" { technology "Hydro"; operation "HydroOp" }
+asset "TradeNode" { technology "Trade"; operation "TradeOp"; max_import 500; max_export 500 }
+
+// --- Scenario ---------------------------------------------------------------
+// Auto-wire: technologies, operations, and rules are inferred from the
+// instances and assets declared above. No need to re-list them.
+
+scenario "SDOMCase" {
+    horizon steps=24 resolution="PT1H"
+    set "budget_periods" from="data/budget_periods.csv"
+    data "demand" from="data/demand.csv"
+    data "solar_cf" from="data/solar_cf.csv"
+    data "wind_cf" from="data/wind_cf.csv"
+    data "nuclear_gen" from="data/nuclear_gen.csv"
+    data "hydro_min" from="data/hydro_min.csv"
+    data "hydro_max" from="data/hydro_max.csv"
+    data "import_price" from="data/import_price.csv"
+    data "export_price" from="data/export_price.csv"
+    instances "PVPlants"
+    instances "WindPlants"
+    instances "BalancingUnits"
+    instances "StorageTechs"
+    asset "DispatchableHydro"
+    asset "TradeNode"
+    minimize "SystemCost"
+    report "PVCost"
+    report "WindCost"
+    report "BalancingCost"
+    report "StorageCost"
+    report "TradeCost"
+}

--- a/crates/arco-kdl/tests/e2e/simple-electricity-market-storage/expected/e2e-summary.json
+++ b/crates/arco-kdl/tests/e2e/simple-electricity-market-storage/expected/e2e-summary.json
@@ -1,0 +1,12 @@
+{
+  "case_id": "simple-electricity-market-storage",
+  "expect_parse_success": true,
+  "expect_semantic_validation_success": true,
+  "expect_lowering_success": true,
+  "expect_solve_success": true,
+  "objective": {
+    "name": "TotalSystemCost",
+    "sense": "minimize"
+  },
+  "reports": ["DispatchCost"]
+}

--- a/crates/arco-kdl/tests/e2e/simple-electricity-market-storage/expected/semantic-program.json
+++ b/crates/arco-kdl/tests/e2e/simple-electricity-market-storage/expected/semantic-program.json
@@ -1,0 +1,20 @@
+{
+  "case_id": "simple-electricity-market-storage",
+  "active_scenario": "SouthAfricaSingleZoneWithStorage",
+  "sets": {
+    "assets": ["Coal", "Gas", "Oil", "PumpedHydro", "Wind"],
+    "time": {
+      "steps": 4,
+      "resolution": "PT1H"
+    }
+  },
+  "parameters": {
+    "series": ["load[t]"],
+    "indexed": ["availability[a,t]"],
+    "asset": ["capacity_mw[a]", "energy_mwh[a]", "initial_soc_mwh[a]", "marginal_cost[a]", "power_mw[a]"]
+  },
+  "variable_families": ["dispatch[a,t]", "soc[a,t]"],
+  "chronology": {
+    "initial_boundary": "initial_soc_mwh[a]"
+  }
+}

--- a/crates/arco-kdl/tests/e2e/simple-electricity-market-storage/input.kdl
+++ b/crates/arco-kdl/tests/e2e/simple-electricity-market-storage/input.kdl
@@ -1,0 +1,96 @@
+technology "Generator" {
+  control "dispatch"
+}
+
+technology "Storage" {
+  control "dispatch"
+  state "soc"
+}
+
+operation "GeneratorDispatch" {
+  constraint "generator_limit" {
+    dispatch[a,t] <= capacity_mw[a] * availability[a,t]
+  }
+}
+
+operation "StorageDispatch" {
+  constraint "soc_balance" {
+    soc[a,t] = soc[a,t-1] - dispatch[a,t]
+  }
+
+  constraint "dispatch_limit" {
+    -power_mw[a] <= dispatch[a,t] <= power_mw[a]
+  }
+
+  constraint "soc_bounds" {
+    0 <= soc[a,t] <= energy_mwh[a]
+  }
+}
+
+rule "SingleZoneBalance" {
+  constraint "balance" {
+    sum(dispatch[a,t] for a in assets) = load[t]
+  }
+}
+
+expression "DispatchCost" {
+  sum(marginal_cost[a] * dispatch[a,t] for a in assets for t in time)
+}
+
+minimize "TotalSystemCost" {
+  DispatchCost
+}
+
+asset "Coal" {
+  technology "Generator"
+  operation "GeneratorDispatch"
+  capacity_mw 35000
+  marginal_cost 30
+}
+
+asset "Wind" {
+  technology "Generator"
+  operation "GeneratorDispatch"
+  capacity_mw 3000
+  marginal_cost 0
+}
+
+asset "Gas" {
+  technology "Generator"
+  operation "GeneratorDispatch"
+  capacity_mw 8000
+  marginal_cost 60
+}
+
+asset "Oil" {
+  technology "Generator"
+  operation "GeneratorDispatch"
+  capacity_mw 2000
+  marginal_cost 80
+}
+
+asset "PumpedHydro" {
+  technology "Storage"
+  operation "StorageDispatch"
+  power_mw 1000
+  energy_mwh 6000
+  initial_soc_mwh 0
+}
+
+scenario "SouthAfricaSingleZoneWithStorage" {
+  horizon steps=4 resolution="PT1H"
+  technology "Generator"
+  technology "Storage"
+  operation "GeneratorDispatch"
+  operation "StorageDispatch"
+  rule "SingleZoneBalance"
+  data "availability" from="data/availability.csv"
+  data "load" from="data/load.csv"
+  asset "Coal"
+  asset "Wind"
+  asset "Gas"
+  asset "Oil"
+  asset "PumpedHydro"
+  minimize "TotalSystemCost"
+  report "DispatchCost"
+}

--- a/crates/arco-kdl/tests/lowering_benchmark.rs
+++ b/crates/arco-kdl/tests/lowering_benchmark.rs
@@ -1,0 +1,45 @@
+use arco_kdl::pipeline::compile_file;
+use std::path::PathBuf;
+use std::time::Instant;
+
+#[test]
+fn lowering_performance_benchmark() -> Result<(), Box<dyn std::error::Error>> {
+    let test_cases = vec![
+        ("price-taker-battery", "input.kdl"),
+        ("pcm", "input.kdl"),
+        ("capacity-expansion", "input.kdl"),
+        ("simple-electricity-market-storage", "input.kdl"),
+        ("generator-allocation", "input.kdl"),
+        ("sdom", "input.kdl"),
+        ("sdom-canonical", "input.kdl"),
+    ];
+
+    let test_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("e2e");
+
+    let mut total_lowering_us = 0u128;
+
+    for (case_name, filename) in &test_cases {
+        let kdl_path = test_dir.join(case_name).join(filename);
+
+        // Compile up to lowering phase
+        let start = Instant::now();
+        let _lowered = compile_file(&kdl_path)?;
+        let elapsed = start.elapsed();
+
+        let lowering_us = elapsed.as_micros();
+        total_lowering_us += lowering_us;
+
+        println!("  {}: {} us", case_name, lowering_us);
+    }
+
+    println!("METRIC lowering_µs={}", total_lowering_us);
+    println!(
+        "Total lowering time: {} us ({} ms)",
+        total_lowering_us,
+        total_lowering_us as f64 / 1000.0
+    );
+
+    Ok(())
+}

--- a/crates/arco-kdl/tests/lowering_suite.rs
+++ b/crates/arco-kdl/tests/lowering_suite.rs
@@ -1,0 +1,1752 @@
+#![allow(clippy::float_cmp)]
+
+use arco_kdl::lowering::lower_program;
+use arco_kdl::semantic::validate_program;
+use arco_kdl::source::{parse_program_file, parse_program_text};
+use std::fs;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[test]
+fn lowers_pcm_fixture_into_internal_contract() -> Result<(), Box<dyn std::error::Error>> {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("e2e")
+        .join("pcm")
+        .join("input.kdl");
+
+    let parsed = parse_program_file(&path)?;
+    let semantic_program = validate_program(&parsed.program, &path)?;
+    let lowered_problem = lower_program(&semantic_program, &parsed.program, &path)?;
+    assert_eq!(lowered_problem.objective.name, "SystemCost");
+    assert_eq!(lowered_problem.objective.sense, "minimize");
+
+    let variable_families: Vec<&str> = lowered_problem
+        .variables
+        .iter()
+        .map(|v| v.family.as_str())
+        .collect();
+    assert_eq!(
+        variable_families,
+        &[
+            "commit[a,t]",
+            "generation[a,t]",
+            "shutdown[a,t]",
+            "start[a,t]",
+            "unserved_energy[t]",
+        ]
+    );
+
+    let constraint_names: Vec<&str> = lowered_problem
+        .constraints
+        .iter()
+        .map(|c| c.name.as_str())
+        .collect();
+    assert_eq!(
+        constraint_names,
+        &[
+            "commitment_transition",
+            "max_output",
+            "min_output",
+            "ramp_down_limit",
+            "ramp_up_limit",
+            "balance",
+        ]
+    );
+
+    let report_names: Vec<&str> = lowered_problem
+        .reports
+        .iter()
+        .map(|r| r.name.as_str())
+        .collect();
+    assert_eq!(report_names, &["FuelCost", "StartupCost", "PenaltyCost"]);
+
+    // 2 assets * 24 time steps each for the per-asset-time variables,
+    // plus 24 steps for unserved_energy (scalar over time) = 216 total instances.
+    assert_eq!(lowered_problem.algebra.variable_instances.len(), 216);
+    // 264 algebraic constraint rows from instantiated DSL constraints.
+    assert_eq!(lowered_problem.algebra.constraints.len(), 264);
+
+    assert!(
+        lowered_problem
+            .traceability
+            .iter()
+            .any(|record| record.dsl_name == "SystemCost" && record.artifact_kind == "objective")
+    );
+    for family in &variable_families {
+        assert!(
+            lowered_problem
+                .traceability
+                .iter()
+                .any(|record| &record.dsl_name == family && record.artifact_kind == "variable"),
+            "missing traceability record for variable family {}",
+            family
+        );
+    }
+    for report in &report_names {
+        assert!(
+            lowered_problem
+                .traceability
+                .iter()
+                .any(|record| &record.dsl_name == report && record.artifact_kind == "report"),
+            "missing traceability record for report {}",
+            report
+        );
+    }
+
+    Ok(())
+}
+
+#[test]
+fn lowers_price_taker_battery_constraints_from_the_source_ast()
+-> Result<(), Box<dyn std::error::Error>> {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("e2e")
+        .join("price-taker-battery")
+        .join("input.kdl");
+
+    let parsed = parse_program_file(&path)?;
+    let semantic_program = validate_program(&parsed.program, &path)?;
+    let lowered_problem = lower_program(&semantic_program, &parsed.program, &path)?;
+
+    let constraint_names = lowered_problem
+        .algebra
+        .constraints
+        .iter()
+        .map(|constraint| constraint.name.as_str())
+        .collect::<Vec<_>>();
+
+    // Spot-check time step 1 for each constraint family.
+    assert!(constraint_names.contains(&"soc_balance[Battery1,1]"));
+    assert!(constraint_names.contains(&"charge_limit[Battery1,1]"));
+    assert!(constraint_names.contains(&"discharge_limit[Battery1,1]"));
+    assert!(constraint_names.contains(&"soc_bounds[Battery1,1]_lower"));
+    assert!(constraint_names.contains(&"soc_bounds[Battery1,1]_upper"));
+    // Verify coverage extends to later time steps, not just step 1.
+    assert!(constraint_names.contains(&"soc_balance[Battery1,24]"));
+    assert!(constraint_names.contains(&"charge_limit[Battery1,24]"));
+    assert!(constraint_names.contains(&"discharge_limit[Battery1,24]"));
+    assert!(constraint_names.contains(&"soc_bounds[Battery1,24]_lower"));
+    assert!(constraint_names.contains(&"soc_bounds[Battery1,24]_upper"));
+    // Terminal constraint is asset-level, not per time step.
+    assert!(constraint_names.contains(&"terminal_soc[Battery1]"));
+
+    // 24 steps * 5 per-timestep constraint types + 1 terminal = 121 total constraint rows.
+    assert_eq!(constraint_names.len(), 121);
+
+    Ok(())
+}
+
+#[test]
+fn filters_capacity_expansion_constraint_rows_by_asset() -> Result<(), Box<dyn std::error::Error>> {
+    let root = temp_test_dir("constraint-row-filter")?;
+    let path = root.join("input.kdl");
+    fs::create_dir_all(root.join("data"))?;
+    fs::write(
+        root.join("data").join("existing_thermal.csv"),
+        "asset_name,existing_capacity_mw,variable_cost,apply_dispatch_limit\nEnabled,50,10,1\nDisabled,50,10,0\n",
+    )?;
+    fs::write(root.join("data").join("demand.csv"), "t,demand\n1,25\n")?;
+    fs::write(root.join("data").join("voll.csv"), "t,voll\n1,1000\n")?;
+    fs::write(
+        &path,
+        r#"
+technology "GasCT" {
+  control "dispatch"
+}
+
+operation "ExpansionDispatch" {
+  constraint "dispatch_limit" if="apply_dispatch_limit[a] == 1" {
+    dispatch[a,t] <= existing_capacity[a]
+  }
+}
+
+rule "EnergyBalance" {
+  constraint "balance" {
+    sum(dispatch[a,t] for a in assets) + unserved_energy[t] = demand[t]
+  }
+}
+
+expression "OperatingCost" {
+  sum(variable_cost[a] * dispatch[a,t] for a in assets for t in time)
+}
+
+expression "PenaltyCost" {
+  sum(voll[t] * unserved_energy[t] for t in time)
+}
+
+minimize "ExpansionCost" {
+  OperatingCost + PenaltyCost
+}
+
+instances "ExistingThermal" from="data/existing_thermal.csv" {
+  technology "GasCT"
+  operation "ExpansionDispatch"
+  map "name" from="asset_name"
+  map "existing_capacity" from="existing_capacity_mw"
+  map "variable_cost" from="variable_cost"
+  map "apply_dispatch_limit" from="apply_dispatch_limit"
+}
+
+scenario "ExpansionCase" {
+  horizon steps=1 resolution="PT1H"
+  technology "GasCT"
+  operation "ExpansionDispatch"
+  rule "EnergyBalance"
+  data "demand" from="data/demand.csv"
+  data "voll" from="data/voll.csv"
+  instances "ExistingThermal"
+  minimize "ExpansionCost"
+}
+"#,
+    )?;
+
+    let parsed = parse_program_file(&path)?;
+    let semantic_program = validate_program(&parsed.program, &path)?;
+    let lowered_problem = lower_program(&semantic_program, &parsed.program, &path)?;
+
+    assert!(
+        lowered_problem
+            .algebra
+            .constraints
+            .iter()
+            .any(|constraint| constraint.name == "dispatch_limit[Enabled,1]")
+    );
+    assert!(
+        lowered_problem
+            .algebra
+            .constraints
+            .iter()
+            .all(|constraint| constraint.name != "dispatch_limit[Disabled,1]")
+    );
+    assert!(
+        lowered_problem
+            .algebra
+            .constraints
+            .iter()
+            .any(|constraint| constraint.name == "balance[1]")
+    );
+
+    fs::remove_dir_all(&root)?;
+    Ok(())
+}
+
+#[test]
+fn filters_market_clearing_bound_constraints_without_emitting_rows()
+-> Result<(), Box<dyn std::error::Error>> {
+    let root = temp_test_dir("constraint-bound-filter")?;
+    let path = root.join("input.kdl");
+    fs::create_dir_all(root.join("data"))?;
+    fs::write(root.join("data").join("prices.csv"), "t,prices\n1,50\n")?;
+    fs::write(
+        &path,
+        r#"
+technology "Battery" {
+  control "charge"
+  control "discharge"
+  state "soc"
+}
+
+asset "Battery1" {
+  technology "Battery"
+  operation "PriceTakerBattery"
+  power_mw 100
+  energy_mwh 400
+  charge_efficiency 0.92
+  discharge_efficiency 0.92
+  initial_soc_mwh 200
+  terminal_soc_mwh 200
+  apply_charge_limit 0
+}
+
+operation "PriceTakerBattery" {
+  constraint "soc_balance" {
+    soc[a,t] = soc[a,t-1] + charge_efficiency[a] * charge[a,t] - discharge[a,t] / discharge_efficiency[a]
+  }
+  constraint "charge_limit" if="apply_charge_limit[a] == 1" {
+    charge[a,t] <= power_mw[a]
+  }
+  constraint "discharge_limit" {
+    discharge[a,t] <= power_mw[a]
+  }
+  constraint "soc_bounds" {
+    0 <= soc[a,t] <= energy_mwh[a]
+  }
+}
+
+expression "ArbitrageRevenue" {
+  sum(prices[t] * (discharge[a,t] - charge[a,t]) for a in assets for t in time)
+}
+
+maximize "ArbitrageProfit" {
+  ArbitrageRevenue
+}
+
+scenario "BatteryArbitrageDay" {
+  horizon steps=1 resolution="PT1H"
+  technology "Battery"
+  operation "PriceTakerBattery"
+  data "prices" from="data/prices.csv"
+  asset "Battery1"
+  maximize "ArbitrageProfit"
+}
+"#,
+    )?;
+
+    let parsed = parse_program_text(&fs::read_to_string(&path)?, &path)?;
+    let semantic_program = validate_program(&parsed.program, &path)?;
+    let lowered_problem = lower_program(&semantic_program, &parsed.program, &path)?;
+    let charge = lowered_problem
+        .algebra
+        .variable_instances
+        .iter()
+        .find(|instance| instance.name == "charge[Battery1,1]")
+        .ok_or("missing charge variable")?;
+
+    assert_eq!(charge.lower, 0.0);
+    assert_eq!(charge.upper, None);
+
+    fs::remove_dir_all(&root)?;
+    Ok(())
+}
+
+#[test]
+fn lowers_canonical_model_with_declared_control_family() -> Result<(), Box<dyn std::error::Error>> {
+    let root = temp_test_dir("canonical-lowering")?;
+    let path = root.join("input.kdl");
+    fs::write(
+        &path,
+        r#"
+model "EconomicDispatch" {
+  control "dispatch" {
+    a
+    t
+  }
+
+  constraint "dispatch_nonnegative" {
+    dispatch[a,t] >= 0
+  }
+
+  minimize "TotalCost" {
+    sum(dispatch[a,t] for a in assets for t in time)
+  }
+}
+
+scenario "Case" {
+  horizon steps=1 resolution="PT1H"
+  use "EconomicDispatch"
+}
+"#,
+    )?;
+
+    let parsed = parse_program_file(&path)?;
+    let semantic_program = validate_program(&parsed.program, &path)?;
+    let lowered_problem = lower_program(&semantic_program, &parsed.program, &path)?;
+
+    assert!(
+        lowered_problem
+            .algebra
+            .variable_instances
+            .iter()
+            .any(|instance| instance.name == "dispatch[default,1]")
+    );
+    assert!(
+        lowered_problem
+            .algebra
+            .constraints
+            .iter()
+            .any(|constraint| constraint.name == "dispatch_nonnegative[default,1]")
+    );
+
+    fs::remove_dir_all(&root)?;
+    Ok(())
+}
+
+#[test]
+fn canonical_model_binary_control_threads_kind_and_bounds() -> Result<(), Box<dyn std::error::Error>>
+{
+    let root = temp_test_dir("binary-control")?;
+    let path = root.join("input.kdl");
+    fs::write(
+        &path,
+        r#"
+model "BinaryIndicatorModel" {
+    control "indicator" kind="binary" lower=0 upper=1 {
+        a
+        t
+    }
+
+    constraint "indicator_nonneg" {
+        indicator[a,t] >= 0
+    }
+
+    minimize "TotalCost" {
+        sum(indicator[a,t] for a in assets for t in time)
+    }
+}
+
+scenario "Case" {
+    horizon steps=2 resolution="PT1H"
+    use "BinaryIndicatorModel"
+}
+"#,
+    )?;
+
+    let parsed = parse_program_file(&path)?;
+    let semantic_program = validate_program(&parsed.program, &path)?;
+
+    // Verify semantic overrides were populated.
+    assert!(
+        semantic_program
+            .variable_overrides
+            .contains_key("indicator"),
+        "expected variable_overrides to contain 'indicator'"
+    );
+
+    let lowered_problem = lower_program(&semantic_program, &parsed.program, &path)?;
+
+    // Every indicator instance should be Binary with lower=0 and upper=Some(1.0).
+    let indicator_instances: Vec<_> = lowered_problem
+        .algebra
+        .variable_instances
+        .iter()
+        .filter(|instance| instance.family == "indicator[a,t]")
+        .collect();
+    assert!(
+        !indicator_instances.is_empty(),
+        "expected at least one indicator variable instance"
+    );
+    for instance in &indicator_instances {
+        assert_eq!(
+            instance.kind,
+            arco_kdl::lowering::VariableKind::Binary,
+            "instance {} should be Binary",
+            instance.name
+        );
+        assert_eq!(
+            instance.lower, 0.0,
+            "instance {} lower should be 0.0",
+            instance.name
+        );
+        assert_eq!(
+            instance.upper,
+            Some(1.0),
+            "instance {} upper should be Some(1.0)",
+            instance.name
+        );
+    }
+
+    fs::remove_dir_all(&root)?;
+    Ok(())
+}
+
+#[test]
+fn canonical_model_without_overrides_uses_hardcoded_defaults()
+-> Result<(), Box<dyn std::error::Error>> {
+    let root = temp_test_dir("no-overrides")?;
+    let path = root.join("input.kdl");
+    fs::write(
+        &path,
+        r#"
+model "SimpleDispatch" {
+    control "dispatch" {
+        a
+        t
+    }
+
+    constraint "dispatch_nonneg" {
+        dispatch[a,t] >= 0
+    }
+
+    minimize "TotalCost" {
+        sum(dispatch[a,t] for a in assets for t in time)
+    }
+}
+
+scenario "Case" {
+    horizon steps=2 resolution="PT1H"
+    use "SimpleDispatch"
+}
+"#,
+    )?;
+
+    let parsed = parse_program_file(&path)?;
+    let semantic_program = validate_program(&parsed.program, &path)?;
+
+    // No overrides when kind/lower/upper are absent.
+    assert!(
+        semantic_program.variable_overrides.is_empty(),
+        "expected no variable overrides for plain controls"
+    );
+
+    let lowered_problem = lower_program(&semantic_program, &parsed.program, &path)?;
+
+    // Dispatch should use the hardcoded default: lower=0 (no energy_mwh
+    // param on the synthetic asset), upper=None, Continuous.
+    let dispatch_instances: Vec<_> = lowered_problem
+        .algebra
+        .variable_instances
+        .iter()
+        .filter(|instance| instance.family == "dispatch[a,t]")
+        .collect();
+    assert!(
+        !dispatch_instances.is_empty(),
+        "expected at least one dispatch variable instance"
+    );
+    for instance in &dispatch_instances {
+        assert_eq!(
+            instance.kind,
+            arco_kdl::lowering::VariableKind::Continuous,
+            "instance {} should be Continuous",
+            instance.name
+        );
+        assert_eq!(
+            instance.lower, 0.0,
+            "instance {} lower should be 0.0",
+            instance.name
+        );
+        assert_eq!(
+            instance.upper, None,
+            "instance {} upper should be None",
+            instance.name
+        );
+    }
+
+    fs::remove_dir_all(&root)?;
+    Ok(())
+}
+
+#[test]
+fn lowers_reduction_with_if_filter_on_parameter() -> Result<(), Box<dyn std::error::Error>> {
+    let root = temp_test_dir("reduction-filter")?;
+    let path = root.join("input.kdl");
+    fs::create_dir_all(root.join("data"))?;
+    fs::write(
+        root.join("data").join("plants.csv"),
+        "asset_name,marginal_cost,is_active\nPlantA,10,1\nPlantB,20,0\nPlantC,30,1\n",
+    )?;
+    fs::write(root.join("data").join("demand.csv"), "t,demand\n1,50\n")?;
+    fs::write(root.join("data").join("voll.csv"), "t,voll\n1,1000\n")?;
+    fs::write(
+        &path,
+        r#"
+technology "Thermal" {
+  control "dispatch"
+}
+
+operation "SimpleDispatch" {
+  constraint "dispatch_nonneg" {
+    dispatch[a,t] >= 0
+  }
+}
+
+rule "Balance" {
+  constraint "balance" {
+    sum(dispatch[a,t] for a in assets if is_active[a] == 1) + unserved_energy[t] = demand[t]
+  }
+}
+
+expression "FuelCost" {
+  sum(marginal_cost[a] * dispatch[a,t] for a in assets for t in time if is_active[a] == 1)
+}
+
+expression "PenaltyCost" {
+  sum(voll[t] * unserved_energy[t] for t in time)
+}
+
+minimize "TotalCost" {
+  FuelCost + PenaltyCost
+}
+
+instances "Plants" from="data/plants.csv" {
+  technology "Thermal"
+  operation "SimpleDispatch"
+  map "name" from="asset_name"
+  map "marginal_cost" from="marginal_cost"
+  map "is_active" from="is_active"
+}
+
+scenario "Case" {
+  horizon steps=1 resolution="PT1H"
+  technology "Thermal"
+  operation "SimpleDispatch"
+  rule "Balance"
+  data "demand" from="data/demand.csv"
+  data "voll" from="data/voll.csv"
+  instances "Plants"
+  minimize "TotalCost"
+}
+"#,
+    )?;
+
+    let parsed = parse_program_file(&path)?;
+    let semantic_program = validate_program(&parsed.program, &path)?;
+    let lowered = lower_program(&semantic_program, &parsed.program, &path)?;
+
+    // The balance constraint should only have terms for active assets (PlantA and PlantC),
+    // not for PlantB (is_active == 0).
+    let balance = lowered
+        .algebra
+        .constraints
+        .iter()
+        .find(|c| c.name == "balance[1]")
+        .expect("expected balance[1] constraint");
+
+    let term_names: Vec<&str> = balance
+        .terms
+        .iter()
+        .map(|t| t.variable_name.as_str())
+        .collect();
+    assert!(
+        term_names.contains(&"dispatch[PlantA,1]"),
+        "balance should contain dispatch[PlantA,1]"
+    );
+    assert!(
+        term_names.contains(&"dispatch[PlantC,1]"),
+        "balance should contain dispatch[PlantC,1]"
+    );
+    assert!(
+        !term_names.contains(&"dispatch[PlantB,1]"),
+        "balance should NOT contain dispatch[PlantB,1] (filtered out by is_active)"
+    );
+
+    // FuelCost expression in the objective should also only reference active assets.
+    let objective_term_names: Vec<&str> = lowered
+        .algebra
+        .objective
+        .terms
+        .iter()
+        .map(|t| t.variable_name.as_str())
+        .collect();
+    assert!(
+        objective_term_names.contains(&"dispatch[PlantA,1]"),
+        "objective should reference dispatch[PlantA,1]"
+    );
+    assert!(
+        objective_term_names.contains(&"dispatch[PlantC,1]"),
+        "objective should reference dispatch[PlantC,1]"
+    );
+    assert!(
+        !objective_term_names.contains(&"dispatch[PlantB,1]"),
+        "objective should NOT reference dispatch[PlantB,1]"
+    );
+
+    fs::remove_dir_all(&root)?;
+    Ok(())
+}
+
+#[test]
+fn lowers_reduction_with_multiple_if_filters() -> Result<(), Box<dyn std::error::Error>> {
+    let root = temp_test_dir("reduction-multi-filter")?;
+    let path = root.join("input.kdl");
+    fs::create_dir_all(root.join("data"))?;
+    // PlantA: active=1, region=1 -> passes both filters
+    // PlantB: active=0, region=1 -> fails is_active filter
+    // PlantC: active=1, region=2 -> fails region filter
+    // PlantD: active=1, region=1 -> passes both filters
+    fs::write(
+        root.join("data").join("plants.csv"),
+        "asset_name,marginal_cost,is_active,region_id\nPlantA,10,1,1\nPlantB,20,0,1\nPlantC,30,1,2\nPlantD,40,1,1\n",
+    )?;
+    fs::write(root.join("data").join("demand.csv"), "t,demand\n1,100\n")?;
+    fs::write(root.join("data").join("voll.csv"), "t,voll\n1,1000\n")?;
+    fs::write(
+        &path,
+        r#"
+technology "Thermal" {
+  control "dispatch"
+}
+
+operation "SimpleDispatch" {
+  constraint "dispatch_nonneg" {
+    dispatch[a,t] >= 0
+  }
+}
+
+rule "Balance" {
+  constraint "balance" {
+    sum(dispatch[a,t] for a in assets if is_active[a] == 1 if region_id[a] == 1) + unserved_energy[t] = demand[t]
+  }
+}
+
+expression "FuelCost" {
+  sum(marginal_cost[a] * dispatch[a,t] for a in assets for t in time)
+}
+
+expression "PenaltyCost" {
+  sum(voll[t] * unserved_energy[t] for t in time)
+}
+
+minimize "TotalCost" {
+  FuelCost + PenaltyCost
+}
+
+instances "Plants" from="data/plants.csv" {
+  technology "Thermal"
+  operation "SimpleDispatch"
+  map "name" from="asset_name"
+  map "marginal_cost" from="marginal_cost"
+  map "is_active" from="is_active"
+  map "region_id" from="region_id"
+}
+
+scenario "Case" {
+  horizon steps=1 resolution="PT1H"
+  technology "Thermal"
+  operation "SimpleDispatch"
+  rule "Balance"
+  data "demand" from="data/demand.csv"
+  data "voll" from="data/voll.csv"
+  instances "Plants"
+  minimize "TotalCost"
+}
+"#,
+    )?;
+
+    let parsed = parse_program_file(&path)?;
+    let semantic_program = validate_program(&parsed.program, &path)?;
+    let lowered = lower_program(&semantic_program, &parsed.program, &path)?;
+
+    // Only PlantA and PlantD pass both filters (is_active == 1 AND region_id == 1).
+    let balance = lowered
+        .algebra
+        .constraints
+        .iter()
+        .find(|c| c.name == "balance[1]")
+        .expect("expected balance[1] constraint");
+
+    let term_names: Vec<&str> = balance
+        .terms
+        .iter()
+        .map(|t| t.variable_name.as_str())
+        .collect();
+    assert!(
+        term_names.contains(&"dispatch[PlantA,1]"),
+        "balance should contain dispatch[PlantA,1]"
+    );
+    assert!(
+        term_names.contains(&"dispatch[PlantD,1]"),
+        "balance should contain dispatch[PlantD,1]"
+    );
+    assert!(
+        !term_names.contains(&"dispatch[PlantB,1]"),
+        "balance should NOT contain dispatch[PlantB,1] (is_active == 0)"
+    );
+    assert!(
+        !term_names.contains(&"dispatch[PlantC,1]"),
+        "balance should NOT contain dispatch[PlantC,1] (region_id == 2)"
+    );
+
+    fs::remove_dir_all(&root)?;
+    Ok(())
+}
+
+#[test]
+fn lowers_constraint_with_over_when_expr_generation() -> Result<(), Box<dyn std::error::Error>> {
+    let root = temp_test_dir("over-when-expr")?;
+    let path = root.join("input.kdl");
+    fs::create_dir_all(root.join("data"))?;
+    // PlantA and PlantB are loaded from "CandidatePlants" (starts with "Candidate"),
+    // so they are candidate assets. PlantC is from "ExistingPlants", not a candidate.
+    // PlantA: candidate, is_active=1 -> passes both candidate domain and filter
+    // PlantB: candidate, is_active=0 -> in candidate domain but fails filter
+    // PlantC: NOT candidate, is_active=1 -> excluded by `over ... in="candidate_assets"`
+    fs::write(
+        root.join("data").join("candidates.csv"),
+        "asset_name,cap_mw,is_active,max_build\nPlantA,100,1,500\nPlantB,200,0,500\n",
+    )?;
+    fs::write(
+        root.join("data").join("existing.csv"),
+        "asset_name,cap_mw,is_active\nPlantC,150,1\n",
+    )?;
+    fs::write(root.join("data").join("demand.csv"), "t,demand\n1,80\n")?;
+    fs::write(root.join("data").join("voll.csv"), "t,voll\n1,1000\n")?;
+    fs::write(
+        &path,
+        r#"
+technology "Thermal" {
+  control "dispatch"
+}
+
+operation "Dispatch" {
+  constraint "dispatch_nonneg" {
+    dispatch[a,t] >= 0
+  }
+  constraint "cap_limit" {
+    over "a" in="candidate_assets"
+    over "t" in="time"
+    when "is_active[a] == 1"
+    expr {
+      dispatch[a,t] <= cap_mw[a]
+    }
+  }
+}
+
+rule "Balance" {
+  constraint "balance" {
+    sum(dispatch[a,t] for a in assets) + unserved_energy[t] = demand[t]
+  }
+}
+
+expression "FuelCost" {
+  sum(dispatch[a,t] for a in assets for t in time)
+}
+
+expression "PenaltyCost" {
+  sum(voll[t] * unserved_energy[t] for t in time)
+}
+
+minimize "TotalCost" {
+  FuelCost + PenaltyCost
+}
+
+instances "CandidatePlants" from="data/candidates.csv" {
+  technology "Thermal"
+  operation "Dispatch"
+  map "name" from="asset_name"
+  map "cap_mw" from="cap_mw"
+  map "is_active" from="is_active"
+  map "max_build" from="max_build"
+}
+
+instances "ExistingPlants" from="data/existing.csv" {
+  technology "Thermal"
+  operation "Dispatch"
+  map "name" from="asset_name"
+  map "cap_mw" from="cap_mw"
+  map "is_active" from="is_active"
+}
+
+scenario "Case" {
+  horizon steps=1 resolution="PT1H"
+  technology "Thermal"
+  operation "Dispatch"
+  rule "Balance"
+  data "demand" from="data/demand.csv"
+  data "voll" from="data/voll.csv"
+  instances "CandidatePlants"
+  instances "ExistingPlants"
+  minimize "TotalCost"
+}
+"#,
+    )?;
+
+    let parsed = parse_program_file(&path)?;
+    let semantic_program = validate_program(&parsed.program, &path)?;
+    let lowered = lower_program(&semantic_program, &parsed.program, &path)?;
+
+    let constraint_names: Vec<&str> = lowered
+        .algebra
+        .constraints
+        .iter()
+        .map(|c| c.name.as_str())
+        .collect();
+
+    // cap_limit should ONLY be emitted for PlantA: it is in candidate_assets AND is_active == 1.
+    // PlantB is a candidate but is_active == 0 -> filtered out by `when`.
+    // PlantC is NOT a candidate -> excluded by `over ... in="candidate_assets"`.
+    assert!(
+        constraint_names.contains(&"cap_limit[PlantA,1]"),
+        "should emit cap_limit for PlantA (candidate + active): {constraint_names:?}"
+    );
+    assert!(
+        !constraint_names
+            .iter()
+            .any(|n| n.contains("cap_limit") && n.contains("PlantB")),
+        "should NOT emit cap_limit for PlantB (candidate but inactive): {constraint_names:?}"
+    );
+    assert!(
+        !constraint_names
+            .iter()
+            .any(|n| n.contains("cap_limit") && n.contains("PlantC")),
+        "should NOT emit cap_limit for PlantC (not a candidate): {constraint_names:?}"
+    );
+
+    let cap_limit_a = lowered
+        .algebra
+        .constraints
+        .iter()
+        .find(|c| c.name == "cap_limit[PlantA,1]")
+        .expect("expected cap_limit constraint for PlantA at step 1");
+    let term_names: Vec<&str> = cap_limit_a
+        .terms
+        .iter()
+        .map(|t| t.variable_name.as_str())
+        .collect();
+    assert!(
+        term_names.contains(&"dispatch[PlantA,1]"),
+        "cap_limit for PlantA should reference dispatch[PlantA,1]: {term_names:?}"
+    );
+
+    // The balance constraint should still work normally (not affected by generation bindings).
+    assert!(
+        constraint_names.contains(&"balance[1]"),
+        "balance constraint should exist: {constraint_names:?}"
+    );
+
+    fs::remove_dir_all(&root)?;
+    Ok(())
+}
+
+#[test]
+fn custom_set_in_scenario_populates_registry_and_resolves_in_reduction()
+-> Result<(), Box<dyn std::error::Error>> {
+    let root = temp_test_dir("custom-set-reduction")?;
+    let path = root.join("input.kdl");
+    fs::create_dir_all(root.join("data"))?;
+    fs::write(
+        root.join("data").join("gen_cost.csv"),
+        "asset_name,t,gen_cost\nUnit1,1,10\nUnit1,2,10\n",
+    )?;
+
+    fs::write(
+        &path,
+        r#"
+technology "Thermal" {
+  control "dispatch"
+}
+
+operation "GenDispatch" {
+  constraint "nonneg" {
+    dispatch[a,t] >= 0
+  }
+}
+
+rule "Balance" {
+  constraint "balance" {
+    sum(dispatch[a,t] for a in generators) = 100
+  }
+}
+
+expression "GenCost" {
+  sum(gen_cost[a,t] * dispatch[a,t] for a in generators for t in time)
+}
+
+minimize "TotalCost" {
+  GenCost
+}
+
+asset "Unit1" {
+  technology "Thermal"
+  operation "GenDispatch"
+}
+
+scenario "S1" {
+  horizon steps=2 resolution="PT1H"
+  technology "Thermal"
+  operation "GenDispatch"
+  rule "Balance"
+  asset "Unit1"
+  data "gen_cost" from="data/gen_cost.csv"
+  minimize "TotalCost"
+  generators {
+    "Unit1"
+  }
+}
+"#,
+    )?;
+
+    let parsed = parse_program_file(&path)?;
+    let semantic_program = validate_program(&parsed.program, &path)?;
+
+    // The custom set should be in the registry.
+    assert!(
+        semantic_program.set_registry.contains_key("generators"),
+        "registry should contain 'generators': {:?}",
+        semantic_program.set_registry.keys().collect::<Vec<_>>()
+    );
+    assert_eq!(
+        semantic_program.set_registry["generators"].values,
+        vec!["Unit1".to_string()]
+    );
+
+    // Lowering should succeed because the "generators" set is resolvable
+    // in reduction_domain_values via the set_registry.
+    let lowered = lower_program(&semantic_program, &parsed.program, &path)?;
+
+    // The reduction `for a in generators` should iterate over the custom
+    // set's members. Since generators = { "Unit1" }, the balance constraint
+    // sums dispatch over that one asset.
+    let constraint_names: Vec<&str> = lowered
+        .algebra
+        .constraints
+        .iter()
+        .map(|c| c.name.as_str())
+        .collect();
+    assert!(
+        constraint_names.contains(&"balance[1]"),
+        "expected balance[1] in constraints: {constraint_names:?}"
+    );
+    assert!(
+        constraint_names.contains(&"balance[2]"),
+        "expected balance[2] in constraints: {constraint_names:?}"
+    );
+
+    fs::remove_dir_all(&root)?;
+    Ok(())
+}
+
+#[test]
+fn lowers_sqrt_of_parameter_into_evaluated_coefficient() -> Result<(), Box<dyn std::error::Error>> {
+    let root = temp_test_dir("sqrt-param")?;
+    let path = root.join("input.kdl");
+    fs::create_dir_all(root.join("data"))?;
+    fs::write(root.join("data").join("demand.csv"), "t,demand\n1,100\n")?;
+    fs::write(root.join("data").join("voll.csv"), "t,voll\n1,1000\n")?;
+    // eta = 0.81 so sqrt(eta) = 0.9
+    fs::write(
+        &path,
+        r#"
+technology "Battery" {
+  control "charge"
+}
+
+operation "BatteryOp" {
+  constraint "scaled_charge" {
+    sqrt(eta[a]) * charge[a,t] <= power_mw[a]
+  }
+}
+
+expression "PenaltyCost" {
+  sum(voll[t] * unserved_energy[t] for t in time)
+}
+
+minimize "Cost" {
+  PenaltyCost
+}
+
+asset "B1" {
+  technology "Battery"
+  operation "BatteryOp"
+  eta 0.81
+  power_mw 100
+}
+
+scenario "S" {
+  horizon steps=1 resolution="PT1H"
+  technology "Battery"
+  operation "BatteryOp"
+  data "demand" from="data/demand.csv"
+  data "voll" from="data/voll.csv"
+  asset "B1"
+  minimize "Cost"
+}
+"#,
+    )?;
+
+    let parsed = parse_program_file(&path)?;
+    let semantic_program = validate_program(&parsed.program, &path)?;
+    let lowered = lower_program(&semantic_program, &parsed.program, &path)?;
+
+    // sqrt(0.81) = 0.9, so the coefficient on charge[B1,1] should be 0.9.
+    let constraint = lowered
+        .algebra
+        .constraints
+        .iter()
+        .find(|c| c.name == "scaled_charge[B1,1]")
+        .expect("expected scaled_charge constraint");
+
+    let charge_term = constraint
+        .terms
+        .iter()
+        .find(|t| t.variable_name == "charge[B1,1]")
+        .expect("expected charge[B1,1] term");
+
+    assert!(
+        (charge_term.coefficient - 0.9).abs() < 1e-9,
+        "sqrt(0.81) should yield coefficient 0.9, got {}",
+        charge_term.coefficient
+    );
+
+    fs::remove_dir_all(&root)?;
+    Ok(())
+}
+
+#[test]
+fn rejects_builtin_function_applied_to_decision_variable() -> Result<(), Box<dyn std::error::Error>>
+{
+    let root = temp_test_dir("sqrt-var-reject")?;
+    let path = root.join("input.kdl");
+    fs::create_dir_all(root.join("data"))?;
+    fs::write(root.join("data").join("demand.csv"), "t,demand\n1,100\n")?;
+    fs::write(root.join("data").join("voll.csv"), "t,voll\n1,1000\n")?;
+    fs::write(
+        &path,
+        r#"
+technology "Battery" {
+  control "charge"
+  control "discharge"
+}
+
+operation "BatteryOp" {
+  constraint "charge_nonneg" {
+    charge[a,t] >= 0
+  }
+  constraint "bad_nonlinear" {
+    sqrt(charge[a,t]) <= 10
+  }
+}
+
+expression "PenaltyCost" {
+  sum(voll[t] * unserved_energy[t] for t in time)
+}
+
+minimize "Cost" {
+  PenaltyCost
+}
+
+asset "B1" {
+  technology "Battery"
+  operation "BatteryOp"
+  power_mw 100
+}
+
+scenario "S" {
+  horizon steps=1 resolution="PT1H"
+  technology "Battery"
+  operation "BatteryOp"
+  data "demand" from="data/demand.csv"
+  data "voll" from="data/voll.csv"
+  asset "B1"
+  minimize "Cost"
+}
+"#,
+    )?;
+
+    let parsed = parse_program_file(&path)?;
+    let semantic_program = validate_program(&parsed.program, &path)?;
+    let result = lower_program(&semantic_program, &parsed.program, &path);
+
+    assert!(
+        result.is_err(),
+        "lowering should reject sqrt() applied to a decision variable"
+    );
+    let err_msg = format!("{}", result.unwrap_err());
+    assert!(
+        err_msg.contains("must remain scalar"),
+        "error should mention that the argument must remain scalar, got: {err_msg}"
+    );
+
+    fs::remove_dir_all(&root)?;
+    Ok(())
+}
+
+#[test]
+fn auto_generates_technology_sets_for_reduction_scoping() -> Result<(), Box<dyn std::error::Error>>
+{
+    let root = temp_test_dir("tech-set-reduction")?;
+    let path = root.join("input.kdl");
+    fs::create_dir_all(root.join("data"))?;
+
+    // Two batteries and one generator. The objective sums dispatch only over
+    // the "Battery" technology set, so the lowered balance constraint should
+    // only reference bat1 and bat2, not gen1.
+    fs::write(
+        root.join("data").join("demand.csv"),
+        "t,demand\n1,100\n2,100\n",
+    )?;
+    fs::write(
+        root.join("data").join("voll.csv"),
+        "t,voll\n1,1000\n2,1000\n",
+    )?;
+
+    fs::write(
+        &path,
+        r#"
+technology "Battery" {
+  control "dispatch"
+}
+
+technology "Generator" {
+  control "dispatch"
+}
+
+operation "SimpleOp" {
+  constraint "nonneg" {
+    dispatch[a,t] >= 0
+  }
+}
+
+rule "BatteryBalance" {
+  constraint "bat_balance" {
+    sum(dispatch[a,t] for a in Battery) = 50
+  }
+}
+
+expression "BatteryCost" {
+  sum(dispatch[a,t] for a in Battery for t in time)
+}
+
+expression "PenaltyCost" {
+  sum(voll[t] * unserved_energy[t] for t in time)
+}
+
+minimize "TotalCost" {
+  BatteryCost + PenaltyCost
+}
+
+asset "bat1" {
+  technology "Battery"
+  operation "SimpleOp"
+}
+
+asset "bat2" {
+  technology "Battery"
+  operation "SimpleOp"
+}
+
+asset "gen1" {
+  technology "Generator"
+  operation "SimpleOp"
+}
+
+scenario "TechSetCase" {
+  horizon steps=2 resolution="PT1H"
+  technology "Battery"
+  technology "Generator"
+  operation "SimpleOp"
+  rule "BatteryBalance"
+  data "demand" from="data/demand.csv"
+  data "voll" from="data/voll.csv"
+  asset "bat1"
+  asset "bat2"
+  asset "gen1"
+  minimize "TotalCost"
+}
+"#,
+    )?;
+
+    let parsed = parse_program_file(&path)?;
+    let semantic_program = validate_program(&parsed.program, &path)?;
+
+    // The set registry should contain auto-generated technology sets.
+    assert!(
+        semantic_program.set_registry.contains_key("Battery"),
+        "registry should contain 'Battery': {:?}",
+        semantic_program.set_registry.keys().collect::<Vec<_>>()
+    );
+    assert_eq!(
+        semantic_program.set_registry["Battery"].values,
+        vec!["bat1".to_string(), "bat2".to_string()]
+    );
+
+    assert!(
+        semantic_program.set_registry.contains_key("Generator"),
+        "registry should contain 'Generator': {:?}",
+        semantic_program.set_registry.keys().collect::<Vec<_>>()
+    );
+    assert_eq!(
+        semantic_program.set_registry["Generator"].values,
+        vec!["gen1".to_string()]
+    );
+
+    // Lowering should succeed because "Battery" is resolvable via the set registry.
+    let lowered = lower_program(&semantic_program, &parsed.program, &path)?;
+
+    // The bat_balance constraint uses `for a in Battery`, so only bat1 and bat2
+    // should appear in its terms, not gen1.
+    let bat_balance_1 = lowered
+        .algebra
+        .constraints
+        .iter()
+        .find(|c| c.name == "bat_balance[1]")
+        .expect("expected bat_balance[1] constraint");
+
+    let term_names: Vec<&str> = bat_balance_1
+        .terms
+        .iter()
+        .map(|t| t.variable_name.as_str())
+        .collect();
+    assert!(
+        term_names.contains(&"dispatch[bat1,1]"),
+        "bat_balance should contain dispatch[bat1,1]: {term_names:?}"
+    );
+    assert!(
+        term_names.contains(&"dispatch[bat2,1]"),
+        "bat_balance should contain dispatch[bat2,1]: {term_names:?}"
+    );
+    assert!(
+        !term_names.contains(&"dispatch[gen1,1]"),
+        "bat_balance should NOT contain dispatch[gen1,1]: {term_names:?}"
+    );
+
+    fs::remove_dir_all(&root)?;
+    Ok(())
+}
+
+#[test]
+fn invest_variables_produce_asset_only_instances() -> Result<(), Box<dyn std::error::Error>> {
+    let root = temp_test_dir("invest-asset-only")?;
+    let path = root.join("input.kdl");
+    fs::create_dir_all(root.join("data"))?;
+    fs::write(
+        root.join("data").join("prices.csv"),
+        "t,prices\n1,50\n2,60\n",
+    )?;
+    fs::write(
+        &path,
+        r#"
+technology "Storage" {
+    invest "power_charge" lower=0 upper=500
+    invest "energy_capacity" kind="integer" lower=0 upper=1000
+    control "charge"
+    control "discharge"
+    state "soc"
+}
+
+asset "Bat1" {
+    technology "Storage"
+    operation "StorageOp"
+    power_mw 100
+    energy_mwh 400
+    charge_efficiency 0.92
+    discharge_efficiency 0.92
+    initial_soc_mwh 200
+    terminal_soc_mwh 200
+}
+
+asset "Bat2" {
+    technology "Storage"
+    operation "StorageOp"
+    power_mw 50
+    energy_mwh 200
+    charge_efficiency 0.90
+    discharge_efficiency 0.90
+    initial_soc_mwh 100
+    terminal_soc_mwh 100
+}
+
+operation "StorageOp" {
+    constraint "soc_balance" {
+        soc[a,t] = soc[a,t-1] + charge_efficiency[a] * charge[a,t] - discharge[a,t] / discharge_efficiency[a]
+    }
+    constraint "charge_limit" {
+        charge[a,t] <= power_mw[a]
+    }
+    constraint "discharge_limit" {
+        discharge[a,t] <= power_mw[a]
+    }
+    constraint "soc_bounds" {
+        0 <= soc[a,t] <= energy_mwh[a]
+    }
+    constraint "invest_charge_cap" {
+        power_charge[a] <= 500
+    }
+}
+
+expression "Revenue" {
+    sum(prices[t] * (discharge[a,t] - charge[a,t]) for a in assets for t in time)
+}
+
+maximize "Profit" {
+    Revenue
+}
+
+scenario "InvestCase" {
+    horizon steps=2 resolution="PT1H"
+    technology "Storage"
+    operation "StorageOp"
+    data "prices" from="data/prices.csv"
+    asset "Bat1"
+    asset "Bat2"
+    maximize "Profit"
+}
+"#,
+    )?;
+
+    let parsed = parse_program_file(&path)?;
+    let semantic_program = validate_program(&parsed.program, &path)?;
+    let lowered = lower_program(&semantic_program, &parsed.program, &path)?;
+
+    // Invest variables should be [a]-indexed (no time dimension).
+    // For 2 assets, we expect 2 instances per invest variable = 4 total invest instances.
+    let invest_charge_instances: Vec<_> = lowered
+        .algebra
+        .variable_instances
+        .iter()
+        .filter(|i| i.family == "power_charge[a]")
+        .collect();
+    assert_eq!(
+        invest_charge_instances.len(),
+        2,
+        "expected 2 power_charge instances (one per asset), got: {:?}",
+        invest_charge_instances
+            .iter()
+            .map(|i| &i.name)
+            .collect::<Vec<_>>()
+    );
+
+    let invest_energy_instances: Vec<_> = lowered
+        .algebra
+        .variable_instances
+        .iter()
+        .filter(|i| i.family == "energy_capacity[a]")
+        .collect();
+    assert_eq!(
+        invest_energy_instances.len(),
+        2,
+        "expected 2 energy_capacity instances (one per asset), got: {:?}",
+        invest_energy_instances
+            .iter()
+            .map(|i| &i.name)
+            .collect::<Vec<_>>()
+    );
+
+    // Verify instance names have asset-only indexing (no time component).
+    assert!(
+        lowered
+            .algebra
+            .variable_instances
+            .iter()
+            .any(|i| i.name == "power_charge[Bat1]"),
+        "expected power_charge[Bat1] in variable instances"
+    );
+    assert!(
+        lowered
+            .algebra
+            .variable_instances
+            .iter()
+            .any(|i| i.name == "power_charge[Bat2]"),
+        "expected power_charge[Bat2] in variable instances"
+    );
+    assert!(
+        lowered
+            .algebra
+            .variable_instances
+            .iter()
+            .any(|i| i.name == "energy_capacity[Bat1]"),
+        "expected energy_capacity[Bat1] in variable instances"
+    );
+    assert!(
+        lowered
+            .algebra
+            .variable_instances
+            .iter()
+            .any(|i| i.name == "energy_capacity[Bat2]"),
+        "expected energy_capacity[Bat2] in variable instances"
+    );
+
+    // Verify invest variable bounds and kind are threaded through.
+    let pc_bat1 = lowered
+        .algebra
+        .variable_instances
+        .iter()
+        .find(|i| i.name == "power_charge[Bat1]")
+        .expect("missing power_charge[Bat1]");
+    assert_eq!(pc_bat1.lower, 0.0, "power_charge lower should be 0");
+    assert_eq!(
+        pc_bat1.upper,
+        Some(500.0),
+        "power_charge upper should be 500"
+    );
+    assert_eq!(
+        pc_bat1.kind,
+        arco_kdl::lowering::VariableKind::Continuous,
+        "power_charge should be Continuous"
+    );
+
+    let ec_bat1 = lowered
+        .algebra
+        .variable_instances
+        .iter()
+        .find(|i| i.name == "energy_capacity[Bat1]")
+        .expect("missing energy_capacity[Bat1]");
+    assert_eq!(
+        ec_bat1.kind,
+        arco_kdl::lowering::VariableKind::Integer,
+        "energy_capacity should be Integer"
+    );
+    assert_eq!(ec_bat1.lower, 0.0, "energy_capacity lower should be 0");
+    assert_eq!(
+        ec_bat1.upper,
+        Some(1000.0),
+        "energy_capacity upper should be 1000"
+    );
+
+    // Invest variables should appear in constraint linearization (invest_charge_cap uses power_charge[a]).
+    let invest_constraint = lowered
+        .algebra
+        .constraints
+        .iter()
+        .find(|c| c.name == "invest_charge_cap[Bat1]")
+        .expect("expected invest_charge_cap[Bat1] constraint");
+    let term_names: Vec<&str> = invest_constraint
+        .terms
+        .iter()
+        .map(|t| t.variable_name.as_str())
+        .collect();
+    assert!(
+        term_names.contains(&"power_charge[Bat1]"),
+        "invest_charge_cap should reference power_charge[Bat1]: {term_names:?}"
+    );
+
+    fs::remove_dir_all(&root)?;
+    Ok(())
+}
+
+#[test]
+fn model_with_explicit_assets_and_custom_index_sets() -> Result<(), Box<dyn std::error::Error>> {
+    let root = temp_test_dir("model-explicit-assets")?;
+    let path = root.join("input.kdl");
+
+    fs::write(
+        &path,
+        r#"
+model "MultiAsset" {
+    control "dispatch" { a; t }
+    control "build_cap" { a }
+
+    constraint "dispatch_cap" {
+        dispatch[a,t] <= build_cap[a]
+    }
+
+    constraint "dispatch_nonneg" {
+        dispatch[a,t] >= 0
+    }
+
+    minimize "Cost" {
+        sum(dispatch[a,t] for a in assets for t in time)
+    }
+}
+
+scenario "S" {
+    horizon steps=2 resolution="PT1H"
+    use "MultiAsset"
+    asset "Gen1" { }
+    asset "Gen2" { }
+    generators { "Gen1"; "Gen2" }
+}
+"#,
+    )?;
+
+    let parsed = parse_program_file(&path)?;
+    let semantic = validate_program(&parsed.program, &path)?;
+
+    // Custom set should be registered
+    assert!(
+        semantic.set_registry.contains_key("generators"),
+        "registry should contain 'generators': {:?}",
+        semantic.set_registry.keys().collect::<Vec<_>>()
+    );
+    assert_eq!(
+        semantic.set_registry["generators"].values,
+        vec!["Gen1".to_string(), "Gen2".to_string()]
+    );
+
+    let lowered = lower_program(&semantic, &parsed.program, &path)?;
+
+    // dispatch should be instantiated per-asset per-time
+    // a domain = assets = {Gen1, Gen2}, t domain = time = {1,2}
+    // So 4 dispatch instances
+    let dispatch_instances: Vec<_> = lowered
+        .algebra
+        .variable_instances
+        .iter()
+        .filter(|i| i.family.starts_with("dispatch"))
+        .collect();
+    assert_eq!(
+        dispatch_instances.len(),
+        4,
+        "expected 4 dispatch instances (2 assets x 2 time steps), got: {:?}",
+        dispatch_instances
+            .iter()
+            .map(|i| &i.name)
+            .collect::<Vec<_>>()
+    );
+
+    // build_cap should be per-asset only (no time)
+    let build_instances: Vec<_> = lowered
+        .algebra
+        .variable_instances
+        .iter()
+        .filter(|i| i.family.starts_with("build_cap"))
+        .collect();
+    assert_eq!(
+        build_instances.len(),
+        2,
+        "expected 2 build_cap instances (2 assets), got: {:?}",
+        build_instances.iter().map(|i| &i.name).collect::<Vec<_>>()
+    );
+
+    // Constraint should reference both dispatch and build_cap for Gen1
+    let cap_constraint = lowered
+        .algebra
+        .constraints
+        .iter()
+        .find(|c| c.name.contains("dispatch_cap") && c.name.contains("Gen1"))
+        .expect("expected dispatch_cap constraint for Gen1");
+    let term_names: Vec<&str> = cap_constraint
+        .terms
+        .iter()
+        .map(|t| t.variable_name.as_str())
+        .collect();
+    assert!(
+        term_names
+            .iter()
+            .any(|n| n.contains("dispatch") && n.contains("Gen1")),
+        "dispatch_cap should reference dispatch[Gen1,...]: {term_names:?}"
+    );
+    assert!(
+        term_names
+            .iter()
+            .any(|n| n.contains("build_cap") && n.contains("Gen1")),
+        "dispatch_cap should reference build_cap[Gen1]: {term_names:?}"
+    );
+
+    fs::remove_dir_all(&root)?;
+    Ok(())
+}
+
+#[test]
+fn set_from_csv_populates_registry_and_resolves_params_in_constraint()
+-> Result<(), Box<dyn std::error::Error>> {
+    let root = temp_test_dir("set-from-csv")?;
+    let path = root.join("input.kdl");
+    fs::create_dir_all(root.join("data"))?;
+    fs::write(
+        root.join("data/periods.csv"),
+        "name,budget_start,budget_end,energy_budget\nDay1,1,2,100\nDay2,3,4,200\n",
+    )?;
+    fs::write(
+        root.join("data/demand.csv"),
+        "t,demand\n1,50\n2,50\n3,50\n4,50\n",
+    )?;
+    fs::write(
+        root.join("data/voll.csv"),
+        "t,voll\n1,1000\n2,1000\n3,1000\n4,1000\n",
+    )?;
+    fs::write(
+        &path,
+        r#"
+technology "Hydro" {
+    control "dispatch"
+}
+
+operation "HydroOp" {
+    constraint "hydro_budget" {
+        over "b" in="periods"
+        expr {
+            sum(dispatch[a,t] for a in assets for t in time
+                if t >= budget_start[b] if t <= budget_end[b])
+            = energy_budget[b]
+        }
+    }
+}
+
+rule "Balance" {
+    constraint "balance" {
+        sum(dispatch[a,t] for a in assets) + unserved_energy[t] = demand[t]
+    }
+}
+
+expression "Penalty" {
+    sum(voll[t] * unserved_energy[t] for t in time)
+}
+
+minimize "Cost" { Penalty }
+
+asset "Hydro1" {
+    technology "Hydro"
+    operation "HydroOp"
+}
+
+scenario "S" {
+    horizon steps=4 resolution="PT1H"
+    technology "Hydro"
+    operation "HydroOp"
+    rule "Balance"
+    set "periods" from="data/periods.csv"
+    data "demand" from="data/demand.csv"
+    data "voll" from="data/voll.csv"
+    asset "Hydro1"
+    minimize "Cost"
+}
+"#,
+    )?;
+
+    let parsed = parse_program_file(&path)?;
+    let semantic = validate_program(&parsed.program, &path)?;
+
+    // Set should be in registry
+    assert!(
+        semantic.set_registry.contains_key("periods"),
+        "registry should contain 'periods': {:?}",
+        semantic.set_registry.keys().collect::<Vec<_>>()
+    );
+    assert_eq!(
+        semantic.set_registry["periods"].values,
+        vec!["Day1".to_string(), "Day2".to_string()]
+    );
+
+    // Set params should be populated
+    assert!(semantic.set_params.contains_key("Day1"));
+    assert_eq!(semantic.set_params["Day1"]["budget_start"], 1.0);
+    assert_eq!(semantic.set_params["Day1"]["budget_end"], 2.0);
+    assert_eq!(semantic.set_params["Day1"]["energy_budget"], 100.0);
+    assert_eq!(semantic.set_params["Day2"]["budget_start"], 3.0);
+
+    let lowered = lower_program(&semantic, &parsed.program, &path)?;
+
+    // Two budget constraints: one per period
+    let constraint_names: Vec<&str> = lowered
+        .algebra
+        .constraints
+        .iter()
+        .map(|c| c.name.as_str())
+        .collect();
+    assert!(
+        constraint_names.contains(&"hydro_budget[Day1]"),
+        "expected hydro_budget[Day1]: {constraint_names:?}"
+    );
+    assert!(
+        constraint_names.contains(&"hydro_budget[Day2]"),
+        "expected hydro_budget[Day2]: {constraint_names:?}"
+    );
+
+    // Day1 budget covers t=1,2. Only those dispatch terms should appear.
+    let day1 = lowered
+        .algebra
+        .constraints
+        .iter()
+        .find(|c| c.name == "hydro_budget[Day1]")
+        .unwrap();
+    let day1_terms: Vec<&str> = day1
+        .terms
+        .iter()
+        .map(|t| t.variable_name.as_str())
+        .collect();
+    assert!(day1_terms.contains(&"dispatch[Hydro1,1]"));
+    assert!(day1_terms.contains(&"dispatch[Hydro1,2]"));
+    assert!(!day1_terms.contains(&"dispatch[Hydro1,3]"));
+    assert!(!day1_terms.contains(&"dispatch[Hydro1,4]"));
+
+    // Day1 RHS should be 100.0
+    assert!(
+        (day1.rhs - 100.0).abs() < 1e-9,
+        "Day1 rhs should be 100.0, got {}",
+        day1.rhs
+    );
+
+    // Day2 budget covers t=3,4
+    let day2 = lowered
+        .algebra
+        .constraints
+        .iter()
+        .find(|c| c.name == "hydro_budget[Day2]")
+        .unwrap();
+    assert!((day2.rhs - 200.0).abs() < 1e-9);
+
+    fs::remove_dir_all(&root)?;
+    Ok(())
+}
+
+fn temp_test_dir(prefix: &str) -> Result<PathBuf, Box<dyn std::error::Error>> {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)?
+        .as_nanos()
+        .to_string();
+    let root = std::env::temp_dir().join(format!("arco-dsl-{prefix}-{unique}"));
+    fs::create_dir_all(&root)?;
+    Ok(root)
+}

--- a/crates/arco-kdl/tests/normalization_suite.rs
+++ b/crates/arco-kdl/tests/normalization_suite.rs
@@ -1,0 +1,144 @@
+use arco_kdl::normalize::normalize_program;
+use arco_kdl::source::parse_program_text;
+use std::path::PathBuf;
+
+#[test]
+fn normalization_equates_direct_wiring_and_canonical_models()
+-> Result<(), Box<dyn std::error::Error>> {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/normalize-equivalence.kdl");
+
+    let direct_wiring = r#"
+technology "Generator" {
+  control "dispatch"
+}
+
+operation "EconomicDispatch" {
+  constraint "capacity_limit[a,t]" {
+    dispatch[a,t] <= capacity[a,t]
+  }
+}
+
+minimize "TotalCost" {
+  sum(dispatch[a,t] for a in assets for t in time)
+}
+
+scenario "Day" {
+  horizon steps=24 resolution="PT1H"
+  technology "Generator"
+  operation "EconomicDispatch"
+  minimize "TotalCost"
+}
+"#;
+
+    let canonical = r#"
+model "DayModel" {
+  control "dispatch" {
+    a
+    t
+  }
+
+  constraint "capacity_limit[a,t]" {
+    dispatch[a,t] <= capacity[a,t]
+  }
+
+  minimize "TotalCost" {
+    sum(dispatch[a,t] for a in assets for t in time)
+  }
+}
+
+scenario "Day" {
+  horizon steps=24 resolution="PT1H"
+  use "DayModel"
+}
+"#;
+
+    let direct_program = parse_program_text(direct_wiring, &path)?.program;
+    let canonical_program = parse_program_text(canonical, &path)?.program;
+
+    let direct_normalized = normalize_program(&direct_program, &path)?;
+    let canonical_normalized = normalize_program(&canonical_program, &path)?;
+
+    assert_eq!(direct_normalized, canonical_normalized);
+    Ok(())
+}
+
+#[test]
+fn normalization_equates_name_property_and_positional_forms()
+-> Result<(), Box<dyn std::error::Error>> {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/normalize-name-forms-equivalence.kdl");
+
+    let positional = r#"
+model "Dispatch" {
+  control "dispatch" {
+    a
+    t
+  }
+  minimize "Cost" {
+    dispatch[a,t]
+  }
+}
+"#;
+
+    let property = r#"
+model name="Dispatch" {
+  control name="dispatch" {
+    a
+    t
+  }
+  minimize name="Cost" {
+    dispatch[a,t]
+  }
+}
+"#;
+
+    let positional_program = parse_program_text(positional, &path)?.program;
+    let property_program = parse_program_text(property, &path)?.program;
+
+    let positional_normalized = normalize_program(&positional_program, &path)?;
+    let property_normalized = normalize_program(&property_program, &path)?;
+
+    assert_eq!(positional_normalized, property_normalized);
+    Ok(())
+}
+
+#[test]
+fn normalization_equates_math_blocks_and_explicit_expression_properties()
+-> Result<(), Box<dyn std::error::Error>> {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/normalize-math-blocks.kdl");
+
+    let block = r#"
+model "Dispatch" {
+  control "dispatch" {
+    a
+    t
+  }
+  constraint "cap[a,t]" {
+    dispatch[a,t] <= capacity[a,t]
+  }
+  maximize "Serve" {
+    sum(dispatch[a,t] for a in assets for t in time)
+  }
+}
+"#;
+
+    let explicit = r#"
+model "Dispatch" {
+  control "dispatch" {
+    a
+    t
+  }
+  constraint "cap[a,t]" expression="dispatch[a,t] <= capacity[a,t]"
+  maximize "Serve" expression="sum(dispatch[a,t] for a in assets for t in time)"
+}
+"#;
+
+    let block_program = parse_program_text(block, &path)?.program;
+    let explicit_program = parse_program_text(explicit, &path)?.program;
+
+    let block_normalized = normalize_program(&block_program, &path)?;
+    let explicit_normalized = normalize_program(&explicit_program, &path)?;
+
+    assert_eq!(block_normalized, explicit_normalized);
+    Ok(())
+}

--- a/crates/arco-kdl/tests/semantic_expression_validation.rs
+++ b/crates/arco-kdl/tests/semantic_expression_validation.rs
@@ -1,0 +1,58 @@
+use arco_kdl::semantic::validate_program;
+use arco_kdl::source::parse_program_text;
+use miette::Diagnostic;
+use std::fs;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[test]
+fn semantic_validation_rejects_missing_named_expression_dependency()
+-> Result<(), Box<dyn std::error::Error>> {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)?
+        .as_nanos()
+        .to_string();
+    let root = std::env::temp_dir().join(format!("arco-dsl-semantic-expr-{unique}"));
+    fs::create_dir_all(&root)?;
+
+    let path = root.join("missing_expression_dependency.kdl");
+    let text = r#"
+technology "Battery" {
+  control "charge"
+}
+
+expression "BatteryValue" {
+  0
+}
+
+maximize "BatteryObjective" {
+  BatteryValue + MissingValue
+}
+
+asset "Battery1" {
+  technology "Battery"
+  power_mw 10
+}
+
+scenario "Case" {
+  horizon steps=1 resolution="PT1H"
+  technology "Battery"
+  asset "Battery1"
+  maximize "BatteryObjective"
+}
+"#;
+
+    let parsed = parse_program_text(text, &path)?;
+    let error = validate_program(&parsed.program, &path).expect_err("validation should fail");
+    assert!(
+        error
+            .to_string()
+            .contains("missing declaration `expression` named `MissingValue`")
+    );
+    assert_eq!(
+        error.code().map(|code| code.to_string()),
+        Some("arco::semantic::missing_declaration".to_string())
+    );
+
+    fs::remove_dir_all(&root)?;
+    Ok(())
+}

--- a/crates/arco-kdl/tests/semantic_validation.rs
+++ b/crates/arco-kdl/tests/semantic_validation.rs
@@ -1,0 +1,153 @@
+use arco_kdl::semantic::{FamilySignature, ResolvedSet, validate_program};
+use arco_kdl::source::parse_program_text;
+use std::fs;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[test]
+fn semantic_validation_accepts_canonical_model_use() -> Result<(), Box<dyn std::error::Error>> {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)?
+        .as_nanos()
+        .to_string();
+    let root = std::env::temp_dir().join(format!("arco-dsl-semantic-canonical-{unique}"));
+    fs::create_dir_all(&root)?;
+
+    let path = root.join("canonical.kdl");
+    let text = r#"
+model "EconomicDispatch" {
+  control "dispatch" {
+    a
+    t
+  }
+
+  constraint "balance[a,t]" {
+    dispatch[a,t] = 0
+  }
+
+  minimize "TotalCost" {
+    sum(dispatch[a,t] for a in assets for t in time)
+  }
+}
+
+scenario "Case" {
+  horizon steps=2 resolution="PT1H"
+  use "EconomicDispatch"
+}
+"#;
+
+    let parsed = parse_program_text(text, &path)?;
+    let semantic = validate_program(&parsed.program, &path)?;
+    assert_eq!(semantic.active_scenario, "Case");
+    assert_eq!(semantic.active_objective.name, "TotalCost");
+    assert_eq!(
+        semantic.variable_families,
+        vec![FamilySignature::new("dispatch", ["a", "t"])]
+    );
+
+    fs::remove_dir_all(&root)?;
+    Ok(())
+}
+
+#[test]
+fn semantic_validation_rejects_canonical_scenario_without_use()
+-> Result<(), Box<dyn std::error::Error>> {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)?
+        .as_nanos()
+        .to_string();
+    let root = std::env::temp_dir().join(format!("arco-dsl-semantic-canonical-missing-{unique}"));
+    fs::create_dir_all(&root)?;
+
+    let path = root.join("canonical_missing_use.kdl");
+    let text = r#"
+model "EconomicDispatch" {
+  control "dispatch" {
+    a
+    t
+  }
+  minimize "TotalCost" {
+    dispatch[a,t]
+  }
+}
+
+scenario "Case" {
+  horizon steps=1 resolution="PT1H"
+}
+"#;
+
+    let parsed = parse_program_text(text, &path)?;
+    let error = validate_program(&parsed.program, &path).expect_err("validation should fail");
+    assert!(
+        error
+            .to_string()
+            .contains("missing declaration `model` named `active model`")
+    );
+
+    fs::remove_dir_all(&root)?;
+    Ok(())
+}
+
+#[test]
+fn set_registry_contains_built_in_sets_after_semantic_analysis()
+-> Result<(), Box<dyn std::error::Error>> {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)?
+        .as_nanos()
+        .to_string();
+    let root = std::env::temp_dir().join(format!("arco-dsl-semantic-set-registry-{unique}"));
+    fs::create_dir_all(&root)?;
+
+    let path = root.join("registry.kdl");
+    let text = r#"
+model "Simple" {
+  control "x" {
+    a
+    t
+  }
+
+  constraint "eq[a,t]" {
+    x[a,t] = 0
+  }
+
+  minimize "Obj" {
+    sum(x[a,t] for a in assets for t in time)
+  }
+}
+
+scenario "S1" {
+  horizon steps=3 resolution="PT1H"
+  use "Simple"
+}
+"#;
+
+    let parsed = parse_program_text(text, &path)?;
+    let semantic = validate_program(&parsed.program, &path)?;
+
+    // The registry should contain entries for assets, candidate_assets, and time.
+    assert!(
+        semantic.set_registry.contains_key("assets"),
+        "registry should contain 'assets'"
+    );
+    assert!(
+        semantic.set_registry.contains_key("candidate_assets"),
+        "registry should contain 'candidate_assets'"
+    );
+    assert!(
+        semantic.set_registry.contains_key("time"),
+        "registry should contain 'time'"
+    );
+
+    // time set should have 3 string entries matching the horizon.
+    assert_eq!(
+        semantic.set_registry["time"],
+        ResolvedSet {
+            values: vec!["1".to_string(), "2".to_string(), "3".to_string()]
+        }
+    );
+
+    // assets set should match the ResolvedSets.assets (which mirrors set_registry).
+    assert_eq!(semantic.set_registry["assets"].values, semantic.sets.assets);
+
+    fs::remove_dir_all(&root)?;
+    Ok(())
+}

--- a/crates/arco-kdl/tests/source_parser.rs
+++ b/crates/arco-kdl/tests/source_parser.rs
@@ -1,0 +1,1077 @@
+use arco_kdl::source::{
+    BoundExpr, ColumnMappingDecl, GenerationBinding, IndexDecl, LiteralValue, NamedVariableDecl,
+    VariableKindDecl, parse_program_file, parse_program_text,
+};
+use std::path::PathBuf;
+
+/// Shorthand to build an `IndexDecl` without a domain binding.
+fn idx(name: &str) -> IndexDecl {
+    IndexDecl {
+        name: name.to_string(),
+        domain: None,
+    }
+}
+
+#[test]
+fn parses_price_taker_battery_fixture_into_typed_declarations()
+-> Result<(), Box<dyn std::error::Error>> {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("e2e")
+        .join("price-taker-battery")
+        .join("input.kdl");
+
+    let parsed = parse_program_file(&path)?;
+    let program = parsed.program;
+
+    assert_eq!(program.technologies.len(), 1);
+    assert_eq!(program.operations.len(), 1);
+    assert_eq!(program.assets.len(), 1);
+    assert_eq!(program.scenarios.len(), 1);
+
+    let technology = program.technology("Battery").ok_or("missing technology")?;
+    let control_names: Vec<&str> = technology
+        .controls
+        .iter()
+        .map(|c| c.name.as_str())
+        .collect();
+    assert_eq!(control_names, vec!["charge", "discharge"]);
+    assert_eq!(technology.states, vec!["soc".to_string()]);
+
+    let scenario = program
+        .scenario("BatteryArbitrageDay")
+        .ok_or("missing scenario")?;
+    assert_eq!(scenario.technologies, vec!["Battery".to_string()]);
+    assert_eq!(scenario.operations, vec!["PriceTakerBattery".to_string()]);
+    assert_eq!(scenario.reports, vec!["ArbitrageRevenue".to_string()]);
+
+    Ok(())
+}
+
+#[test]
+fn parses_constraint_math_blocks_with_named_and_unnamed_constraints()
+-> Result<(), Box<dyn std::error::Error>> {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("inline-constraint-blocks.kdl");
+    let text = r#"
+operation "BatteryOperation" {
+  constraint name="soc_balance" {
+    soc[a,t] = soc[a,t-1] + charge_efficiency[a] * charge[a,t] - discharge[a,t] / discharge_efficiency[a]
+  }
+
+  constraint {
+    charge[a,t] <= power_mw[a]
+  }
+}
+"#;
+
+    let parsed = parse_program_text(text, &path)?;
+    let program = parsed.program;
+    let operation = program
+        .operation("BatteryOperation")
+        .ok_or("missing operation")?;
+
+    assert_eq!(operation.constraints.len(), 2);
+    assert_eq!(operation.constraints[0].name, "soc_balance");
+    assert_eq!(
+        operation.constraints[0].expression,
+        "soc[a,t] = soc[a,t-1] + charge_efficiency[a] * charge[a,t] - discharge[a,t] / discharge_efficiency[a]"
+    );
+    assert_eq!(operation.constraints[1].name, "constraint_2");
+    assert_eq!(
+        operation.constraints[1].expression,
+        "charge[a,t] <= power_mw[a]"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn parses_constraint_filters_into_typed_declarations() -> Result<(), Box<dyn std::error::Error>> {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("constraint-filters.kdl");
+    let text = r#"
+operation "ExpansionDispatch" {
+  constraint "dispatch_limit" if="apply_dispatch_limit[a] == 1" {
+    dispatch[a,t] <= existing_capacity[a]
+  }
+}
+"#;
+
+    let parsed = parse_program_text(text, &path)?;
+    let program = parsed.program;
+    let operation = program
+        .operation("ExpansionDispatch")
+        .ok_or("missing operation")?;
+
+    assert_eq!(operation.constraints.len(), 1);
+    assert_eq!(
+        operation.constraints[0].generation_filter.as_deref(),
+        Some("apply_dispatch_limit[a] == 1")
+    );
+    assert_eq!(
+        operation.constraints[0]
+            .parsed_generation_filter
+            .as_ref()
+            .ok_or("missing parsed filter")?
+            .to_string(),
+        "apply_dispatch_limit[a] == 1"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn parses_expression_math_blocks_without_formula_wrapper() -> Result<(), Box<dyn std::error::Error>>
+{
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("inline-expression-blocks.kdl");
+    let text = r#"
+expression "ArbitrageRevenue" {
+  sum(prices[t] * (discharge[a,t] - charge[a,t]) for a in assets for t in time)
+}
+"#;
+
+    let parsed = parse_program_text(text, &path)?;
+    let program = parsed.program;
+    let expression = program
+        .expression("ArbitrageRevenue")
+        .ok_or("missing expression")?;
+
+    assert_eq!(
+        expression.formula,
+        "sum(prices[t] * (discharge[a,t] - charge[a,t]) for a in assets for t in time)"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn parses_verbose_name_properties_for_common_declarations() -> Result<(), Box<dyn std::error::Error>>
+{
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("verbose-name-properties.kdl");
+    let text = r#"
+technology name="Battery" {
+  control name="charge"
+  state name="soc"
+}
+
+operation name="BatteryDispatch" {
+  constraint name="charge_limit" {
+    charge[a,t] <= power_mw[a]
+  }
+}
+
+asset name="Battery1" {
+  technology name="Battery"
+  operation name="BatteryDispatch"
+  power_mw 100
+}
+
+expression name="Revenue" {
+  charge[a,t]
+}
+
+maximize name="Profit" {
+  Revenue
+}
+
+scenario name="Case" {
+  horizon steps=1 resolution="PT1H"
+  asset name="Battery1"
+  maximize name="Profit"
+}
+"#;
+
+    let parsed = parse_program_text(text, &path)?;
+    let program = parsed.program;
+
+    let technology = program.technology("Battery").ok_or("missing technology")?;
+    assert_eq!(technology.controls.len(), 1);
+    assert_eq!(technology.controls[0].name, "charge");
+    assert_eq!(technology.states, vec!["soc".to_string()]);
+
+    let operation = program
+        .operation("BatteryDispatch")
+        .ok_or("missing operation")?;
+    assert_eq!(operation.constraints.len(), 1);
+    assert_eq!(operation.constraints[0].name, "charge_limit");
+    assert_eq!(
+        operation.constraints[0].expression,
+        "charge[a,t] <= power_mw[a]"
+    );
+
+    let asset = program.asset("Battery1").ok_or("missing asset")?;
+    assert_eq!(asset.technology, "Battery");
+    assert_eq!(asset.operation.as_deref(), Some("BatteryDispatch"));
+    assert_eq!(
+        asset.parameters.get("power_mw"),
+        Some(&LiteralValue::Integer(100))
+    );
+
+    let expression = program.expression("Revenue").ok_or("missing expression")?;
+    assert_eq!(expression.formula, "charge[a,t]");
+
+    let objective = program.objective("Profit").ok_or("missing objective")?;
+    assert_eq!(objective.sense, "maximize");
+    assert_eq!(objective.expression, "Revenue");
+
+    let scenario = program.scenario("Case").ok_or("missing scenario")?;
+    assert_eq!(scenario.horizon.steps, 1);
+    assert_eq!(scenario.assets, vec!["Battery1".to_string()]);
+    assert_eq!(scenario.objective.as_deref(), Some("Profit"));
+
+    Ok(())
+}
+
+#[test]
+fn parses_generalized_network_fixture_into_ast_declarations()
+-> Result<(), Box<dyn std::error::Error>> {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("e2e")
+        .join("generalized-two-node-network")
+        .join("input.kdl");
+
+    let parsed = parse_program_file(&path)?;
+    let program = parsed.program;
+
+    let operation = program
+        .operation("Transmission")
+        .ok_or("missing transmission operation")?;
+    let rule = program.rule("NodeBalance").ok_or("missing balance rule")?;
+    let objective = program.objective("TotalCost").ok_or("missing objective")?;
+
+    assert_eq!(
+        operation.constraints[0].parsed_expression.to_string(),
+        "-thermal_limit_mw[l] <= flow[l,t] <= thermal_limit_mw[l]"
+    );
+    assert_eq!(
+        rule.constraints[0].parsed_expression.to_string(),
+        "sum(dispatch[g,t] for g in generators if generator_node[g] == n) + sum(flow[l,t] for l in incoming_lines if line_to[l] == n) - sum(flow[l,t] for l in outgoing_lines if line_from[l] == n) = demand[n,t]"
+    );
+    assert_eq!(
+        objective.parsed_expression.to_string(),
+        "GenerationCost + LossPenalty"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn parses_canonical_model_with_balanced_syntax() -> Result<(), Box<dyn std::error::Error>> {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("canonical-model.kdl");
+    let text = r#"
+model "EconomicDispatch" {
+  set "generators"
+  set "time" from="horizon"
+
+  param "capacity_mw" {
+    g
+  }
+  param "availability" {
+    g
+    t
+  }
+  param "marginal_cost" {
+    g
+  }
+  param "demand" {
+    t
+  }
+
+  control "dispatch" lower=0 {
+    a
+    t
+  }
+
+  constraint "capacity_limit[g in generators, t in time]" {
+    dispatch[g,t] <= capacity_mw[g] * availability[g,t]
+  }
+
+  constraint "balance[t in time]" {
+    sum(dispatch[g,t] for g in generators) = demand[t]
+  }
+
+  minimize "TotalCost" {
+    sum(marginal_cost[g] * dispatch[g,t] for g in generators for t in time)
+  }
+}
+"#;
+
+    let parsed = parse_program_text(text, &path)?;
+    let program = parsed.program;
+    let model = program.model("EconomicDispatch").ok_or("missing model")?;
+
+    assert_eq!(model.sets[0].name, "generators");
+    assert_eq!(model.sets[0].source, None);
+    assert_eq!(model.sets[1].name, "time");
+    assert_eq!(model.sets[1].source.as_deref(), Some("horizon"));
+
+    let param_names: Vec<&str> = model.parameters.iter().map(|p| p.name.as_str()).collect();
+    assert_eq!(
+        param_names,
+        &["capacity_mw", "availability", "marginal_cost", "demand"]
+    );
+
+    assert_eq!(model.controls[0].name, "dispatch");
+    assert_eq!(
+        model.controls[0].lower,
+        Some(BoundExpr::Literal(LiteralValue::Integer(0)))
+    );
+    assert_eq!(model.controls[0].indices, vec![idx("a"), idx("t")]);
+    let constraint_names: Vec<&str> = model.constraints.iter().map(|c| c.name.as_str()).collect();
+    assert_eq!(
+        constraint_names,
+        &[
+            "capacity_limit[g in generators, t in time]",
+            "balance[t in time]",
+        ]
+    );
+
+    assert_eq!(model.optimize.name, "TotalCost");
+    assert_eq!(model.optimize.sense, "minimize");
+    assert!(
+        model
+            .optimize
+            .expression
+            .contains("marginal_cost[g] * dispatch[g,t]")
+    );
+
+    Ok(())
+}
+
+#[test]
+fn parses_scenario_use_of_model() -> Result<(), Box<dyn std::error::Error>> {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("canonical-scenario-use.kdl");
+    let text = r#"
+model "EconomicDispatch" {
+  set "generators"
+  set "time" from="horizon"
+
+  param "demand" {
+    t
+  }
+  control "dispatch" lower=0 {
+    a
+    t
+  }
+
+  constraint "balance[t in time]" {
+    sum(dispatch[g,t] for g in generators) = demand[t]
+  }
+
+  maximize "ServeDemand" {
+    sum(dispatch[g,t] for g in generators for t in time)
+  }
+}
+
+scenario "Day" {
+  horizon steps=24 resolution="PT1H"
+  use "EconomicDispatch"
+}
+"#;
+
+    let parsed = parse_program_text(text, &path)?;
+    let scenario = parsed.program.scenario("Day").ok_or("missing scenario")?;
+
+    assert_eq!(scenario.model_use.as_deref(), Some("EconomicDispatch"));
+
+    Ok(())
+}
+
+#[test]
+fn parses_data_binding_with_positional_name_and_from_property()
+-> Result<(), Box<dyn std::error::Error>> {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("data-binding-positional.kdl");
+    let text = r#"
+scenario "Base" {
+  horizon steps=24 resolution="PT1H"
+  data "demand" from="data/demand.csv"
+}
+"#;
+
+    let parsed = parse_program_text(text, &path)?;
+    let scenario = parsed.program.scenario("Base").ok_or("missing scenario")?;
+
+    assert_eq!(scenario.data.len(), 1);
+    assert_eq!(scenario.data[0].name, "demand");
+    assert_eq!(scenario.data[0].source, "data/demand.csv");
+
+    Ok(())
+}
+
+#[test]
+fn parses_report_positional_syntax_in_scenario() -> Result<(), Box<dyn std::error::Error>> {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("report-positional-syntax.kdl");
+    let text = r#"
+model "EconomicDispatch" {
+  set "generators"
+  set "time" from="horizon"
+
+  param "demand" {
+    t
+  }
+  control "dispatch" lower=0 {
+    a
+    t
+  }
+
+  constraint "balance[t in time]" {
+    sum(dispatch[g,t] for g in generators) = demand[t]
+  }
+
+  maximize "ServeDemand" {
+    sum(dispatch[g,t] for g in generators for t in time)
+  }
+}
+
+scenario "Day" {
+  horizon steps=24 resolution="PT1H"
+  use "EconomicDispatch"
+  report "FuelCost"
+  report "StartupCost"
+}
+"#;
+
+    let parsed = parse_program_text(text, &path)?;
+    let scenario = parsed.program.scenario("Day").ok_or("missing scenario")?;
+
+    assert_eq!(
+        scenario.reports,
+        vec!["FuelCost".to_string(), "StartupCost".to_string()]
+    );
+
+    Ok(())
+}
+
+#[test]
+fn parses_instances_map_syntax_for_column_mappings() -> Result<(), Box<dyn std::error::Error>> {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("instances-map-syntax.kdl");
+    let text = r#"
+technology "GasCT" {
+  control "dispatch"
+}
+
+operation "SimpleDispatch" {
+  constraint "dispatch_limit" {
+    dispatch[a,t] <= capacity[a]
+  }
+}
+
+instances "Fleet" from="data/fleet.csv" {
+  technology "GasCT"
+  operation "SimpleDispatch"
+  map "name" from="asset_name"
+  map "capacity" from="capacity_mw"
+}
+"#;
+
+    let parsed = parse_program_text(text, &path)?;
+    let instances = parsed
+        .program
+        .instances
+        .first()
+        .ok_or("missing instances")?;
+
+    assert_eq!(instances.name, "Fleet");
+    assert_eq!(instances.source, "data/fleet.csv");
+    assert_eq!(
+        instances.columns,
+        vec![
+            ColumnMappingDecl {
+                source: "asset_name".to_string(),
+                target: "name".to_string(),
+            },
+            ColumnMappingDecl {
+                source: "capacity_mw".to_string(),
+                target: "capacity".to_string(),
+            },
+        ]
+    );
+
+    Ok(())
+}
+
+#[test]
+fn parses_minimize_directive_in_scenario_as_objective() -> Result<(), Box<dyn std::error::Error>> {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("scenario-minimize.kdl");
+    let text = r#"
+model "EconomicDispatch" {
+  set "generators"
+  set "time" from="horizon"
+
+  param "demand" {
+    t
+  }
+  control "dispatch" lower=0 {
+    a
+    t
+  }
+
+  constraint "balance[t in time]" {
+    sum(dispatch[g,t] for g in generators) = demand[t]
+  }
+
+  minimize "C" {
+    sum(dispatch[g,t] for g in generators for t in time)
+  }
+}
+
+scenario "Day" {
+  horizon steps=24 resolution="PT1H"
+  use "EconomicDispatch"
+  minimize "C"
+}
+"#;
+
+    let parsed = parse_program_text(text, &path)?;
+    let scenario = parsed.program.scenario("Day").ok_or("missing scenario")?;
+
+    assert_eq!(scenario.objective.as_deref(), Some("C"));
+
+    Ok(())
+}
+
+#[test]
+fn parses_top_level_minimize_into_objective() -> Result<(), Box<dyn std::error::Error>> {
+    let path = PathBuf::from("test.kdl");
+    let text = r#"
+minimize "SystemCost" { FuelCost }
+"#;
+
+    let parsed = parse_program_text(text, &path)?;
+    let program = parsed.program;
+
+    assert_eq!(program.objectives.len(), 1);
+
+    let obj = &program.objectives[0];
+    assert_eq!(obj.name, "SystemCost");
+    assert_eq!(obj.sense, "minimize");
+    assert_eq!(obj.expression, "FuelCost");
+
+    Ok(())
+}
+
+#[test]
+fn parses_top_level_maximize_into_objective() -> Result<(), Box<dyn std::error::Error>> {
+    let path = PathBuf::from("test.kdl");
+    let text = r#"
+maximize "TotalProfit" { Revenue - Cost }
+"#;
+
+    let parsed = parse_program_text(text, &path)?;
+    let program = parsed.program;
+
+    assert_eq!(program.objectives.len(), 1);
+
+    let obj = &program.objectives[0];
+    assert_eq!(obj.name, "TotalProfit");
+    assert_eq!(obj.sense, "maximize");
+    assert_eq!(obj.expression, "Revenue - Cost");
+
+    Ok(())
+}
+
+#[test]
+fn parses_scenario_with_direct_technology_operation_rule_wiring()
+-> Result<(), Box<dyn std::error::Error>> {
+    let path = PathBuf::from("test.kdl");
+    let text = r#"
+scenario "Wired" {
+  horizon steps=24 resolution="PT1H"
+  technology "Generator"
+  operation "Dispatch"
+  rule "Balance"
+}
+"#;
+
+    let parsed = parse_program_text(text, &path)?;
+    let scenario = parsed.program.scenario("Wired").ok_or("missing scenario")?;
+
+    assert_eq!(scenario.technologies, vec!["Generator".to_string()]);
+    assert_eq!(scenario.operations, vec!["Dispatch".to_string()]);
+    assert_eq!(scenario.rules, vec!["Balance".to_string()]);
+
+    Ok(())
+}
+
+#[test]
+fn parses_top_level_set_declarations() -> Result<(), Box<dyn std::error::Error>> {
+    let path = PathBuf::from("test.kdl");
+    let text = r#"
+set "generators"
+set "time" from="horizon"
+set "nodes"
+"#;
+
+    let parsed = parse_program_text(text, &path)?;
+    let program = parsed.program;
+
+    assert_eq!(program.sets.len(), 3);
+
+    assert_eq!(program.sets[0].name, "generators");
+    assert_eq!(program.sets[0].source, None);
+
+    assert_eq!(program.sets[1].name, "time");
+    assert_eq!(program.sets[1].source.as_deref(), Some("horizon"));
+
+    assert_eq!(program.sets[2].name, "nodes");
+    assert_eq!(program.sets[2].source, None);
+
+    Ok(())
+}
+
+#[test]
+fn parses_constraint_with_over_when_expr_generation_bindings()
+-> Result<(), Box<dyn std::error::Error>> {
+    let path = PathBuf::from("test.kdl");
+    let text = r#"
+rule "NodeBalance" {
+  constraint "balance" {
+    over "n" in="nodes"
+    over "t" in="time"
+    when "active_node[n]"
+    expr {
+      sum(dispatch[g,t] for g in generators if generator_node[g] == n) = demand[n,t]
+    }
+  }
+}
+"#;
+
+    let parsed = parse_program_text(text, &path)?;
+    let program = parsed.program;
+    let rule = program.rule("NodeBalance").ok_or("missing rule")?;
+
+    assert_eq!(rule.constraints.len(), 1);
+    let constraint = &rule.constraints[0];
+
+    assert_eq!(constraint.name, "balance");
+    assert_eq!(
+        constraint.generation_bindings,
+        vec![
+            GenerationBinding {
+                variable: "n".to_string(),
+                domain: "nodes".to_string(),
+            },
+            GenerationBinding {
+                variable: "t".to_string(),
+                domain: "time".to_string(),
+            },
+        ]
+    );
+    assert_eq!(
+        constraint.generation_filter.as_deref(),
+        Some("active_node[n]")
+    );
+    assert!(constraint.expression.contains(
+        "sum(dispatch[g,t] for g in generators if generator_node[g] == n) = demand[n,t]"
+    ));
+
+    Ok(())
+}
+
+#[test]
+fn parses_control_with_kind_and_upper_bound() -> Result<(), Box<dyn std::error::Error>> {
+    let path = std::path::PathBuf::from("test.kdl");
+    let text = r#"
+model "BinaryModel" {
+  set "assets"
+  set "time" from="horizon"
+
+  control "indicator" kind="binary" lower=0 upper=1 {
+    a
+    t
+  }
+
+  constraint "limit[a in assets, t in time]" {
+    indicator[a,t] <= 1
+  }
+
+  minimize "Cost" {
+    sum(indicator[a,t] for a in assets for t in time)
+  }
+}
+"#;
+
+    let parsed = parse_program_text(text, &path)?;
+    let model = parsed.program.model("BinaryModel").ok_or("missing model")?;
+
+    assert_eq!(model.controls.len(), 1);
+    let control = &model.controls[0];
+    assert_eq!(control.name, "indicator");
+    assert_eq!(control.kind, Some(VariableKindDecl::Binary));
+    assert_eq!(
+        control.lower,
+        Some(BoundExpr::Literal(LiteralValue::Integer(0)))
+    );
+    assert_eq!(
+        control.upper,
+        Some(BoundExpr::Literal(LiteralValue::Integer(1)))
+    );
+    assert_eq!(control.indices, vec![idx("a"), idx("t")]);
+
+    Ok(())
+}
+
+#[test]
+fn parses_control_with_formula_bounds_via_child_nodes() -> Result<(), Box<dyn std::error::Error>> {
+    let path = std::path::PathBuf::from("test.kdl");
+    let text = r#"
+model "FormulaModel" {
+  set "assets"
+  set "time" from="horizon"
+
+  param "max_cap" {
+    a
+  }
+
+  control "output" lower=0 {
+    a
+    t
+    upper { max_cap[a] }
+  }
+
+  constraint "limit[a in assets, t in time]" {
+    output[a,t] <= max_cap[a]
+  }
+
+  minimize "Cost" {
+    sum(output[a,t] for a in assets for t in time)
+  }
+}
+"#;
+
+    let parsed = parse_program_text(text, &path)?;
+    let model = parsed
+        .program
+        .model("FormulaModel")
+        .ok_or("missing model")?;
+
+    let control = &model.controls[0];
+    assert_eq!(control.name, "output");
+    // Literal lower from property
+    assert_eq!(
+        control.lower,
+        Some(BoundExpr::Literal(LiteralValue::Integer(0)))
+    );
+    // Formula upper from child node
+    assert!(matches!(control.upper, Some(BoundExpr::Formula(_))));
+    if let Some(BoundExpr::Formula(ref expr)) = control.upper {
+        assert_eq!(expr.to_string(), "max_cap[a]");
+    }
+    // Indices should NOT include "upper" (that's a bound child, not an index)
+    assert_eq!(control.indices, vec![idx("a"), idx("t")]);
+
+    Ok(())
+}
+
+#[test]
+fn parses_technology_with_control_metadata() -> Result<(), Box<dyn std::error::Error>> {
+    let path = std::path::PathBuf::from("test.kdl");
+    let text = r#"
+technology "Generator" {
+  control "dispatch" kind="continuous" lower=0
+  control "commit" kind="binary" lower=0 upper=1
+  state "on_hours"
+}
+"#;
+
+    let parsed = parse_program_text(text, &path)?;
+    let technology = parsed
+        .program
+        .technology("Generator")
+        .ok_or("missing technology")?;
+
+    assert_eq!(technology.controls.len(), 2);
+
+    let dispatch = &technology.controls[0];
+    assert_eq!(dispatch.name, "dispatch");
+    assert_eq!(dispatch.kind, Some(VariableKindDecl::Continuous));
+    assert_eq!(
+        dispatch.lower,
+        Some(BoundExpr::Literal(LiteralValue::Integer(0)))
+    );
+    assert_eq!(dispatch.upper, None);
+
+    let commit = &technology.controls[1];
+    assert_eq!(commit.name, "commit");
+    assert_eq!(commit.kind, Some(VariableKindDecl::Binary));
+    assert_eq!(
+        commit.lower,
+        Some(BoundExpr::Literal(LiteralValue::Integer(0)))
+    );
+    assert_eq!(
+        commit.upper,
+        Some(BoundExpr::Literal(LiteralValue::Integer(1)))
+    );
+
+    assert_eq!(technology.states, vec!["on_hours".to_string()]);
+
+    Ok(())
+}
+
+#[test]
+fn parses_control_with_integer_kind() -> Result<(), Box<dyn std::error::Error>> {
+    let path = std::path::PathBuf::from("test.kdl");
+    let text = r#"
+model "IntModel" {
+  set "assets"
+  set "time" from="horizon"
+
+  control "units" kind="integer" lower=0 upper=10 {
+    a
+    t
+  }
+
+  constraint "limit[a in assets, t in time]" {
+    units[a,t] <= 10
+  }
+
+  minimize "Cost" {
+    sum(units[a,t] for a in assets for t in time)
+  }
+}
+"#;
+
+    let parsed = parse_program_text(text, &path)?;
+    let model = parsed.program.model("IntModel").ok_or("missing model")?;
+
+    let control = &model.controls[0];
+    assert_eq!(control.kind, Some(VariableKindDecl::Integer));
+    assert_eq!(
+        control.lower,
+        Some(BoundExpr::Literal(LiteralValue::Integer(0)))
+    );
+    assert_eq!(
+        control.upper,
+        Some(BoundExpr::Literal(LiteralValue::Integer(10)))
+    );
+
+    Ok(())
+}
+
+#[test]
+fn parses_control_without_kind_defaults_to_none() -> Result<(), Box<dyn std::error::Error>> {
+    let path = std::path::PathBuf::from("test.kdl");
+    let text = r#"
+model "SimpleModel" {
+  set "assets"
+  set "time" from="horizon"
+
+  control "dispatch" lower=0 {
+    a
+    t
+  }
+
+  constraint "limit[a in assets, t in time]" {
+    dispatch[a,t] <= 100
+  }
+
+  minimize "Cost" {
+    sum(dispatch[a,t] for a in assets for t in time)
+  }
+}
+"#;
+
+    let parsed = parse_program_text(text, &path)?;
+    let model = parsed.program.model("SimpleModel").ok_or("missing model")?;
+
+    let control = &model.controls[0];
+    assert_eq!(control.kind, None);
+    assert_eq!(control.upper, None);
+
+    Ok(())
+}
+
+#[test]
+fn parses_control_index_with_domain_binding() -> Result<(), Box<dyn std::error::Error>> {
+    let path = std::path::PathBuf::from("test.kdl");
+    let text = r#"
+model "GenModel" {
+  set "generators"
+  set "time" from="horizon"
+
+  control "gen_output" {
+    g in="generators"
+    t
+  }
+
+  constraint "limit[g in generators, t in time]" {
+    gen_output[g,t] <= 100
+  }
+
+  minimize "Cost" {
+    sum(gen_output[g,t] for g in generators for t in time)
+  }
+}
+"#;
+
+    let parsed = parse_program_text(text, &path)?;
+    let model = parsed.program.model("GenModel").ok_or("missing model")?;
+
+    let control = &model.controls[0];
+    assert_eq!(control.name, "gen_output");
+    assert_eq!(
+        control.indices,
+        vec![
+            IndexDecl {
+                name: "g".to_string(),
+                domain: Some("generators".to_string()),
+            },
+            idx("t"),
+        ]
+    );
+
+    Ok(())
+}
+
+#[test]
+fn parses_scenario_with_custom_set_declarations() -> Result<(), Box<dyn std::error::Error>> {
+    let path = std::path::PathBuf::from("test.kdl");
+    let text = r#"
+model "Simple" {
+  control "x" {
+    a
+    t
+  }
+  constraint "eq[a,t]" {
+    x[a,t] = 0
+  }
+  minimize "Obj" {
+    sum(x[a,t] for a in assets for t in time)
+  }
+}
+
+scenario "S1" {
+  horizon steps=2 resolution="PT1H"
+  use "Simple"
+  generators {
+    "gen1"
+    "gen2"
+    "gen3"
+  }
+}
+"#;
+
+    let parsed = parse_program_text(text, &path)?;
+    let scenario = parsed.program.first_scenario().ok_or("missing scenario")?;
+
+    assert_eq!(
+        scenario.custom_sets.get("generators"),
+        Some(&vec![
+            "gen1".to_string(),
+            "gen2".to_string(),
+            "gen3".to_string()
+        ])
+    );
+
+    Ok(())
+}
+
+#[test]
+fn parses_technology_with_invest_declarations() -> Result<(), Box<dyn std::error::Error>> {
+    let path = std::path::PathBuf::from("test.kdl");
+    let text = r#"
+technology "CoupledStorage" {
+    invest "power_charge"
+    invest "power_discharge"
+    invest "energy_capacity" kind="integer"
+    control "charge"
+    control "discharge"
+    state "soc"
+}
+"#;
+
+    let parsed = parse_program_text(text, &path)?;
+    let technology = parsed
+        .program
+        .technology("CoupledStorage")
+        .ok_or("missing technology")?;
+
+    assert_eq!(technology.investments.len(), 3);
+
+    assert_eq!(
+        technology.investments[0],
+        NamedVariableDecl {
+            name: "power_charge".to_string(),
+            kind: None,
+            lower: None,
+            upper: None,
+        }
+    );
+    assert_eq!(
+        technology.investments[1],
+        NamedVariableDecl {
+            name: "power_discharge".to_string(),
+            kind: None,
+            lower: None,
+            upper: None,
+        }
+    );
+    assert_eq!(
+        technology.investments[2],
+        NamedVariableDecl {
+            name: "energy_capacity".to_string(),
+            kind: Some(VariableKindDecl::Integer),
+            lower: None,
+            upper: None,
+        }
+    );
+
+    assert_eq!(technology.controls.len(), 2);
+    assert_eq!(technology.controls[0].name, "charge");
+    assert_eq!(technology.controls[1].name, "discharge");
+    assert_eq!(technology.states, vec!["soc".to_string()]);
+
+    Ok(())
+}
+
+#[test]
+fn parses_invest_with_bounds() -> Result<(), Box<dyn std::error::Error>> {
+    let path = std::path::PathBuf::from("test.kdl");
+    let text = r#"
+technology "Storage" {
+    invest "energy_capacity" kind="continuous" lower=0 upper=1000
+    control "charge"
+}
+"#;
+
+    let parsed = parse_program_text(text, &path)?;
+    let technology = parsed
+        .program
+        .technology("Storage")
+        .ok_or("missing technology")?;
+
+    assert_eq!(technology.investments.len(), 1);
+    let invest = &technology.investments[0];
+    assert_eq!(invest.name, "energy_capacity");
+    assert_eq!(invest.kind, Some(VariableKindDecl::Continuous));
+    assert_eq!(
+        invest.lower,
+        Some(BoundExpr::Literal(LiteralValue::Integer(0)))
+    );
+    assert_eq!(
+        invest.upper,
+        Some(BoundExpr::Literal(LiteralValue::Integer(1000)))
+    );
+
+    Ok(())
+}

--- a/crates/arco-xpress/build.rs
+++ b/crates/arco-xpress/build.rs
@@ -10,15 +10,26 @@ fn main() {
         None
     });
 
-    if let Some(dir) = xpress_dir {
-        let lib_dir = format!("{dir}/lib");
-        println!("cargo:rustc-link-search=native={lib_dir}");
-        println!("cargo:rustc-link-lib=dylib=xprs");
-        println!("cargo:rustc-cfg=has_xpress");
-    } else {
-        println!(
-            "cargo:warning=XPRESSDIR not set and Xpress not found in default locations. \
-             FFI functions will not link. Set XPRESSDIR to your Xpress installation directory."
-        );
+    match xpress_dir {
+        Some(dir) => {
+            let lib_dir = format!("{dir}/lib");
+            println!("cargo:rustc-link-search=native={lib_dir}");
+            println!("cargo:rustc-link-lib=dylib=xprs");
+        }
+        None => {
+            panic!(
+                "XPRESSDIR not set and Xpress SDK not found in default locations.\n\
+                 Set XPRESSDIR to your FICO Xpress installation directory.\n\
+                 \n\
+                 On macOS (DMG install):\n\
+                     export XPRESSDIR=\"/Applications/FICO Xpress/xpressmp\"\n\
+                 \n\
+                 On Linux:\n\
+                     export XPRESSDIR=\"/opt/xpressmp\"\n\
+                 \n\
+                 To use HiGHS instead (no extra dependencies):\n\
+                     cargo build without the xpress feature"
+            );
+        }
     }
 }

--- a/crates/arco-xpress/src/ffi.rs
+++ b/crates/arco-xpress/src/ffi.rs
@@ -62,7 +62,7 @@ unsafe extern "C" {
         dub: *const c_double,
     ) -> c_int;
 
-    pub fn XPRSloadglobal(
+    pub fn XPRSloadmip(
         prob: XPRSprob,
         probname: *const c_char,
         ncols: c_int,
@@ -134,6 +134,10 @@ unsafe extern "C" {
     // Attributes
     pub fn XPRSgetintattrib(prob: XPRSprob, ipar: c_int, p_value: *mut c_int) -> c_int;
     pub fn XPRSgetdblattrib(prob: XPRSprob, ipar: c_int, p_value: *mut c_double) -> c_int;
+
+    // Licensing (required before XPRSinit on newer SDK versions)
+    pub fn XPRSlicense(lic: *mut c_int, path: *const c_char) -> c_int;
+    pub fn XPRSgetlicerrmsg(msg: *mut c_char, len: c_int) -> c_int;
 
     // Version
     /// Caller must provide a buffer of at least 16 bytes.

--- a/crates/arco-xpress/src/solver.rs
+++ b/crates/arco-xpress/src/solver.rs
@@ -49,14 +49,105 @@ impl Drop for ProbGuard {
     }
 }
 
-/// Initialize the Xpress environment, returning an RAII guard that frees it on
-/// drop.
+const ERRMSG_BUF_LEN: c_int = 512;
+
+/// Retrieve the current Xpress license error message.
+#[allow(unsafe_code)]
+fn xprs_lic_errmsg() -> String {
+    let mut buf = [0 as std::ffi::c_char; ERRMSG_BUF_LEN as usize];
+    // SAFETY: buf is a valid, zeroed buffer of the declared length.
+    unsafe { ffi::XPRSgetlicerrmsg(buf.as_mut_ptr(), ERRMSG_BUF_LEN) };
+    unsafe { std::ffi::CStr::from_ptr(buf.as_ptr()) }
+        .to_string_lossy()
+        .into_owned()
+}
+
+/// Initialize the Xpress environment, returning an RAII guard that frees it
+/// on drop.
+///
+/// Xpress SDK 9+ requires `XPRSlicense` before `XPRSinit`. Additionally,
+/// `XPRSinit` independently searches `XPRESSDIR/bin/xpauth.xpr` for a
+/// license file, ignoring whatever `XPRSlicense` loaded. The only way to
+/// override this is to set the `XPAUTH_PATH` env var before calling
+/// `XPRSinit`.
+///
+/// License candidates are tried in this order:
+/// 1. Explicit `XPAUTH_PATH` (if already set by the user)
+/// 2. `$XPRESSDIR/bin/community-xpauth.xpr` (community license)
+/// 3. `$XPRESSDIR/bin/xpauth.xpr` (commercial license)
+/// 4. `$XPRESSDIR/xpauth.xpr`
+///
+/// The community license (`hostid="any"`) is tried before the commercial
+/// one so that a stale commercial license for a different machine does not
+/// poison the Xpress init state.
 #[allow(unsafe_code)]
 fn xprs_init() -> Result<XpressGuard, SolverError> {
-    // SAFETY: XPRSinit with null starts default initialization; safe to call.
-    ffi::check_xprs(unsafe { ffi::XPRSinit(std::ptr::null()) })
-        .map_err(|rc| SolverError::SolverSpecific(format!("XPRSinit failed: {rc}")))?;
-    Ok(XpressGuard)
+    let xpress_dir = std::env::var("XPRESSDIR").ok();
+    let original_xpauth = std::env::var("XPAUTH_PATH").ok();
+
+    // Build candidate license file paths in priority order.
+    let mut candidates: Vec<String> = Vec::new();
+    if let Some(path) = &original_xpauth {
+        candidates.push(path.clone());
+    }
+    if let Some(dir) = &xpress_dir {
+        for suffix in &[
+            "bin/community-xpauth.xpr",
+            "bin/xpauth.xpr",
+            "xpauth.xpr",
+        ] {
+            candidates.push(format!("{dir}/{suffix}"));
+        }
+    }
+
+    // Try each candidate: call XPRSlicense to load the file, then set
+    // XPAUTH_PATH so XPRSinit uses it (instead of auto-discovering a
+    // different file in XPRESSDIR). Clean up with XPRSfree on failure so
+    // the next candidate can be tried.
+    for candidate in &candidates {
+        let Ok(c_path) = std::ffi::CString::new(candidate.as_str()) else {
+            continue;
+        };
+        let mut lic_status: std::ffi::c_int = 0;
+        // SAFETY: c_path is a valid, null-terminated C string.
+        if unsafe { ffi::XPRSlicense(&raw mut lic_status, c_path.as_ptr()) } != 0 {
+            continue;
+        }
+        // SAFETY: single-threaded init path; restored after attempt.
+        unsafe { std::env::set_var("XPAUTH_PATH", candidate) };
+        // SAFETY: XPRSlicense succeeded.
+        let init_rc = unsafe { ffi::XPRSinit(std::ptr::null()) };
+        if init_rc == 0 {
+            // Success — restore XPAUTH_PATH and return.
+            restore_env("XPAUTH_PATH", &original_xpauth);
+            return Ok(XpressGuard);
+        }
+        // Failed — clean up so the next candidate can be tried.
+        unsafe { ffi::XPRSfree() };
+    }
+
+    // All candidates exhausted — restore env and report failure.
+    restore_env("XPAUTH_PATH", &original_xpauth);
+    let dir_info = xpress_dir.as_deref().unwrap_or("(not set)");
+    let msg = xprs_lic_errmsg();
+    Err(SolverError::SolverSpecific(format!(
+        "Xpress license initialization failed: {msg} [XPRESSDIR={dir_info}]\n\
+         \n\
+         To use the Xpress community edition, download and install it from\n\
+         https://www.fico.com/en/products/fico-xpress-optimization\n\
+         The installer generates a machine-specific xpauth.xpr license file."
+    )))
+}
+
+/// Restore an environment variable to its original value, or remove it if it
+/// was originally unset.
+#[allow(unsafe_code)]
+fn restore_env(key: &str, original: &Option<String>) {
+    // SAFETY: called from single-threaded init/cleanup path.
+    match original {
+        Some(val) => unsafe { std::env::set_var(key, val) },
+        None => unsafe { std::env::remove_var(key) },
+    }
 }
 
 /// Create a new Xpress problem, returning an RAII guard that destroys it on
@@ -373,7 +464,7 @@ fn solve_model(
         let ngents = int_col_indices.len() as c_int;
         // SAFETY: prob is valid; all arrays have correct lengths per Xpress API.
         ffi::check_xprs(unsafe {
-            ffi::XPRSloadglobal(
+            ffi::XPRSloadmip(
                 prob,
                 std::ptr::null(),                // probname
                 ncols_i,                         // ncols
@@ -399,7 +490,7 @@ fn solve_model(
                 std::ptr::null(),                // dref
             )
         })
-        .map_err(|rc| SolverError::SolverSpecific(format!("XPRSloadglobal failed: {rc}")))?;
+        .map_err(|rc| SolverError::SolverSpecific(format!("XPRSloadmip failed: {rc}")))?;
     } else {
         // SAFETY: prob is valid; all arrays have correct lengths per Xpress API.
         ffi::check_xprs(unsafe {

--- a/crates/arco-xpress/src/solver.rs
+++ b/crates/arco-xpress/src/solver.rs
@@ -91,11 +91,7 @@ fn xprs_init() -> Result<XpressGuard, SolverError> {
         candidates.push(path.clone());
     }
     if let Some(dir) = &xpress_dir {
-        for suffix in &[
-            "bin/community-xpauth.xpr",
-            "bin/xpauth.xpr",
-            "xpauth.xpr",
-        ] {
+        for suffix in &["bin/community-xpauth.xpr", "bin/xpauth.xpr", "xpauth.xpr"] {
             candidates.push(format!("{dir}/{suffix}"));
         }
     }


### PR DESCRIPTION
## Summary

- Replace deprecated `XPRSloadglobal` FFI binding with `XPRSloadmip` (renamed in Xpress SDK 9+)
- Add `XPRSlicense` / `XPRSgetlicerrmsg` FFI bindings for the new licensing flow required before `XPRSinit`
- Try `community-xpauth.xpr` before `xpauth.xpr` so a stale commercial license for a different machine doesn't poison `XPRSinit` state
- Set `XPAUTH_PATH` env var before `XPRSinit` to override its auto-discovery of stale license files in `XPRESSDIR`
- Fail `build.rs` with clear instructions when `XPRESSDIR` is not found (instead of a silent warning that leads to a cryptic linker error)
- Add `arco-cli/build.rs` to embed rpath for `libxprs.dylib` on Unix so the binary works without `DYLD_LIBRARY_PATH`

## Test plan

- [x] `cargo check -p arco-xpress -p arco-cli` compiles
- [x] `cargo check -p arco-cli --features xpress` compiles
- [x] `cargo test -p arco-xpress -p arco-cli` passes
- [x] `arco run crates/arco-kdl/tests/e2e/sdom-canonical/input.kdl` solves to optimal with Xpress community license
- [ ] Verify on Linux with `XPRESSDIR=/opt/xpressmp`