### PR TITLE
docs(readme): horizontal nav bar (r2x-cli style)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,16 @@ The name stands for **Assembled Resource-Constrained Optimization** to reflect
 both the memory-focused design and the API ideas assembled from multiple
 optimization ecosystems.
 
+<p align="center">
+  <a href="#philosophy">Philosophy</a> ·
+  <a href="#at-a-glance">At a Glance</a> ·
+  <a href="#quickstart">Quickstart</a> ·
+  <a href="#api-comparison">API</a> ·
+  <a href="#features-and-roadmap">Features</a> ·
+  <a href="#benchmarking">Benchmarking</a> ·
+  <a href="#contributing">Contributing</a>
+</p>
+
 ## Philosophy
 
 Arco is built for harder optimization problems on constrained resources. We are


### PR DESCRIPTION
Updates the README to use a horizontal navigation bar matching the r2x-cli style.

Changes:
- Added centered navigation bar with · separators between links
- Links to major sections: Philosophy, At a Glance, Quickstart, API, Features, Benchmarking, Contributing

This is a fresh PR replacing the closed #114.