### PR TITLE
fix(release): remove explicit group-pull-request-title-pattern

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "pull-request-title-pattern": "chore: release ${component} v${version}",
-  "group-pull-request-title-pattern": "chore: release ${component} v${version}",
   "draft": true,
   "force-tag-creation": true,
   "separate-pull-requests": true,


### PR DESCRIPTION
## Summary
- Removes the `group-pull-request-title-pattern` field from `.release-please-config.json`
- This field was added at `6969f0d` and is the root cause of every release failure since v0.2.5 (the last fully automated release)
- When present, release-please resolves `${component}` to empty string for grouped PRs, causing a fatal `"PR component: undefined does not match configured component: arco"` mismatch that blocks tag/release creation
- Without this field, release-please uses internal defaults that properly resolve the component — matching the config that successfully produced v0.2.1 through v0.2.5

## Context
- v0.2.5: last automated release (config had no explicit group pattern)
- v0.2.6: manually tagged (`"Release v0.2.6 — see PR #76 for changelog"`) because the pipeline was already broken
- v0.2.7: stuck — PR #79 merged but never tagged, all downstream jobs skipped

## After merging
Once merged, PR #79 (with `autorelease: pending` label restored) will be retried by release-please. It should parse the title `"chore: release arco v0.2.7"` correctly, create the tag + draft release, and trigger the full cargo-dist + PyPI pipeline.

## Test plan
- [ ] Merge and verify release-please creates `v0.2.7` tag and draft release
- [ ] Verify cargo-dist builds artifacts for all targets
- [ ] Verify PyPI publish succeeds
- [ ] Verify release notes include install instructions