### PR TITLE
fix(release): remove component config to fix release-please parsing

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "pull-request-title-pattern": "chore: release ${component} v${version}",
+  "pull-request-title-pattern": "chore: release v${version}",
   "draft": true,
   "force-tag-creation": true,
   "separate-pull-requests": true,
@@ -8,8 +8,6 @@
     ".": {
       "release-type": "simple",
       "bump-minor-pre-major": true,
-      "component": "arco",
-      "include-component-in-tag": false,
       "changelog-sections": [
         {
           "section": "Features",


### PR DESCRIPTION
## Summary
- Removes `component: "arco"` and `include-component-in-tag: false` from the release-please config
- Simplifies `pull-request-title-pattern` to `"chore: release v${version}"` (no `${component}`)
- Root cause: `include-component-in-tag: false` causes the runtime component to resolve to empty, but `component: "arco"` is still used for PR title parsing comparison, producing the fatal `"PR component: undefined does not match configured component: arco"` on every run
- This has blocked all automated releases since v0.2.5

## After merging
PR #79's title will be edited to `"chore: release v0.2.7"` and its label restored to `autorelease: pending`. Release-please should then parse it successfully, create the v0.2.7 tag + draft release, and trigger the full cargo-dist + PyPI pipeline.

## Trade-off
Release titles will lose the `"arco: "` prefix (e.g., `"v0.2.7"` instead of `"arco: v0.2.7"`). This is cosmetic and can be restored later if release-please fixes the component + include-component-in-tag interaction.

## Test plan
- [ ] Merge this PR
- [ ] Verify release-please processes PR #79 and creates v0.2.7 tag + draft release
- [ ] Verify cargo-dist, py-build, and publish-pypi jobs all run