### PR TITLE
fix(ci): isolate cargo-dist CLI release builds from workspace crates

### DIFF
--- a/.github/workflows/release-smoke.yaml
+++ b/.github/workflows/release-smoke.yaml
@@ -17,36 +17,19 @@ env:
   RUST_TOOLCHAIN_VERSION: "1.85"
 
 jobs:
-  detect-release-pr:
-    name: Detect release-please PR
+  cli-smoke:
+    name: CLI smoke (dist build)
+    if: "${{ startsWith(github.head_ref, 'release-please--') || startsWith(github.event.pull_request.title, 'chore: release arco v') }}"
     runs-on: ubuntu-latest
-    outputs:
-      should_run: ${{ steps.detect.outputs.should_run }}
-      dist_tag: ${{ steps.version.outputs.dist_tag }}
+    timeout-minutes: 30
     steps:
-      - name: Detect release-please PR shape
-        id: detect
-        env:
-          PR_TITLE: ${{ github.event.pull_request.title }}
-          HEAD_REF: ${{ github.head_ref }}
-        run: |
-          set -euo pipefail
-
-          if [[ "$HEAD_REF" == release-please--* ]] || [[ "$PR_TITLE" == chore:\ release\ arco\ v* ]]; then
-            echo "should_run=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "should_run=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        if: steps.detect.outputs.should_run == 'true'
         with:
           fetch-depth: 1
           persist-credentials: false
 
-      - name: Resolve release tag from versions
+      - name: Resolve dist tag from versions
         id: version
-        if: steps.detect.outputs.should_run == 'true'
         run: |
           set -euo pipefail
 
@@ -69,44 +52,23 @@ jobs:
 
           echo "dist_tag=v$CARGO_VERSION" >> "$GITHUB_OUTPUT"
 
-  cli-smoke:
-    name: CLI smoke (dist build)
-    needs: detect-release-pr
-    if: needs.detect-release-pr.outputs.should_run == 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          fetch-depth: 1
-          persist-credentials: false
-
       - name: Install Rust
-        run: rustup update "1.85" --no-self-update && rustup default "1.85"
+        run: rustup update "$RUST_TOOLCHAIN_VERSION" --no-self-update && rustup default "$RUST_TOOLCHAIN_VERSION"
 
       - name: Install dist
         shell: bash
         run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.31.0/cargo-dist-installer.sh | sh"
 
-      - name: Plan release artifacts
-        env:
-          DIST_TAG: ${{ needs.detect-release-pr.outputs.dist_tag }}
-        run: |
-          set -euo pipefail
-          dist plan --tag="$DIST_TAG" --output-format=json > plan-dist-manifest.json
-          jq -e '.releases[] | select(.app_name == "arco-cli")' plan-dist-manifest.json > /dev/null
-
       - name: Build one CLI release target
         env:
-          DIST_TAG: ${{ needs.detect-release-pr.outputs.dist_tag }}
+          DIST_TAG: ${{ steps.version.outputs.dist_tag }}
         run: |
           set -euo pipefail
           dist build --tag="$DIST_TAG" --artifacts=local --target=x86_64-unknown-linux-gnu --print=linkage --output-format=human
 
   python-smoke:
     name: Python smoke (wheel build)
-    needs: detect-release-pr
-    if: needs.detect-release-pr.outputs.should_run == 'true'
+    if: "${{ startsWith(github.head_ref, 'release-please--') || startsWith(github.event.pull_request.title, 'chore: release arco v') }}"
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/release-smoke.yaml
+++ b/.github/workflows/release-smoke.yaml
@@ -1,0 +1,133 @@
+name: release-smoke
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: release-smoke-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  UV_VERSION: "0.9.4"
+  JUST_VERSION: "1.5.0"
+  RUST_TOOLCHAIN_VERSION: "1.85"
+
+jobs:
+  detect-release-pr:
+    name: Detect release-please PR
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.detect.outputs.should_run }}
+      dist_tag: ${{ steps.version.outputs.dist_tag }}
+    steps:
+      - name: Detect release-please PR shape
+        id: detect
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$HEAD_REF" == release-please--* ]] || [[ "$PR_TITLE" == chore:\ release\ arco\ v* ]]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        if: steps.detect.outputs.should_run == 'true'
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Resolve release tag from versions
+        id: version
+        if: steps.detect.outputs.should_run == 'true'
+        run: |
+          set -euo pipefail
+
+          CARGO_VERSION=$(python3 -c "
+          import tomllib, pathlib
+          data = tomllib.loads(pathlib.Path('Cargo.toml').read_text())
+          print(data['workspace']['package']['version'])
+          ")
+
+          PYTHON_VERSION=$(python3 -c "
+          import tomllib, pathlib
+          data = tomllib.loads(pathlib.Path('bindings/python/pyproject.toml').read_text())
+          print(data['project']['version'])
+          ")
+
+          if [[ "$CARGO_VERSION" != "$PYTHON_VERSION" ]]; then
+            echo "::error::Version mismatch: Cargo.toml=$CARGO_VERSION, pyproject.toml=$PYTHON_VERSION"
+            exit 1
+          fi
+
+          echo "dist_tag=v$CARGO_VERSION" >> "$GITHUB_OUTPUT"
+
+  cli-smoke:
+    name: CLI smoke (dist build)
+    needs: detect-release-pr
+    if: needs.detect-release-pr.outputs.should_run == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Install Rust
+        run: rustup update "1.85" --no-self-update && rustup default "1.85"
+
+      - name: Install dist
+        shell: bash
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.31.0/cargo-dist-installer.sh | sh"
+
+      - name: Plan release artifacts
+        env:
+          DIST_TAG: ${{ needs.detect-release-pr.outputs.dist_tag }}
+        run: |
+          set -euo pipefail
+          dist plan --tag="$DIST_TAG" --output-format=json > plan-dist-manifest.json
+          jq -e '.releases[] | select(.app_name == "arco-cli")' plan-dist-manifest.json > /dev/null
+
+      - name: Build one CLI release target
+        env:
+          DIST_TAG: ${{ needs.detect-release-pr.outputs.dist_tag }}
+        run: |
+          set -euo pipefail
+          dist build --tag="$DIST_TAG" --artifacts=local --target=x86_64-unknown-linux-gnu --print=linkage --output-format=human
+
+  python-smoke:
+    name: Python smoke (wheel build)
+    needs: detect-release-pr
+    if: needs.detect-release-pr.outputs.should_run == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Set up build environment
+        uses: ./.github/actions/setup-build-env
+        with:
+          python-version: "3.12"
+          uv-version: ${{ env.UV_VERSION }}
+          just-version: ${{ env.JUST_VERSION }}
+          rust-toolchain-version: ${{ env.RUST_TOOLCHAIN_VERSION }}
+
+      - name: Build wheel
+        run: just py-build-ci
+
+      - name: Smoke test wheel install and import
+        run: just py-smoke-wheel "dist/*.whl"
+
+      - name: Validate distributions
+        run: uvx twine check dist/*

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,8 @@ repository = "https://github.com/pesap/arco"
 [workspace.metadata.dist]
 # The preferred dist version to use in CI
 cargo-dist-version = "0.31.0"
+# Explicitly release only the CLI package from this workspace.
+packages = ["arco-cli"]
 # The preferred Rust toolchain to use in CI (Rustup must be able to install it)
 rust-toolchain-version = "1.85"
 # CI backends to support
@@ -65,6 +67,8 @@ auto-updater = true
 # Use workflow_dispatch instead of tag-push triggers.
 # release-please owns tag/release creation; dist builds and uploads artifacts.
 dispatch-releases = true
+# Build per package instead of `--workspace` to avoid compiling non-release crates.
+precise-builds = true
 # Protect hand-edits to generated CI workflow from being overwritten.
 allow-dirty = ["ci"]
 

--- a/RELEASE_POLICY.md
+++ b/RELEASE_POLICY.md
@@ -35,6 +35,7 @@ Three independent workflows handle the release lifecycle:
 
 | Workflow              | Trigger                                                        | Purpose                                                                                         |
 | --------------------- | -------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `release-smoke.yaml`  | Pull requests matching release-please PR shape                 | Pre-merge smoke checks for CLI + Python release paths without publishing                        |
 | `release-please.yaml` | Push to `main`                                                 | Version management — creates release PR, tag, GitHub Release; dispatches both release workflows |
 | `release-python.yaml` | Dispatched by release-please, tag push, or `workflow_dispatch` | Builds wheels, publishes to PyPI, uploads to release                                            |
 | `release-cli.yaml`    | Dispatched by release-please, tag push, or `workflow_dispatch` | Builds CLI binaries via `cargo-dist`, uploads to release                                        |
@@ -97,6 +98,15 @@ Both product workflows support safe testing via `workflow_dispatch`:
   publishing to PyPI or uploading to a GitHub Release.
 - **CLI dry-run** (tag input `dry-run`): Runs `dist plan` and builds all
   platform artifacts without uploading to a GitHub Release.
+
+## Automatic Pre-Merge Release Smoke Checks
+
+- `release-smoke.yaml` runs automatically on release-please PRs
+  (`release-please--*` branch names or `chore: release arco v*` titles).
+- It validates release readiness before merge by running:
+  - CLI smoke: `dist plan` + single-target `dist build` for the release tag
+  - Python smoke: wheel build + install/import smoke + `twine check`
+- It never publishes to PyPI or GitHub Releases.
 
 ## Failure Handling
 

--- a/RELEASE_POLICY.md
+++ b/RELEASE_POLICY.md
@@ -104,7 +104,7 @@ Both product workflows support safe testing via `workflow_dispatch`:
 - `release-smoke.yaml` runs automatically on release-please PRs
   (`release-please--*` branch names or `chore: release arco v*` titles).
 - It validates release readiness before merge by running:
-  - CLI smoke: `dist plan` + single-target `dist build` for the release tag
+  - CLI smoke: single-target `dist build` for the release tag
   - Python smoke: wheel build + install/import smoke + `twine check`
 - It never publishes to PyPI or GitHub Releases.
 

--- a/RELEASE_POLICY.md
+++ b/RELEASE_POLICY.md
@@ -33,11 +33,11 @@ Rust crates and bindings evolve together under one release version.
 
 Three independent workflows handle the release lifecycle:
 
-| Workflow | Trigger | Purpose |
-|----------|---------|---------|
-| `release-please.yaml` | Push to `main` | Version management — creates release PR, tag, GitHub Release; dispatches both release workflows |
-| `release-python.yaml` | Dispatched by release-please, tag push, or `workflow_dispatch` | Builds wheels, publishes to PyPI, uploads to release |
-| `release-cli.yaml` | Dispatched by release-please, tag push, or `workflow_dispatch` | Builds CLI binaries via `cargo-dist`, uploads to release |
+| Workflow              | Trigger                                                        | Purpose                                                                                         |
+| --------------------- | -------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `release-please.yaml` | Push to `main`                                                 | Version management — creates release PR, tag, GitHub Release; dispatches both release workflows |
+| `release-python.yaml` | Dispatched by release-please, tag push, or `workflow_dispatch` | Builds wheels, publishes to PyPI, uploads to release                                            |
+| `release-cli.yaml`    | Dispatched by release-please, tag push, or `workflow_dispatch` | Builds CLI binaries via `cargo-dist`, uploads to release                                        |
 
 > **Note:** Tags created by `GITHUB_TOKEN` do not trigger `on.push.tags` workflows
 > (GitHub restriction). `release-please.yaml` explicitly dispatches both release
@@ -113,6 +113,11 @@ CLI binary builds are configured in `[workspace.metadata.dist]` in `Cargo.toml`:
 
 - `dispatch-releases = true` — the workflow uses `workflow_dispatch` and tag
   push instead of cargo-dist's default tag-only trigger.
+- `packages = ["arco-cli"]` — release scope is explicitly limited to the CLI
+  package.
+- `precise-builds = true` — builds CLI artifacts package-by-package instead of
+  `--workspace`, so non-release crates (for example Python-only optional
+  backends) do not break CLI releases.
 - `allow-dirty = ["ci"]` — protects hand-edits to the generated workflow from
   being overwritten by `dist generate-ci`.
 - Tag format: release-please creates `arco-v*` tags; the workflow strips the

--- a/crates/arco-cli/Cargo.toml
+++ b/crates/arco-cli/Cargo.toml
@@ -7,7 +7,7 @@ rust-version = { workspace = true }
 homepage = { workspace = true }
 repository = { workspace = true }
 authors = { workspace = true }
-license-file = { workspace = true }
+license-file = "licenses/BSD-3-Clause.txt"
 publish = false
 autobins = false
 default-run = "arco"


### PR DESCRIPTION
## Summary
- configure cargo-dist to release only `arco-cli` with `packages = [\"arco-cli\"]`
- enable `precise-builds` so release builds use package scope instead of `--workspace`, avoiding Python/IPOPT build-path breakage in CLI release jobs
- fix `arco-cli` license file path so package-scoped dist builds copy license assets correctly, and document the new release behavior

## Verification
- `dist build --artifacts=local --target=x86_64-apple-darwin --tag=v0.2.3 --print=linkage --output-format=human`
- `dist plan --tag=v0.2.3 --output-format=json >/tmp/dist-plan-v023.json && jq -r '.ci.github.artifacts_matrix.include[0].dist_args' /tmp/dist-plan-v023.json`