### PR TITLE
feat(tree-sitter): add highlight queries for arco_kdl parser

### DIFF
--- a/tools/tree-sitter-arco-kdl/queries/highlights.scm
+++ b/tools/tree-sitter-arco-kdl/queries/highlights.scm
@@ -1,0 +1,57 @@
+; Arco KDL Tree-sitter Highlight Queries
+; Extends base KDL with Arco-specific node highlighting
+
+; Types
+(node (identifier) @type)
+(type) @type
+(annotation_type) @type.builtin
+
+; Properties
+(prop (identifier) @property)
+
+; Variables
+(identifier) @variable
+
+; Operators
+[
+  "="
+  "+"
+  "-"
+] @operator
+
+; Literals
+(string) @string
+(escape) @string.escape
+(number) @number
+(boolean) @boolean
+"null" @constant.builtin
+
+; Punctuation
+[
+  "{"
+  "}"
+  "("
+  ")"
+] @punctuation.bracket
+
+[
+  ";"
+] @punctuation.delimiter
+
+; Comments
+(single_line_comment) @comment
+(multi_line_comment) @comment
+
+; Arco-specific nodes (arco_kdl extension over base KDL)
+(arco_math_node
+  name: (
+    "constraint"
+    "expression"
+    "minimize"
+    "maximize"
+    "expr"
+    "lower"
+    "upper"
+  ) @keyword.function)
+
+(arco_math_text) @string.special


### PR DESCRIPTION
Adds syntax highlighting queries for the arco_kdl tree-sitter parser.

## Changes
- Added `highlights.scm` to `tools/tree-sitter-arco-kdl/queries/`
- Provides syntax highlighting for base KDL nodes (types, properties, literals, etc.)
- Highlights Arco-specific math nodes (`constraint`, `expression`, `minimize`, `maximize`, etc.) as `@keyword.function`
- Highlights math text content as `@string.special`

## Context
This allows Neovim users to install the arco_kdl parser via nvim-treesitter with full syntax highlighting support. The queries extend the base KDL grammar with Arco-specific node types.

## Testing
- [ ] Parser installs successfully with `:TSInstall arco_kdl`
- [ ] Syntax highlighting works in Neovim
- [ ] Arco-specific nodes are highlighted correctly

Related: tree-sitter parser setup for arco KDL surface syntax.