### PR TITLE
fix(release): switch to separate PRs to fix component parsing

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -1,10 +1,10 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "pull-request-title-pattern": "chore: release arco v${version}",
-  "group-pull-request-title-pattern": "chore: release arco v${version}",
+  "pull-request-title-pattern": "chore: release ${component} v${version}",
+  "group-pull-request-title-pattern": "chore: release ${component} v${version}",
   "draft": true,
   "force-tag-creation": true,
-  "separate-pull-requests": false,
+  "separate-pull-requests": true,
   "packages": {
     ".": {
       "release-type": "simple",


### PR DESCRIPTION
## Summary
- Switches `separate-pull-requests` from `false` to `true` and restores `${component}` in title patterns
- Grouped PR mode resolves `${component}` to empty string when creating titles, but still expects it to match the configured component `arco` when parsing merged PRs back — making tag/release creation impossible
- This unblocks the stuck v0.2.7 release (PR #79 merged but never tagged)

## Test plan
- [ ] Merge this PR and verify the next release-please run on main creates the v0.2.7 tag and draft release
- [ ] Verify downstream jobs (cargo-dist, py-build, publish-pypi) are no longer skipped