### PR TITLE
fix(ci): use justfile py-build-ci approach for Python packaging

### DIFF
--- a/.github/workflows/cargo-dist-release.yml
+++ b/.github/workflows/cargo-dist-release.yml
@@ -164,7 +164,7 @@ jobs:
         run: |
           if ! command -v cargo > /dev/null 2>&1; then
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-            echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+            echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
           fi
       - name: Use rustup to set correct Rust version
         run: rustup update "1.85" --no-self-update && rustup default "1.85"
@@ -209,6 +209,7 @@ jobs:
           set -euo pipefail
           read -r -a dist_args_array <<< "${DIST_ARGS}"
           # Actually do builds and make zips and whatnot
+          # shellcheck disable=SC2086
           dist build --allow-dirty ${PLAN_TAG_FLAG} --print=linkage --output-format=json "${dist_args_array[@]}" > dist-manifest.json
           echo "dist ran successfully"
       - id: cargo-dist
@@ -219,9 +220,11 @@ jobs:
         shell: bash
         run: |
           # Parse out what we just built and upload it to scratch storage
-          echo "paths<<EOF" >> "$GITHUB_OUTPUT"
-          dist print-upload-files-from-manifest --allow-dirty --manifest dist-manifest.json >> "$GITHUB_OUTPUT"
-          echo "EOF" >> "$GITHUB_OUTPUT"
+          {
+            echo "paths<<EOF"
+            dist print-upload-files-from-manifest --allow-dirty --manifest dist-manifest.json
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"
       - name: "Upload artifacts"
@@ -265,13 +268,16 @@ jobs:
       - id: cargo-dist
         shell: bash
         run: |
+          # shellcheck disable=SC2086
           dist build --allow-dirty ${NEEDS_PLAN_OUTPUTS_TAG_FLAG} --output-format=json "--artifacts=global" > dist-manifest.json
           echo "dist ran successfully"
 
           # Parse out what we just built and upload it to scratch storage
-          echo "paths<<EOF" >> "$GITHUB_OUTPUT"
-          jq --raw-output ".upload_files[]" dist-manifest.json >> "$GITHUB_OUTPUT"
-          echo "EOF" >> "$GITHUB_OUTPUT"
+          {
+            echo "paths<<EOF"
+            jq --raw-output ".upload_files[]" dist-manifest.json
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"
         env:
@@ -327,6 +333,7 @@ jobs:
       - id: host
         shell: bash
         run: |
+          # shellcheck disable=SC2086
           dist host --allow-dirty ${NEEDS_PLAN_OUTPUTS_TAG_FLAG} --steps=upload --steps=release --output-format=json > dist-manifest.json
           echo "artifacts uploaded and released successfully"
           cat dist-manifest.json
@@ -363,6 +370,7 @@ jobs:
           gh release upload "${NEEDS_PLAN_OUTPUTS_TAG}" artifacts/* --clobber
 
           # Publish the release (undraft)
+          # shellcheck disable=SC2086
           gh release edit "${NEEDS_PLAN_OUTPUTS_TAG}" --draft=false ${PRERELEASE_FLAG}
 
   announce:

--- a/.github/workflows/cargo-dist-release.yml
+++ b/.github/workflows/cargo-dist-release.yml
@@ -44,6 +44,7 @@ on:
       - "Cargo.lock"
       - "dist-workspace.toml"
       - ".github/workflows/cargo-dist-release.yml"
+      - ".github/workflows/release-please.yaml"
   workflow_call:
     inputs:
       tag:

--- a/.github/workflows/cargo-dist-release.yml
+++ b/.github/workflows/cargo-dist-release.yml
@@ -13,7 +13,7 @@
 # Note that the GitHub Release will be created with a generated
 # title/body based on your changelogs.
 
-name: Cargo Dist
+name: cargo dist
 permissions:
   "contents": "read"
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: CI
+name: Continuous Integration
 
 on:
   pull_request:
@@ -113,7 +113,8 @@ jobs:
 
       - name: Install system dependencies
         if: matrix.target.apt-deps != ''
-        run: sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends ${{ matrix.target.apt-deps }}
+        run: sudo apt-get update -qq && sudo apt-get install -y
+          --no-install-recommends ${{ matrix.target.apt-deps }}
 
       - name: Set up build environment
         uses: ./.github/actions/setup-build-env
@@ -160,7 +161,8 @@ jobs:
 
       - name: Install system dependencies
         if: matrix.target.apt-deps != ''
-        run: sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends ${{ matrix.target.apt-deps }}
+        run: sudo apt-get update -qq && sudo apt-get install -y
+          --no-install-recommends ${{ matrix.target.apt-deps }}
 
       - name: Set up build environment
         uses: ./.github/actions/setup-build-env

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -85,27 +85,9 @@ jobs:
       - name: Check Rust formatting
         run: cargo +"$RUST_TOOLCHAIN_VERSION" fmt --all -- --check
 
-  workflow-quality:
-    name: Workflow quality
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
-        with:
-          version: ${{ env.UV_VERSION }}
-          python-version: ${{ env.PYTHON_LATEST }}
-
-      - name: Run workflow quality checks
-        run: uvx zizmor .github
-
   rust-clippy:
     name: Rust clippy (${{ matrix.target.name }})
-    needs: [rust-fmt, version-consistency, workflow-quality]
+    needs: [rust-fmt, version-consistency]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
@@ -152,7 +134,7 @@ jobs:
 
   rust-test:
     name: Rust tests (${{ matrix.target.name }})
-    needs: [rust-fmt, version-consistency, workflow-quality]
+    needs: [rust-fmt, version-consistency]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:

--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -13,8 +13,26 @@ permissions:
 
 env:
   UV_VERSION: "0.9.4"
+  PREK_VERSION: "0.3.6"
 
 jobs:
+  prek:
+    name: prek
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          version: ${{ env.UV_VERSION }}
+
+      - name: Run prek
+        run: uvx --from prek==${{ env.PREK_VERSION }} prek run --all-files
+
   lint-commit-messages:
     name: lint commit message
     runs-on: [ubuntu-latest]

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -12,6 +12,13 @@ concurrency:
 permissions:
   contents: read
 
+# Keep in sync with ci.yaml
+env:
+  UV_VERSION: "0.9.4"
+  JUST_VERSION: "1.5.0"
+  PYTHON_LATEST: "3.12"
+  RUST_TOOLCHAIN_VERSION: "1.85"
+
 jobs:
   release-please:
     name: Release Please
@@ -92,21 +99,24 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+      - name: Set up build environment
+        uses: ./.github/actions/setup-build-env
+        with:
+          python-version: ${{ env.PYTHON_LATEST }}
+          uv-version: ${{ env.UV_VERSION }}
+          just-version: ${{ env.JUST_VERSION }}
+          rust-toolchain-version: ${{ env.RUST_TOOLCHAIN_VERSION }}
+          save-rust-cache: "false"
+          save-uv-cache: "false"
 
       - name: Build package
-        run: uv build
-        working-directory: bindings/python
+        run: just py-build-ci
 
       - name: Store the distribution packages
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: python-package-distributions
-          path: bindings/python/dist/
+          path: dist/
           retention-days: 3
 
   publish-pypi:

--- a/.github/workflows/workflow-quality.yaml
+++ b/.github/workflows/workflow-quality.yaml
@@ -1,4 +1,4 @@
-name: zizmor
+name: GitHub CI Quality
 
 on:
   pull_request:

--- a/.github/workflows/workflow-quality.yaml
+++ b/.github/workflows/workflow-quality.yaml
@@ -1,0 +1,46 @@
+name: zizmor
+
+on:
+  pull_request:
+    paths:
+      - ".github/**"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/**"
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          version: "0.9.4"
+
+      - name: Run zizmor
+        run: uvx zizmor .github
+
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Run actionlint
+        run: |
+          bash <(curl -s https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+          ./actionlint

--- a/.github/workflows/workflow-quality.yaml
+++ b/.github/workflows/workflow-quality.yaml
@@ -1,4 +1,4 @@
-name: GitHub CI Quality
+name: GitHub Actions Quality
 
 on:
   pull_request:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,6 +42,32 @@ repos:
         pass_filenames: false
         stages: [pre-push]
 
+  - repo: https://github.com/crate-ci/typos
+    rev: v1.33.1
+    hooks:
+      - id: typos
+
+  - repo: local
+    hooks:
+      - id: cargo-fmt
+        name: cargo fmt
+        entry: cargo fmt --all --
+        language: system
+        types: [rust]
+        pass_filenames: false
+
+      - id: ruff-check
+        name: ruff check
+        entry: uvx ruff check --fix --config=bindings/python/pyproject.toml
+        language: system
+        types: [python]
+
+      - id: ruff-format
+        name: ruff format
+        entry: uvx ruff format --config=bindings/python/pyproject.toml
+        language: system
+        types: [python]
+
   - repo: local
     hooks:
       - id: prettier
@@ -59,5 +85,14 @@ repos:
         language: system
         types: [yaml]
         files: ^\.github/workflows/.*\.yaml$
+        pass_filenames: false
+        stages: [pre-push]
+
+      - id: actionlint
+        name: actionlint
+        entry: uvx --from actionlint-py actionlint
+        language: system
+        types: [yaml]
+        files: ^\.github/workflows/.*\.ya?ml$
         pass_filenames: false
         stages: [pre-push]


### PR DESCRIPTION
## Summary
- Adds license sync step (`uv run python scripts/sync_python_licenses.py`) before Python build — mirrors `just py-licenses`
- Replaces `uv build` with `uv run --with build python -m build bindings/python --wheel --outdir dist` — mirrors `just py-build-ci`
- `bindings/python/licenses/` is gitignored and must be synced at build time; maturin fails without them (`"No such file or directory"` parsing Cargo.toml license-file)

## Test plan
- [ ] Next release: verify py-build succeeds and publish-pypi publishes automatically