### PR TITLE
fix(release): match tag format to existing tags

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -10,7 +10,7 @@
       "release-type": "simple",
       "bump-minor-pre-major": true,
       "component": "arco",
-      "include-component-in-tag": false,
+      "include-component-in-tag": true,
       "changelog-sections": [
         {
           "section": "Features",


### PR DESCRIPTION
## Summary
- Sets `include-component-in-tag: true` so release-please looks for `arco-v0.2.4` tags (which exist) instead of `v0.2.4` (which don't)
- Without this, release-please treats the entire git history as unreleased and dumps all commits into the changelog
- Includes `Release-As: 0.2.5` to override the stale `Release-As: 0.1.1` trailer from commit 6053cbb