### PR TITLE
docs(readme): horizontal nav bar (r2x-cli style)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,16 @@ The name stands for **Assembled Resource-Constrained Optimization** to reflect
 both the memory-focused design and the API ideas assembled from multiple
 optimization ecosystems.
 
+<p align="center">
+  <a href="#philosophy">Philosophy</a> ·
+  <a href="#at-a-glance">At a Glance</a> ·
+  <a href="#quickstart">Quickstart</a> ·
+  <a href="#api-comparison">API</a> ·
+  <a href="#features-and-roadmap">Features</a> ·
+  <a href="#benchmarking">Benchmarking</a> ·
+  <a href="#contributing">Contributing</a>
+</p>
+
 ## Philosophy
 
 Arco is built for harder optimization problems on constrained resources. We are


### PR DESCRIPTION
Convert the README to use a horizontal navigation bar matching the r2x-cli style.

Adds a centered navigation bar with links to major sections, using · as separators for a clean visual style.