### PR TITLE
fix(ci): add cargo-dist dependency to py-build to avoid tag race

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -63,6 +63,7 @@ jobs:
       - name: Append install instructions to release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
           TAG: ${{ needs.release-please.outputs.tag_name }}
         run: |
           set -euo pipefail

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -80,7 +80,7 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
-    needs: release-please
+    needs: [release-please, cargo-dist]
     if: needs.release-please.outputs.release_created == 'true'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -100,12 +100,13 @@ jobs:
 
       - name: Build package
         run: uv build
+        working-directory: bindings/python
 
       - name: Store the distribution packages
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: python-package-distributions
-          path: dist/
+          path: bindings/python/dist/
           retention-days: 3
 
   publish-pypi:


### PR DESCRIPTION
## Summary
- Adds `cargo-dist` as a dependency of `py-build` in the release workflow
- With `draft: true`, release-please creates a draft GitHub release but the git tag is only created when the release is published (undrafted)
- cargo-dist's `host` job undrafts the release, creating the tag
- Previously `py-build` only depended on `release-please` and ran in parallel with `cargo-dist`, so it tried to checkout a tag that didn't exist yet

## Test plan
- [ ] Next release: verify py-build runs after cargo-dist completes and checks out the tag successfully