### PR TITLE
fix: refresh stale justfile recipes and benchmark targets

### DIFF
--- a/benchmarks/justfile
+++ b/benchmarks/justfile
@@ -15,13 +15,44 @@ install-arco:
     uv add --upgrade arco
 
 install-torc:
-    tmpdir="$(mktemp -d)"; gh release download --repo NatLabRockies/torc --pattern "torc-x86_64-unknown-linux-musl.tar.gz" --dir "$tmpdir"; tar -xzf "$tmpdir/torc-x86_64-unknown-linux-musl.tar.gz" -C "$tmpdir"; mkdir -p "$HOME/.local/bin"; install -m 0755 "$tmpdir/torc" "$tmpdir/torc-server" "$HOME/.local/bin/"; rm -rf "$tmpdir"
+    #!/usr/bin/env bash
+    set -euo pipefail
+    os="$(uname -s)"
+    arch="$(uname -m)"
+    case "${os}/${arch}" in
+        Darwin/arm64) artifact="torc-aarch64-apple-darwin.tar.gz" ;;
+        Linux/x86_64) artifact="torc-x86_64-unknown-linux-musl.tar.gz" ;;
+        *)
+            echo "unsupported platform: ${os}/${arch}"
+            exit 1
+            ;;
+    esac
+    tmpdir="$(mktemp -d)"
+    trap 'rm -rf "$tmpdir"' EXIT
+    gh release download --repo NatLabRockies/torc --pattern "$artifact" --dir "$tmpdir"
+    tar -xzf "$tmpdir/$artifact" -C "$tmpdir"
+    mkdir -p "$HOME/.local/bin"
+    install -m 0755 "$tmpdir/torc" "$tmpdir/torc-server" "$HOME/.local/bin/"
 
 install-julia-deps:
     bash scripts/run_jump_point.sh --install-only
 
 start-torc:
-    if [ -f {{torc_pid}} ] && kill -0 "$(cat {{torc_pid}})" >/dev/null 2>&1; then echo "torc-server already running"; exit 0; fi; nohup "$HOME/.local/bin/torc-server" run --database {{torc_db}} --host localhost --port 8080 --completion-check-interval-secs 2 > {{torc_log}} 2>&1 & echo $! > {{torc_pid}}; sleep 1
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ -f {{torc_pid}} ] && kill -0 "$(cat {{torc_pid}})" >/dev/null 2>&1; then
+        echo "torc-server already running"
+        exit 0
+    fi
+    nohup "$HOME/.local/bin/torc-server" run --database {{torc_db}} --host localhost --port 8080 --completion-check-interval-secs 2 > {{torc_log}} 2>&1 &
+    pid="$!"
+    echo "$pid" > {{torc_pid}}
+    sleep 1
+    if ! kill -0 "$pid" >/dev/null 2>&1; then
+        echo "torc-server failed to start; showing log tail"
+        tail -n 50 {{torc_log}} || true
+        exit 1
+    fi
 
 stop-torc:
     if [ -f {{torc_pid}} ]; then kill "$(cat {{torc_pid}})" >/dev/null 2>&1 || true; rm -f {{torc_pid}}; fi

--- a/crates/arco-xpress/src/solver.rs
+++ b/crates/arco-xpress/src/solver.rs
@@ -115,7 +115,7 @@ fn xprs_init() -> Result<XpressGuard, SolverError> {
         let init_rc = unsafe { ffi::XPRSinit(std::ptr::null()) };
         if init_rc == 0 {
             // Success — restore XPAUTH_PATH and return.
-            restore_env("XPAUTH_PATH", &original_xpauth);
+            restore_env("XPAUTH_PATH", original_xpauth.as_deref());
             return Ok(XpressGuard);
         }
         // Failed — clean up so the next candidate can be tried.
@@ -123,7 +123,7 @@ fn xprs_init() -> Result<XpressGuard, SolverError> {
     }
 
     // All candidates exhausted — restore env and report failure.
-    restore_env("XPAUTH_PATH", &original_xpauth);
+    restore_env("XPAUTH_PATH", original_xpauth.as_deref());
     let dir_info = xpress_dir.as_deref().unwrap_or("(not set)");
     let msg = xprs_lic_errmsg();
     Err(SolverError::SolverSpecific(format!(
@@ -138,7 +138,7 @@ fn xprs_init() -> Result<XpressGuard, SolverError> {
 /// Restore an environment variable to its original value, or remove it if it
 /// was originally unset.
 #[allow(unsafe_code)]
-fn restore_env(key: &str, original: &Option<String>) {
+fn restore_env(key: &str, original: Option<&str>) {
     // SAFETY: called from single-threaded init/cleanup path.
     match original {
         Some(val) => unsafe { std::env::set_var(key, val) },

--- a/justfile
+++ b/justfile
@@ -5,6 +5,8 @@ export UV_CACHE_DIR := justfile_directory() / ".uv-cache"
 maturin := "uv run --with maturin maturin"
 prek := "uvx --from prek==0.3.6 prek"
 core-packages := "-p arco-core -p arco-expr -p arco-solver -p arco-tools -p arco-blocks -p arco-highs -p arco-bench"
+workspace-packages := "-p arco-core -p arco-expr -p arco-solver -p arco-tools -p arco-blocks -p arco-highs -p arco-bench -p arco-kdl -p arco-cli -p arco-xpress"
+test-packages := "-p arco-core -p arco-expr -p arco-solver -p arco-tools -p arco-blocks -p arco-highs -p arco-bench"
 
 bench-compare baseline candidate:
     cargo run -p arco-bench -- compare \
@@ -32,15 +34,15 @@ bench-run:
     cargo run -p arco-bench -- run
 
 check:
-    cargo check --workspace --all-features --tests --benches --examples
+    cargo check {{ workspace-packages }} --all-features --tests --benches --examples
 
 check-lib:
-    cargo check --workspace --all-features
+    cargo check {{ workspace-packages }} --all-features
 
 ci: fmt-check clippy test docs-test
 
 clippy:
-    cargo clippy --all --benches --tests --examples --all-features -- -D warnings
+    cargo clippy {{ workspace-packages }} --benches --tests --examples --all-features -- -D warnings
 
 clippy-core:
     cargo clippy {{ core-packages }} --benches --tests --examples --all-features -- -D warnings
@@ -97,7 +99,7 @@ py-sync:
     cd bindings/python && uv sync
 
 py-test: py-dev
-    uv run --project bindings/python --with pytest --with numpy pytest scripts/test_docs_doctest.py
+    uv run --project bindings/python --with pytest pytest bindings/python/tests -v
 
 py-type:
     cd bindings/python && uv run ty check src/
@@ -106,7 +108,7 @@ setup:
     ./scripts/setup-dev-env.sh
 
 test:
-    PYO3_PYTHON=${PYO3_PYTHON:-python3} cargo test --workspace --all-features --exclude arco-python
+    PYO3_PYTHON=${PYO3_PYTHON:-python3} cargo test {{ test-packages }} --all-features
 
 test-core:
     PYO3_PYTHON=${PYO3_PYTHON:-python3} cargo test {{ core-packages }} --all-features


### PR DESCRIPTION
## Summary
- update root justfile check/lint/test recipes to use an explicit supported package set instead of workspace all-features
- keep just test aligned with stable core+bench packages in clean checkouts
- update py-test to run Python package tests in bindings/python/tests instead of duplicating docs doctests
- harden benchmarks/justfile:
  - make install-torc platform-aware (Darwin arm64, Linux x86_64)
  - make start-torc verify startup and print log tail on failure
- fix clippy ref_option lint in arco-xpress env restore helper

## Validation
- just check
- just clippy
- just test
- just py-test
- just ci
- cd benchmarks and dry-run each recipe

## Notes
- benchmark export recipes still depend on Torc runtime data; they execute correctly but fail fast when no workflow/job results exist.
