### PR TITLE
fix(ci): dispatch release workflows and fix CLI build quoting

### DIFF
--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -158,9 +158,7 @@ jobs:
       - name: Use rustup to set correct Rust version
         run: rustup update "1.85" --no-self-update && rustup default "1.85"
       - name: Install dist
-        env:
-          INSTALL_DIST_CMD: ${{ matrix.install_dist.run }}
-        run: $INSTALL_DIST_CMD
+        run: ${{ matrix.install_dist.run }} # zizmor: ignore[template-injection] — value from repo-controlled dist plan
       # Get the dist-manifest
       - name: Fetch local artifacts
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
@@ -169,10 +167,7 @@ jobs:
           path: target/distrib/
           merge-multiple: true
       - name: Install dependencies
-        env:
-          PACKAGES_INSTALL_CMD: ${{ matrix.packages_install }}
-        run: |
-          $PACKAGES_INSTALL_CMD
+        run: ${{ matrix.packages_install }} # zizmor: ignore[template-injection] — value from repo-controlled dist plan
       - name: Build artifacts
         env:
           DIST_TAG_FLAG: ${{ needs.plan.outputs.tag-flag }}

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -47,11 +47,12 @@ jobs:
       - name: Trigger release-cli workflow
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ needs.release-please.outputs.tag_name }}
         run: |
           gh workflow run release-cli.yaml \
             --repo "$GITHUB_REPOSITORY" \
             --ref main \
-            -f tag="${{ needs.release-please.outputs.tag_name }}"
+            -f tag="$RELEASE_TAG"
 
   dispatch-release-python:
     name: Dispatch Python release
@@ -65,7 +66,8 @@ jobs:
       - name: Trigger release-python workflow
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ needs.release-please.outputs.tag_name }}
         run: |
           gh workflow run release-python.yaml \
             --repo "$GITHUB_REPOSITORY" \
-            --ref "${{ needs.release-please.outputs.tag_name }}"
+            --ref "$RELEASE_TAG"

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -51,7 +51,7 @@ jobs:
         run: |
           gh workflow run release-cli.yaml \
             --repo "$GITHUB_REPOSITORY" \
-            --ref main \
+            --ref "$RELEASE_TAG" \
             -f tag="$RELEASE_TAG"
 
   dispatch-release-python:

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -20,11 +20,52 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - name: Run release-please
+        id: release
         uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json
           target-branch: main
+
+  # Tags created by GITHUB_TOKEN don't trigger on.push.tags workflows.
+  # Dispatch the release workflows explicitly after release-please creates a release.
+  dispatch-release-cli:
+    name: Dispatch CLI release
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: write
+    steps:
+      - name: Trigger release-cli workflow
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run release-cli.yaml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref main \
+            -f tag="${{ needs.release-please.outputs.tag_name }}"
+
+  dispatch-release-python:
+    name: Dispatch Python release
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: write
+    steps:
+      - name: Trigger release-python workflow
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run release-python.yaml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref "${{ needs.release-please.outputs.tag_name }}"

--- a/RELEASE_POLICY.md
+++ b/RELEASE_POLICY.md
@@ -35,9 +35,13 @@ Three independent workflows handle the release lifecycle:
 
 | Workflow | Trigger | Purpose |
 |----------|---------|---------|
-| `release-please.yaml` | Push to `main` | Version management — creates release PR, tag, GitHub Release |
-| `release-python.yaml` | Tag `arco-v*` or `workflow_dispatch` | Builds wheels, publishes to PyPI, uploads to release |
-| `release-cli.yaml` | Tag `arco-v*` or `workflow_dispatch` | Builds CLI binaries via `cargo-dist`, uploads to release |
+| `release-please.yaml` | Push to `main` | Version management — creates release PR, tag, GitHub Release; dispatches both release workflows |
+| `release-python.yaml` | Dispatched by release-please, tag push, or `workflow_dispatch` | Builds wheels, publishes to PyPI, uploads to release |
+| `release-cli.yaml` | Dispatched by release-please, tag push, or `workflow_dispatch` | Builds CLI binaries via `cargo-dist`, uploads to release |
+
+> **Note:** Tags created by `GITHUB_TOKEN` do not trigger `on.push.tags` workflows
+> (GitHub restriction). `release-please.yaml` explicitly dispatches both release
+> workflows after creating a release to work around this.
 
 ## Publishing Behavior
 
@@ -49,14 +53,16 @@ Three independent workflows handle the release lifecycle:
 
 ## Independent Release Pipelines
 
-Both product pipelines are triggered by the same `arco-v*` tag and run
-independently in parallel:
+Both product pipelines are dispatched by `release-please.yaml` after a release
+is created and run independently in parallel:
 
 ### Phase 1: Version and Tag (release-please)
 
 - `release-please` creates a release PR with version bumps.
 - Merging the PR creates the `arco-v*` tag and a GitHub Release with the
   changelog body.
+- `release-please.yaml` then dispatches `release-cli.yaml` and
+  `release-python.yaml` via `workflow_dispatch`.
 
 ### Phase 2a: Python Pipeline (release-python.yaml)
 


### PR DESCRIPTION
## Summary
- **Fix release pipeline**: `release-please` now explicitly dispatches `release-cli` and `release-python` via `workflow_dispatch` after creating a release. Tags created by `GITHUB_TOKEN` don't trigger `on.push.tags` workflows (GitHub restriction), which is why v0.2.2 shipped with zero assets.
- **Fix CLI build quoting**: `install_dist.run` and `packages_install` commands were broken when passed through env vars — shell quoting was mangled (e.g. `curl --proto '=https'` failed on all platforms). Switched to direct GitHub Actions expression expansion with zizmor ignore annotations.
- **Update RELEASE_POLICY.md**: Documents the dispatch mechanism and the `GITHUB_TOKEN` limitation.

## Test plan
- [ ] CI passes (zizmor, clippy, tests)
- [ ] `release-cli` runs on this PR with `pr_run_mode=plan` (validates the quoting fix)
- [ ] After merge, manually dispatch `release-cli` for `arco-v0.2.2` to verify full pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)