### PR TITLE
ci(release): append install instructions and fix repo URLs

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -45,6 +45,36 @@ jobs:
     with:
       tag: ${{ needs.release-please.outputs.tag_name }}
 
+  update-release-notes:
+    name: Append install instructions
+    needs: [release-please, cargo-dist]
+    if: needs.release-please.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    steps:
+      - name: Download dist-manifest
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: artifacts-dist-manifest
+          path: .
+
+      - name: Append install instructions to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.release-please.outputs.tag_name }}
+        run: |
+          set -euo pipefail
+          install_body=$(jq -r '.announcement_github_body // empty' dist-manifest.json)
+          if [[ -z "$install_body" ]]; then
+            echo "No install instructions found in dist-manifest.json"
+            exit 0
+          fi
+          current_body=$(gh release view "$TAG" --json body --jq '.body')
+          printf '%s\n\n---\n\n%s' "$current_body" "$install_body" > release-body.md
+          gh release edit "$TAG" --notes-file release-body.md
+
   py-build:
     name: Python Build Artifacts
     timeout-minutes: 15

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,8 +42,8 @@ authors = [
     "pesap <pesap@users.noreply.github.com>",
 ]
 description = "Workspace for the Arco multi-language bindings"
-homepage = "https://github.com/pesap/arco"
-repository = "https://github.com/pesap/arco"
+homepage = "https://github.com/NatLabRockies/arco"
+repository = "https://github.com/NatLabRockies/arco"
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/README.md
+++ b/README.md
@@ -102,17 +102,17 @@ The `arco` CLI is available as a standalone binary from GitHub Releases. Install
 via the shell installer:
 
 ```bash
-curl --proto '=https' --tlsv1.2 -LsSf https://github.com/pesap/arco/releases/latest/download/arco-cli-installer.sh | sh
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/NatLabRockies/arco/releases/latest/download/arco-cli-installer.sh | sh
 ```
 
 Or on Windows via PowerShell:
 
 ```powershell
-powershell -c "irm https://github.com/pesap/arco/releases/latest/download/arco-cli-installer.ps1 | iex"
+powershell -c "irm https://github.com/NatLabRockies/arco/releases/latest/download/arco-cli-installer.ps1 | iex"
 ```
 
 For specific versions or manual installation, download the appropriate binary for
-your platform from the [GitHub Releases](https://github.com/pesap/arco/releases)
+your platform from the [GitHub Releases](https://github.com/NatLabRockies/arco/releases)
 page.
 
 ## API comparison

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -37,10 +37,10 @@ classifiers = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/pesap/arco"
-Repository = "https://github.com/pesap/arco"
-Issues = "https://github.com/pesap/arco/issues"
-Changelog = "https://github.com/pesap/arco/releases"
+Homepage = "https://github.com/NatLabRockies/arco"
+Repository = "https://github.com/NatLabRockies/arco"
+Issues = "https://github.com/NatLabRockies/arco/issues"
+Changelog = "https://github.com/NatLabRockies/arco/releases"
 
 [tool.maturin]
 features = ["pyo3/extension-module"]

--- a/bindings/python/uv.lock
+++ b/bindings/python/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "arco"
-version = "0.2.0"
+version = "0.2.5"
 source = { editable = "." }
 
 [package.dev-dependencies]

--- a/crates/arco-cli/wix/main.wxs
+++ b/crates/arco-cli/wix/main.wxs
@@ -173,7 +173,7 @@
         <!--<Icon Id='ProductICO' SourceFile='wix\Product.ico'/>-->
         <!--<Property Id='ARPPRODUCTICON' Value='ProductICO' />-->
 
-        <Property Id='ARPHELPLINK' Value='https://github.com/pesap/arco'/>
+        <Property Id='ARPHELPLINK' Value='https://github.com/NatLabRockies/arco'/>
 
         <UI>
             <UIRef Id='WixUI_FeatureTree'/>

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -16,7 +16,7 @@ installers = ["shell", "powershell", "msi"]
 # Target platforms to build apps for (Rust target-triple syntax)
 targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
 # Which actions to run on pull requests
-pr-run-mode = "upload"
+pr-run-mode = "plan"
 # Path that installers should place binaries in
 install-path = "CARGO_HOME"
 # Whether CI should trigger releases with dispatches instead of tag pushes


### PR DESCRIPTION
## Summary
- Adds `update-release-notes` job that appends cargo-dist install instructions to the release body after artifacts are built
- Fixes all repository URLs from `pesap/arco` to `NatLabRockies/arco` (Cargo.toml, pyproject.toml, README, MSI installer, dist-workspace)