### PR TITLE
fix(ci): trigger release smoke for release-please PRs

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -23,6 +23,8 @@ jobs:
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
+      prs_created: ${{ steps.release.outputs.prs_created }}
+      pr: ${{ steps.release.outputs.pr }}
     steps:
       - name: Run release-please
         id: release
@@ -35,6 +37,40 @@ jobs:
 
   # Tags created by GITHUB_TOKEN don't trigger on.push.tags workflows.
   # Dispatch the release workflows explicitly after release-please creates a release.
+  dispatch-release-smoke:
+    name: Dispatch release smoke
+    needs: release-please
+    if: needs.release-please.outputs.prs_created == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: write
+    steps:
+      - name: Resolve release PR branch
+        id: pr
+        env:
+          PR_JSON: ${{ needs.release-please.outputs.pr }}
+        run: |
+          set -euo pipefail
+
+          PR_BRANCH=$(jq -r '.headBranchName // empty' <<< "$PR_JSON")
+
+          if [[ -z "$PR_BRANCH" ]]; then
+            echo "::error::Could not resolve release-please PR branch from action output"
+            exit 1
+          fi
+
+          echo "branch=$PR_BRANCH" >> "$GITHUB_OUTPUT"
+
+      - name: Trigger release-smoke workflow
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_BRANCH: ${{ steps.pr.outputs.branch }}
+        run: |
+          gh workflow run release-smoke.yaml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref "$PR_BRANCH"
+
   dispatch-release-cli:
     name: Dispatch CLI release
     needs: release-please

--- a/.github/workflows/release-smoke.yaml
+++ b/.github/workflows/release-smoke.yaml
@@ -3,9 +3,10 @@ name: release-smoke
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
 
 concurrency:
-  group: release-smoke-${{ github.event.pull_request.number }}
+  group: release-smoke-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 permissions:
@@ -19,7 +20,7 @@ env:
 jobs:
   cli-smoke:
     name: CLI smoke (dist build)
-    if: "${{ startsWith(github.head_ref, 'release-please--') || startsWith(github.event.pull_request.title, 'chore: release arco v') }}"
+    if: "${{ github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'release-please--') || startsWith(github.event.pull_request.title, 'chore: release arco v') }}"
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -68,7 +69,7 @@ jobs:
 
   python-smoke:
     name: Python smoke (wheel build)
-    if: "${{ startsWith(github.head_ref, 'release-please--') || startsWith(github.event.pull_request.title, 'chore: release arco v') }}"
+    if: "${{ github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'release-please--') || startsWith(github.event.pull_request.title, 'chore: release arco v') }}"
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/RELEASE_POLICY.md
+++ b/RELEASE_POLICY.md
@@ -33,12 +33,12 @@ Rust crates and bindings evolve together under one release version.
 
 Three independent workflows handle the release lifecycle:
 
-| Workflow              | Trigger                                                        | Purpose                                                                                         |
-| --------------------- | -------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| `release-smoke.yaml`  | Pull requests matching release-please PR shape                 | Pre-merge smoke checks for CLI + Python release paths without publishing                        |
-| `release-please.yaml` | Push to `main`                                                 | Version management — creates release PR, tag, GitHub Release; dispatches both release workflows |
-| `release-python.yaml` | Dispatched by release-please, tag push, or `workflow_dispatch` | Builds wheels, publishes to PyPI, uploads to release                                            |
-| `release-cli.yaml`    | Dispatched by release-please, tag push, or `workflow_dispatch` | Builds CLI binaries via `cargo-dist`, uploads to release                                        |
+| Workflow              | Trigger                                                                                | Purpose                                                                                         |
+| --------------------- | -------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `release-smoke.yaml`  | Pull requests matching release-please PR shape, or dispatched by `release-please.yaml` | Pre-merge smoke checks for CLI + Python release paths without publishing                        |
+| `release-please.yaml` | Push to `main`                                                                         | Version management — creates release PR, tag, GitHub Release; dispatches both release workflows |
+| `release-python.yaml` | Dispatched by release-please, tag push, or `workflow_dispatch`                         | Builds wheels, publishes to PyPI, uploads to release                                            |
+| `release-cli.yaml`    | Dispatched by release-please, tag push, or `workflow_dispatch`                         | Builds CLI binaries via `cargo-dist`, uploads to release                                        |
 
 > **Note:** Tags created by `GITHUB_TOKEN` do not trigger `on.push.tags` workflows
 > (GitHub restriction). `release-please.yaml` explicitly dispatches both release
@@ -103,6 +103,9 @@ Both product workflows support safe testing via `workflow_dispatch`:
 
 - `release-smoke.yaml` runs automatically on release-please PRs
   (`release-please--*` branch names or `chore: release arco v*` titles).
+- `release-please.yaml` also dispatches `release-smoke.yaml` when it creates or
+  updates a release PR, so smoke checks still run even though PR events created
+  by `GITHUB_TOKEN` do not trigger downstream workflows.
 - It validates release readiness before merge by running:
   - CLI smoke: single-target `dist build` for the release tag
   - Python smoke: wheel build + install/import smoke + `twine check`

--- a/RELEASE_POLICY.md
+++ b/RELEASE_POLICY.md
@@ -31,7 +31,7 @@ Rust crates and bindings evolve together under one release version.
 
 ## Workflow Structure
 
-Three independent workflows handle the release lifecycle:
+Four independent workflows handle the release lifecycle:
 
 | Workflow              | Trigger                                                                                | Purpose                                                                                         |
 | --------------------- | -------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
## Summary
- dispatch `release-smoke.yaml` from `release-please.yaml` when release-please creates or updates a release PR
- add `workflow_dispatch` support to `release-smoke.yaml` so dispatches from release-please can run smoke jobs automatically
- keep pull-request-based smoke checks for release-please-shaped PRs and document the GITHUB_TOKEN trigger limitation in policy docs

## Why
Release-please currently uses `GITHUB_TOKEN`, and PR/tag events created by that token do not trigger downstream workflows. This caused release-please PRs (for example `#62`) to have no smoke checks.

## Verification
- `just workflow-quality`