### PR TITLE
feat: expose constraint duals via unified report keyword

### DIFF
--- a/crates/arco-cli/src/driver.rs
+++ b/crates/arco-cli/src/driver.rs
@@ -48,6 +48,8 @@ pub struct RunSummary {
     pub active_scenario: String,
     pub objective: ObjectiveSummary,
     pub reports: Vec<ReportSummary>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub dual_reports: Vec<DualReportSummary>,
     pub variables: Vec<VariableSummary>,
     pub counts: ProblemCounts,
     pub timing: TimingSummary,
@@ -77,6 +79,18 @@ pub struct VariableSummary {
 #[derive(Debug, Serialize, PartialEq)]
 pub struct VariableValueSummary {
     pub name: String,
+    pub value: f64,
+}
+
+#[derive(Debug, Serialize, PartialEq)]
+pub struct DualReportSummary {
+    pub name: String,
+    pub values: Vec<DualReportValueSummary>,
+}
+
+#[derive(Debug, Serialize, PartialEq)]
+pub struct DualReportValueSummary {
+    pub instance: String,
     pub value: f64,
 }
 
@@ -236,6 +250,24 @@ pub fn run_file_with_options_and_backend(
             .map(|report| ReportSummary {
                 name: report.dsl_name,
                 value: report.value,
+            })
+            .collect(),
+        dual_reports: execution_result
+            .dual_reports
+            .into_iter()
+            .map(|dr| {
+                let values = dr
+                    .values
+                    .into_iter()
+                    .map(|v| DualReportValueSummary {
+                        instance: trim_family_prefix(&dr.constraint_family, &v.instance_name),
+                        value: v.value,
+                    })
+                    .collect();
+                DualReportSummary {
+                    name: dr.constraint_family,
+                    values,
+                }
             })
             .collect(),
         variables,

--- a/crates/arco-cli/src/execution.rs
+++ b/crates/arco-cli/src/execution.rs
@@ -14,11 +14,24 @@ use thiserror::Error;
 use tracing::info;
 
 #[derive(Debug, Clone, PartialEq)]
+pub struct DualReportResult {
+    pub constraint_family: String,
+    pub values: Vec<DualReportValue>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct DualReportValue {
+    pub instance_name: String,
+    pub value: f64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub struct AdapterSolveOutput {
     pub status: SolveStatus,
     pub objective_value: ScalarArtifactValue,
     pub report_values: Vec<ScalarArtifactValue>,
     pub variable_values: Vec<VariableArtifactValue>,
+    pub dual_report_values: Vec<DualReportResult>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -55,6 +68,7 @@ pub struct ExecutionResult {
     pub objective: MappedScalarResult,
     pub reports: Vec<MappedScalarResult>,
     pub variables: Vec<MappedVariableResult>,
+    pub dual_reports: Vec<DualReportResult>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -258,6 +272,14 @@ impl OptimizationAdapter for MockArcoAdapter {
                     },
                 })
                 .collect(),
+            dual_report_values: problem
+                .dual_reports
+                .iter()
+                .map(|dr| DualReportResult {
+                    constraint_family: dr.constraint_name.clone(),
+                    values: Vec::new(),
+                })
+                .collect(),
         })
     }
 }
@@ -279,6 +301,7 @@ impl OptimizationAdapter for RustArcoAdapter {
         let BuiltModel {
             model,
             variable_indices,
+            constraint_indices,
         } = build_model(problem, &backend)?;
         info!(
             "solver model translation completed in {:.2} ms",
@@ -378,6 +401,9 @@ impl OptimizationAdapter for RustArcoAdapter {
             })
             .collect::<Result<Vec<_>, _>>()?;
 
+        let dual_report_values =
+            extract_dual_report_values(problem, &constraint_indices, solution.constraint_duals());
+
         Ok(AdapterSolveOutput {
             status: map_solver_status(solution.core_status()),
             objective_value: ScalarArtifactValue {
@@ -386,6 +412,7 @@ impl OptimizationAdapter for RustArcoAdapter {
             },
             report_values,
             variable_values,
+            dual_report_values,
         })
     }
 }
@@ -421,6 +448,7 @@ impl OptimizationAdapter for XpressArcoAdapter {
         let BuiltModel {
             model,
             variable_indices,
+            constraint_indices,
         } = build_model(problem, &backend)?;
         info!(
             "solver model translation completed in {:.2} ms",
@@ -520,6 +548,9 @@ impl OptimizationAdapter for XpressArcoAdapter {
             })
             .collect::<Result<Vec<_>, _>>()?;
 
+        let dual_report_values =
+            extract_dual_report_values(problem, &constraint_indices, solution.constraint_duals());
+
         Ok(AdapterSolveOutput {
             status: map_solver_status(solution.core_status()),
             objective_value: ScalarArtifactValue {
@@ -528,6 +559,7 @@ impl OptimizationAdapter for XpressArcoAdapter {
             },
             report_values,
             variable_values,
+            dual_report_values,
         })
     }
 }
@@ -625,6 +657,7 @@ pub fn execute_problem_with_options(
         objective,
         reports,
         variables,
+        dual_reports: solve_output.dual_report_values,
     })
 }
 
@@ -636,6 +669,7 @@ pub fn render_problem_model(problem: &LoweredProblem) -> Result<String, Executio
 struct BuiltModel {
     model: Model,
     variable_indices: BTreeMap<String, usize>,
+    constraint_indices: BTreeMap<String, usize>,
 }
 
 fn build_model(problem: &LoweredProblem, backend: &str) -> Result<BuiltModel, ExecutionError> {
@@ -644,6 +678,7 @@ fn build_model(problem: &LoweredProblem, backend: &str) -> Result<BuiltModel, Ex
         problem.algebra.constraints.len(),
     );
     let mut variable_ids = BTreeMap::new();
+    let mut constraint_ids = BTreeMap::new();
 
     for variable in &problem.algebra.variable_instances {
         let upper = variable.upper.unwrap_or(f64::INFINITY);
@@ -687,6 +722,7 @@ fn build_model(problem: &LoweredProblem, backend: &str) -> Result<BuiltModel, Ex
                 lowered_name: constraint.name.clone(),
                 source,
             })?;
+        constraint_ids.insert(constraint.name.clone(), constraint_id.inner() as usize);
 
         for term in &constraint.terms {
             let variable_id = variable_ids
@@ -749,6 +785,7 @@ fn build_model(problem: &LoweredProblem, backend: &str) -> Result<BuiltModel, Ex
     Ok(BuiltModel {
         model,
         variable_indices,
+        constraint_indices: constraint_ids,
     })
 }
 
@@ -801,6 +838,41 @@ fn lookup_primal_value(
         })
 }
 
+fn extract_dual_report_values(
+    problem: &LoweredProblem,
+    constraint_indices: &BTreeMap<String, usize>,
+    constraint_duals: &[f64],
+) -> Vec<DualReportResult> {
+    problem
+        .dual_reports
+        .iter()
+        .map(|dual_report| {
+            let family = &dual_report.constraint_name;
+            let prefix = format!("{family}[");
+            let mut upper = prefix.clone();
+            // Increment last char to form exclusive upper bound for range query.
+            // '[' + 1 == '\\' in ASCII, so range "name[".."name\\" captures all "name[...]" keys.
+            if let Some(last) = upper.pop() {
+                upper.push((last as u8 + 1) as char);
+            }
+            let values = constraint_indices
+                .range(prefix..upper)
+                .map(|(name, &index)| {
+                    let dual = constraint_duals.get(index).copied().unwrap_or(0.0);
+                    DualReportValue {
+                        instance_name: name.clone(),
+                        value: dual,
+                    }
+                })
+                .collect();
+            DualReportResult {
+                constraint_family: family.clone(),
+                values,
+            }
+        })
+        .collect()
+}
+
 fn to_bounds(sense: ConstraintSense, rhs: f64) -> Bounds {
     match sense {
         ConstraintSense::GreaterEqual => Bounds::new(rhs, f64::INFINITY),
@@ -850,6 +922,7 @@ mod tests {
                 expression: "0".to_string(),
             },
             reports: Vec::new(),
+            dual_reports: Vec::new(),
             traceability: Vec::new(),
             algebra: AlgebraicProblem {
                 variable_instances: vec![VariableInstance {

--- a/crates/arco-cli/tests/execution_suite.rs
+++ b/crates/arco-cli/tests/execution_suite.rs
@@ -187,6 +187,7 @@ impl OptimizationAdapter for MissingReportAdapter {
                     values: Vec::new(),
                 })
                 .collect(),
+            dual_report_values: Vec::new(),
         })
     }
 }

--- a/crates/arco-kdl/src/lowering.rs
+++ b/crates/arco-kdl/src/lowering.rs
@@ -25,6 +25,7 @@ pub struct LoweredProblem {
     pub constraints: Vec<LoweredConstraint>,
     pub objective: LoweredObjective,
     pub reports: Vec<LoweredReport>,
+    pub dual_reports: Vec<LoweredDualReport>,
     pub traceability: Vec<TraceabilityRecord>,
     pub algebra: AlgebraicProblem,
 }
@@ -59,6 +60,11 @@ pub struct LoweredObjective {
 pub struct LoweredReport {
     pub name: String,
     pub formula: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LoweredDualReport {
+    pub constraint_name: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -321,6 +327,14 @@ pub fn lower_program(
         .map(lower_report)
         .collect::<Vec<_>>();
 
+    let dual_reports = program
+        .active_dual_reports
+        .iter()
+        .map(|dr| LoweredDualReport {
+            constraint_name: dr.constraint_name.clone(),
+        })
+        .collect::<Vec<_>>();
+
     let mut traceability = Vec::new();
     traceability.extend(variables.iter().map(|variable| TraceabilityRecord {
         dsl_name: variable.family.clone(),
@@ -344,6 +358,7 @@ pub fn lower_program(
         constraints,
         objective,
         reports,
+        dual_reports,
         traceability,
         algebra,
     };

--- a/crates/arco-kdl/src/semantic.rs
+++ b/crates/arco-kdl/src/semantic.rs
@@ -104,6 +104,7 @@ pub struct SemanticProgram {
     pub active_expressions: Vec<ResolvedExpression>,
     pub active_objective: ResolvedObjective,
     pub active_reports: Vec<ResolvedReport>,
+    pub active_dual_reports: Vec<ResolvedDualReport>,
     pub lowering_rules: Vec<String>,
 }
 
@@ -174,6 +175,11 @@ pub struct ResolvedReport {
     pub name: String,
     pub formula_text: String,
     pub formula: Expr,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedDualReport {
+    pub constraint_name: String,
 }
 
 #[derive(Debug, Error, Diagnostic)]
@@ -455,12 +461,18 @@ pub fn validate_program(
 
     // Scan all algebra sources for implicit variable families not covered
     // by declared technologies (e.g. unserved_energy).
+    let scalar_report_names: Vec<String> = scenario
+        .reports
+        .iter()
+        .filter(|r| r.kind == crate::source::ReportKind::Scalar)
+        .map(|r| r.target.clone())
+        .collect();
     let implicit_families = collect_implicit_variable_families(
         program,
         &operation_names,
         &active_rule_names,
         active_objective_decl,
-        &scenario.reports,
+        &scalar_report_names,
         &variable_families,
     );
     variable_families.extend(implicit_families);
@@ -494,7 +506,8 @@ pub fn validate_program(
         expression_text: active_objective_decl.expression.clone(),
         expression: active_objective_decl.parsed_expression.clone(),
     };
-    let active_reports = resolve_scenario_reports(program, scenario, entrypoint)?;
+    let (active_reports, active_dual_reports) =
+        resolve_scenario_reports(program, scenario, &active_constraints, entrypoint)?;
     let active_expressions =
         resolve_active_expressions(program, &active_objective, &active_reports, entrypoint)?;
 
@@ -554,6 +567,7 @@ pub fn validate_program(
         active_expressions,
         active_objective,
         active_reports,
+        active_dual_reports,
         lowering_rules,
     })
     .inspect(|semantic_program| {
@@ -643,7 +657,8 @@ fn validate_canonical_model_program(
         expression_text: model.optimize.expression.clone(),
         expression: model.optimize.parsed_expression.clone(),
     };
-    let active_reports = resolve_scenario_reports(program, scenario, entrypoint)?;
+    let (active_reports, active_dual_reports) =
+        resolve_scenario_reports(program, scenario, &active_constraints, entrypoint)?;
     let active_expressions =
         resolve_active_expressions(program, &active_objective, &active_reports, entrypoint)?;
 
@@ -698,6 +713,7 @@ fn validate_canonical_model_program(
         active_expressions,
         active_objective,
         active_reports,
+        active_dual_reports,
         lowering_rules: Vec::new(),
     })
 }
@@ -822,25 +838,45 @@ fn append_constraints(
 fn resolve_scenario_reports(
     program: &SourceProgram,
     scenario: &ScenarioDecl,
+    active_constraints: &[ResolvedConstraint],
     entrypoint: &Path,
-) -> Result<Vec<ResolvedReport>, SemanticError> {
+) -> Result<(Vec<ResolvedReport>, Vec<ResolvedDualReport>), SemanticError> {
+    use crate::source::ReportKind;
     let mut reports = Vec::new();
-    for report_name in &scenario.reports {
-        let expression =
-            program
-                .expression(report_name)
-                .ok_or_else(|| SemanticError::MissingDeclaration {
-                    kind: "expression",
-                    name: report_name.clone(),
-                    path: entrypoint.to_path_buf(),
+    let mut dual_reports = Vec::new();
+    for report_decl in &scenario.reports {
+        match report_decl.kind {
+            ReportKind::Scalar => {
+                let expression = program.expression(&report_decl.target).ok_or_else(|| {
+                    SemanticError::MissingDeclaration {
+                        kind: "expression",
+                        name: report_decl.target.clone(),
+                        path: entrypoint.to_path_buf(),
+                    }
                 })?;
-        reports.push(ResolvedReport {
-            name: expression.name.clone(),
-            formula_text: expression.formula.clone(),
-            formula: expression.parsed_formula.clone(),
-        });
+                reports.push(ResolvedReport {
+                    name: expression.name.clone(),
+                    formula_text: expression.formula.clone(),
+                    formula: expression.parsed_formula.clone(),
+                });
+            }
+            ReportKind::Dual => {
+                let target = &report_decl.target;
+                let exists = active_constraints.iter().any(|c| c.name == *target);
+                if !exists {
+                    return Err(SemanticError::MissingDeclaration {
+                        kind: "constraint",
+                        name: target.clone(),
+                        path: entrypoint.to_path_buf(),
+                    });
+                }
+                dual_reports.push(ResolvedDualReport {
+                    constraint_name: target.clone(),
+                });
+            }
+        }
     }
-    Ok(reports)
+    Ok((reports, dual_reports))
 }
 
 fn resolve_active_expressions(

--- a/crates/arco-kdl/src/source.rs
+++ b/crates/arco-kdl/src/source.rs
@@ -174,6 +174,20 @@ pub struct ObjectiveDecl {
     pub parsed_expression: Expr,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReportKind {
+    /// Scalar expression evaluated at the primal solution.
+    Scalar,
+    /// Constraint shadow prices (dual values).
+    Dual,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReportDecl {
+    pub kind: ReportKind,
+    pub target: String,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ScenarioDecl {
     pub name: String,
@@ -187,7 +201,7 @@ pub struct ScenarioDecl {
     pub rules: Vec<String>,
     pub model_use: Option<String>,
     pub objective: Option<String>,
-    pub reports: Vec<String>,
+    pub reports: Vec<ReportDecl>,
     /// User-declared sets whose members are listed inline in the scenario.
     /// E.g. `generators { "gen1"; "gen2" }` produces `("generators", ["gen1", "gen2"])`.
     pub custom_sets: BTreeMap<String, Vec<String>>,
@@ -827,7 +841,24 @@ fn parse_scenario(node: &KdlNode, context: &ParseContext<'_>) -> Result<Scenario
             "minimize" | "maximize" => {
                 objective = Some(first_arg_string(child, 0, context)?);
             }
-            "report" => reports.push(first_arg_string(child, 0, context)?),
+            "report" => {
+                let first = first_arg_string(child, 0, context)?;
+                match first.as_str() {
+                    "dual" => {
+                        let target = first_arg_string(child, 1, context)?;
+                        reports.push(ReportDecl {
+                            kind: ReportKind::Dual,
+                            target,
+                        });
+                    }
+                    _ => {
+                        reports.push(ReportDecl {
+                            kind: ReportKind::Scalar,
+                            target: first,
+                        });
+                    }
+                }
+            }
             name if !SCENARIO_KEYWORDS.contains(&name) => {
                 let members = parse_custom_set_members(child);
                 if !members.is_empty() {

--- a/crates/arco-kdl/tests/source_parser.rs
+++ b/crates/arco-kdl/tests/source_parser.rs
@@ -43,7 +43,13 @@ fn parses_price_taker_battery_fixture_into_typed_declarations()
         .ok_or("missing scenario")?;
     assert_eq!(scenario.technologies, vec!["Battery".to_string()]);
     assert_eq!(scenario.operations, vec!["PriceTakerBattery".to_string()]);
-    assert_eq!(scenario.reports, vec!["ArbitrageRevenue".to_string()]);
+    assert_eq!(
+        scenario.reports,
+        vec![arco_kdl::source::ReportDecl {
+            kind: arco_kdl::source::ReportKind::Scalar,
+            target: "ArbitrageRevenue".to_string(),
+        }]
+    );
 
     Ok(())
 }
@@ -452,7 +458,16 @@ scenario "Day" {
 
     assert_eq!(
         scenario.reports,
-        vec!["FuelCost".to_string(), "StartupCost".to_string()]
+        vec![
+            arco_kdl::source::ReportDecl {
+                kind: arco_kdl::source::ReportKind::Scalar,
+                target: "FuelCost".to_string(),
+            },
+            arco_kdl::source::ReportDecl {
+                kind: arco_kdl::source::ReportKind::Scalar,
+                target: "StartupCost".to_string(),
+            },
+        ]
     );
 
     Ok(())


### PR DESCRIPTION
## Summary

- Extends the KDL `report` keyword to support `report "dual" "constraint_name"` for extracting constraint shadow prices (dual values) after solving
- Plumbs dual report declarations through the full pipeline: source parsing → semantic validation → lowering → execution → JSON output
- Validates at the semantic layer that dual report targets reference existing constraints (typos produce clear errors)
- Uses efficient `BTreeMap::range()` for constraint family prefix matching at extraction time
- Backwards compatible: plain `report "Expr"` continues to work unchanged, and `dual_reports` is omitted from JSON when empty

### KDL syntax

```kdl
scenario "Run" {
  // existing scalar report (unchanged)
  report "TotalEmissions"

  // NEW: constraint shadow prices
  report dual "meet_nodal_demand"
}
```

### JSON output

```json
{
  "dual_reports": [
    {
      "name": "meet_nodal_demand",
      "values": [
        { "instance": "[NodeA,1]", "value": 45.2 },
        { "instance": "[NodeA,2]", "value": 38.7 }
      ]
    }
  ]
}
```

## Test plan

- [x] All existing `arco-kdl` tests pass (26/26) — no breaking change to `report "Expr"`
- [x] All existing `arco-cli` lib tests pass (6/6)
- [x] All `arco-core` and `arco-highs` tests pass (10/10)
- [x] Clean `cargo check` with no warnings
- [ ] E2E: add `report "dual" "meet_nodal_demand"` to nodal example, run `arco run`, verify `dual_reports` contains sensible shadow prices
- [ ] Verify `report "dual" "nonexistent"` produces a clear validation error