### PR TITLE
fix(tree-sitter): correct highlight queries to match grammar node names

### DIFF
--- a/tools/tree-sitter-arco-kdl/queries/highlights.scm
+++ b/tools/tree-sitter-arco-kdl/queries/highlights.scm
@@ -43,15 +43,19 @@
 (multi_line_comment) @comment
 
 ; Arco-specific nodes (arco_kdl extension over base KDL)
-(arco_math_node
+(arco_pure_math_node
   name: (
-    "constraint"
     "expression"
     "minimize"
     "maximize"
     "expr"
+    "filter"
+    "if"
     "lower"
     "upper"
   ) @keyword.function)
+
+(arco_constraint_node
+  name: "constraint" @keyword.function)
 
 (arco_math_text) @string.special


### PR DESCRIPTION
Fixes the highlight queries to use correct node names from the grammar.

## Problem
The highlight queries referenced non-existent nodes:
- `arco_math_node` doesn't exist in grammar
- Missing `filter` and `if` keywords from `arco_pure_math_node`

## Changes
- `arco_math_node` → `arco_pure_math_node` (with correct keywords: expression, minimize, maximize, expr, **filter**, **if**, lower, upper)
- Added `arco_constraint_node` for `constraint` keyword
- Separated constraint highlighting from pure math nodes

## Before (broken)
```scheme
(arco_math_node  ; ❌ node doesn't exist
  name: (constraint expression ...) @keyword.function)
```

## After (fixed)
```scheme
(arco_pure_math_node
  name: (expression minimize maximize expr filter if lower upper) @keyword.function)

(arco_constraint_node
  name: constraint @keyword.function)
```

## Testing
- [ ] Highlighting works for expression/minimize/maximize nodes
- [ ] Highlighting works for constraint nodes
- [ ] Highlighting works for filter/if keywords

Related: PR #131 which added the initial highlight queries.