### PR TITLE
ci(release): revert tag format and fix artifact action SHAs

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -71,7 +71,7 @@ jobs:
         run: uv build
 
       - name: Store the distribution packages
-        uses: actions/upload-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: python-package-distributions
           path: dist/
@@ -90,7 +90,7 @@ jobs:
       url: https://pypi.org/p/arco
     steps:
       - name: Download all the dists
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: python-package-distributions
           path: dist/

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -10,7 +10,7 @@
       "release-type": "simple",
       "bump-minor-pre-major": true,
       "component": "arco",
-      "include-component-in-tag": true,
+      "include-component-in-tag": false,
       "changelog-sections": [
         {
           "section": "Features",


### PR DESCRIPTION
## Summary
- Reverts `include-component-in-tag` to `false` — cargo-dist can't parse `arco-v*` tags
- Restores `upload-artifact` to v6 and `download-artifact` to v7 (the v8 SHA was invalid for upload-artifact)
- Created `v*` alias tags pointing to the same commits as existing `arco-v*` tags so release-please can find them with `include-component-in-tag: false`
- Deleted broken `arco-v0.2.5` draft release and tag
- Closed stale release-please PR #73

## Context
PR #72 set `include-component-in-tag: true` which caused cargo-dist to fail parsing the tag. The bad upload-artifact SHA (from PR #70) caused py-build to fail at job setup.