### PR TITLE
fix(release): correct grouped PR title pattern

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "pull-request-title-pattern": "chore: release ${component} v${version}",
+  "group-pull-request-title-pattern": "chore: release ${component} v${version}",
   "draft": true,
   "force-tag-creation": true,
   "separate-pull-requests": false,


### PR DESCRIPTION
## Summary
- Adds `group-pull-request-title-pattern` to `.release-please-config.json` so grouped release PRs use the component name (`arco`) instead of the branch name (`main`)
- Includes `Release-As: 0.2.5` trailer to override the stale `Release-As: 0.1.1` from commit 6053cbb

## Context
PR #69 was created with title "chore: release main" and version 0.1.1 (downgrade from 0.2.4). Both caused by:
1. Missing `group-pull-request-title-pattern` config
2. Old `Release-As: 0.1.1` commit trailer still in the scan range