### PR TITLE
style(kdl): fix consistency across all example KDL files

### DIFF
--- a/crates/arco-kdl/src/source/parser.rs
+++ b/crates/arco-kdl/src/source/parser.rs
@@ -10,7 +10,7 @@ use crate::source::parser_helpers::{
     ParseContext, algebra_error, algebra_text_from_node, declaration_indices, first_arg_string,
     invalid_value_error, missing_node_error, optional_property_literal, optional_property_string,
     parse_optimize, parse_optional_filter_expression, parse_reduce, positional_value,
-    property_string,
+    property_string_alternatives,
 };
 use crate::source::surface::normalize_surface_syntax;
 use kdl::{KdlDocument, KdlNode, KdlValue};
@@ -176,7 +176,8 @@ fn parse_data(node: &KdlNode, context: &ParseContext<'_>) -> Result<DataDecl, So
 
     Ok(DataDecl {
         name: first_arg_string(node, 0, context)?,
-        source: property_string(node, "from", context)?,
+        // Support both `source=` (new) and `from=` (legacy) for data file paths
+        source: property_string_alternatives(node, &["source", "from"], context)?,
         maps,
         sets,
         indices,
@@ -404,7 +405,8 @@ fn parse_scenario(node: &KdlNode, context: &ParseContext<'_>) -> Result<Scenario
                 }
                 data.push(DataBindingDecl {
                     name: first_arg_string(child, 0, context)?,
-                    source: property_string(child, "from", context)?,
+                    // Support both `source=` (new) and `from=` (legacy) for data file paths
+                    source: property_string_alternatives(child, &["source", "from"], context)?,
                 });
             }
             "use" => model_use = Some(first_arg_string(child, 0, context)?),

--- a/crates/arco-kdl/src/source/parser_helpers.rs
+++ b/crates/arco-kdl/src/source/parser_helpers.rs
@@ -219,6 +219,22 @@ pub(super) fn property_string(
         .ok_or_else(|| missing_property_error(node, property, context))
 }
 
+/// Try multiple property names in order, returning the first match.
+/// For backward compatibility during property renaming transitions.
+pub(super) fn property_string_alternatives(
+    node: &KdlNode,
+    properties: &[&'static str],
+    context: &ParseContext<'_>,
+) -> Result<String, SourceError> {
+    for property in properties {
+        if let Some(value) = node.get(*property).and_then(KdlValue::as_string) {
+            return Ok(value.to_string());
+        }
+    }
+    // Error uses the first (preferred) property name
+    Err(missing_property_error(node, properties[0], context))
+}
+
 pub(super) fn optional_property_string(
     node: &KdlNode,
     property: &'static str,

--- a/docs/arco-spec.md
+++ b/docs/arco-spec.md
@@ -246,7 +246,7 @@ param big_m 1e6
 set bus { 1; 2; 3; 4; 5 }
 
 // CSV-backed data with subsets via set { in ... }
-data generators from="data/generators.csv" {
+data generators source="data/generators.csv" {
   set gen
   set solar { in gen; filter { type == solar } }
   param pmax index=gen
@@ -258,7 +258,7 @@ model dispatch_model {
 
 scenario day_ahead {
   use dispatch_model
-  data demand from="data/demand.csv"
+  data demand source="data/demand.csv"
 }
 ```
 
@@ -337,7 +337,7 @@ document can reference them by name. A single `data` block can supply sets and
 parameters to multiple models.
 
 ```
-data <name> from=<path> { ... }
+data <name> source=<path> { ... }
 ```
 
 Required properties:
@@ -382,7 +382,7 @@ Semantics:
 
 `set` extracts unique values from a dataset column and exposes them as a named
 domain. The column used is the one matching `<name>` (after `map` resolution).
-Unlike `param`, `set` declarations inside a `data` block do not accept a `from=`
+Unlike `param`, `set` declarations inside a `data` block do not accept a `source=`
 property; the set name itself determines the column. Sets declared inside a
 `data` block are globally visible and can be referenced by any model,
 constraint, or algebra expression in the document.
@@ -492,7 +492,7 @@ Semantics:
 
 ```kdl
 // valid: multi-column index on a single declaration
-data plants from="data/plants.csv" {
+data plants source="data/plants.csv" {
   set plant_id
   set unit_id { in plant_id }
   index plant_id unit_id
@@ -500,7 +500,7 @@ data plants from="data/plants.csv" {
 }
 
 // INVALID: two separate index declarations
-data plants from="data/plants.csv" {
+data plants source="data/plants.csv" {
   set plant_id
   set unit_id
   index plant_id
@@ -548,7 +548,7 @@ g3,150,9.8
 ```
 
 ```kdl
-data generators from="data/generators.csv" {
+data generators source="data/generators.csv" {
   set gen_id
   // reads from the "capacity_mw" column (name matches)
   param capacity_mw index=gen_id
@@ -673,7 +673,7 @@ discount_rate,value_of_lost_load
 ```
 
 ```kdl
-data settings from="data/settings.csv" {
+data settings source="data/settings.csv" {
   // column name matches param name, no from= needed
   param discount_rate
   // column name differs, use source= to read "value_of_lost_load" as "voll"
@@ -787,7 +787,7 @@ set <name> alias=<short>
 
 ```arco
 // data declares gen, capacity_mw, fuel_cost, and the thermal_gen subset
-data generators from="data/generators.csv" {
+data generators source="data/generators.csv" {
   map gen from=generator_id
   set gen alias=g
   set thermal_gen { in gen; filter { type == thermal } }
@@ -1345,7 +1345,7 @@ data and activates execution.
 ```
 scenario <name> {
   use <model_name>
-  data <name> from=<path>
+  data <name> source=<path>
   report <expression_name>
   report dual <constraint_name>
 }
@@ -1361,13 +1361,13 @@ share mutable state with other scenarios.
 ```kdl
 scenario distance_check {
   use distance_model
-  data distances from="data/distances.csv"
+  data distances source="data/distances.csv"
 }
 
 scenario day_ahead {
   use dispatch_model
-  data demand from="data/demand.csv"
-  data gen_data from="data/generators.csv"
+  data demand source="data/demand.csv"
+  data gen_data source="data/generators.csv"
 }
 ```
 
@@ -1387,14 +1387,14 @@ declarations MUST NOT have a child block (`{ ... }`). They are simple
 name-to-CSV bindings, not namespaced declarations like top-level `data` blocks.
 
 ```kdl
-data demand from="data/demand.csv"
-data capacity from="data/capacity.csv"
-data fuel_cost from="data/fuel_cost.csv"
+data demand source="data/demand.csv"
+data capacity source="data/capacity.csv"
+data fuel_cost source="data/fuel_cost.csv"
 ```
 
 The `<name>` of each binding MUST match either a `param` declared in the
 referenced model or a `param` declared in a top-level `data` block. Top-level
-`data` block params are already resolved from their own `from=` path and do not
+`data` block params are already resolved from their own `source=` path and do not
 need scenario-level bindings, but a scenario MAY override them by providing a
 binding with the same param name (see [§7.4](#74-data-scoping) for override
 rules). Scenario `data` bindings that match neither a model param nor a
@@ -1416,7 +1416,7 @@ Column-to-index matching:
 5. Missing required columns (index sets or value column) MUST fail validation.
 
 Example: A model declares `param demand { index region; index time }`. The
-scenario binds `data demand from="data/demand.csv"`. The CSV MUST contain
+scenario binds `data demand source="data/demand.csv"`. The CSV MUST contain
 columns `region`, `time`, and `demand` (or the column specified by `from`). Each
 row provides one value of `demand` for a `(region, time)` pair.
 
@@ -1518,7 +1518,7 @@ param, so users are aware of the override:
 
 ```kdl
 // top-level: declares a param named "demand" inside block "demand_data"
-data demand_data from="data/demand_base.csv" {
+data demand_data source="data/demand_base.csv" {
   set region
   param demand index=region
 }
@@ -1526,7 +1526,7 @@ data demand_data from="data/demand_base.csv" {
 scenario stress_test {
   use dispatch_model
   // overrides the "demand" param (originally from demand_data) for this scenario
-  data demand from="data/demand_stress.csv"
+  data demand source="data/demand_stress.csv"
 }
 ```
 
@@ -1563,12 +1563,12 @@ If two CSV files have a column with the same logical name, use `from=` to give
 them distinct param names, or consolidate into one `data` block:
 
 ```kdl
-data generators from="data/generators.csv" {
+data generators source="data/generators.csv" {
   set gen_id
   // reads from CSV column "capacity", exposes as "gen_capacity" in algebra
   param gen_capacity from=capacity index=gen_id
 }
-data lines from="data/lines.csv" {
+data lines source="data/lines.csv" {
   set line_id
   // reads from CSV column "capacity", exposes as "line_capacity" in algebra
   param line_capacity from=capacity index=line_id
@@ -1579,7 +1579,7 @@ data lines from="data/lines.csv" {
 
 ```arco
 // sets and params here are globally visible to all models
-data units from="data/units.csv" {
+data units source="data/units.csv" {
   set plant_id
   set unit_id alias=u { in plant_id }
   param capacity_mw index=unit_id
@@ -1619,13 +1619,13 @@ model planning_model {
 scenario base_case {
   use dispatch_model
   // only available in this scenario
-  data demand from="data/demand_base.csv"
+  data demand source="data/demand_base.csv"
 }
 
 scenario high_demand {
   use dispatch_model
   // different demand for this scenario
-  data demand from="data/demand_high.csv"
+  data demand source="data/demand_high.csv"
 }
 ```
 
@@ -1704,7 +1704,7 @@ Rules:
   `map` resolution) on the left-hand side of each comparison.
 
 ```arco
-data generators from="data/generators.csv" {
+data generators source="data/generators.csv" {
   set gen
   set thermal { in gen; filter { type == thermal } }
   set large { in gen; filter { capacity >= 200 } }
@@ -2455,7 +2455,7 @@ for the component domains and use a multi-column `index` to define the composite
 key:
 
 ```kdl
-data branch_data from="data/branches.csv" {
+data branch_data source="data/branches.csv" {
   // CSV has columns: from_bus, to_bus, capacity, ...
   set from_bus
   set to_bus

--- a/docs/arco-spec.md
+++ b/docs/arco-spec.md
@@ -32,7 +32,7 @@ Scope of this specification:
 
 ## 1. Conformance
 
-Arco KDL files MUST conform to [KDL 2.0](https://kdl.dev/spec/):
+Arco files are KDL-based with non-KDL subgrammars. The structural layer MUST conform to [KDL 2.0](https://kdl.dev/spec/) everywhere Arco does not define an algebra or predicate subgrammar:
 
 - UTF-8 encoding
 - KDL node/value type annotations are allowed
@@ -337,12 +337,12 @@ document can reference them by name. A single `data` block can supply sets and
 parameters to multiple models.
 
 ```
-data <name> from=<path> { ... }
+data <name> source=<path> { ... }
 ```
 
 Required properties:
 
-- `from`: CSV file path. Relative paths are resolved from the directory
+- `source`: CSV file path. Relative paths are resolved from the directory
   containing the `.kdl` file being parsed. Absolute paths are also accepted.
 
 CSV parsing: Arco expects RFC 4180-compliant CSV files (comma-delimited,
@@ -492,7 +492,7 @@ Semantics:
 
 ```kdl
 // valid: multi-column index on a single declaration
-data plants from="data/plants.csv" {
+data plants source="data/plants.csv" {
   set plant_id
   set unit_id { in plant_id }
   index plant_id unit_id
@@ -500,7 +500,7 @@ data plants from="data/plants.csv" {
 }
 
 // INVALID: two separate index declarations
-data plants from="data/plants.csv" {
+data plants source="data/plants.csv" {
   set plant_id
   set unit_id
   index plant_id
@@ -548,7 +548,7 @@ g3,150,9.8
 ```
 
 ```kdl
-data generators from="data/generators.csv" {
+data generators source="data/generators.csv" {
   set gen_id
   // reads from the "capacity_mw" column (name matches)
   param capacity_mw index=gen_id
@@ -673,7 +673,7 @@ discount_rate,value_of_lost_load
 ```
 
 ```kdl
-data settings from="data/settings.csv" {
+data settings source="data/settings.csv" {
   // column name matches param name, no from= needed
   param discount_rate
   // column name differs, use from= to read "value_of_lost_load" as "voll"
@@ -1324,8 +1324,9 @@ scenario <name> {
 Every `scenario` MUST contain exactly one `use` declaration. When multiple
 `scenario` declarations exist in a document, the execution order is
 implementation-defined. Implementations MAY execute scenarios in parallel or
-sequentially. Each scenario is independent and MUST NOT share mutable state with
-other scenarios.
+sequentially. Authors MUST NOT rely on declaration order or any implicit
+execution ordering across scenarios. Each scenario is independent and MUST NOT
+share mutable state with other scenarios.
 
 ```kdl
 scenario distance_check {
@@ -1673,7 +1674,7 @@ Rules:
   `map` resolution) on the left-hand side of each comparison.
 
 ```arco
-data generators from="data/generators.csv" {
+data generators source="data/generators.csv" {
   set gen
   set thermal { in gen; filter { type == thermal } }
   set large { in gen; filter { capacity >= 200 } }
@@ -1739,8 +1740,8 @@ Quick-reference index:
 | 46  | Inline selector           | Inline selector data ref must resolve to `data` block                             |
 | 47  | Inline selector           | Inline selector fields must resolve to data columns                               |
 | 48  | Ergonomic profile         | `use_data` must resolve to top-level `data` block                                 |
-| 49  | _(removed)_               | _(`bounds` is now a canonical `control` child; see rules 60, 68)_                 |
-| 50  | _(removed)_               | _(subsumed by rules 60 and 68)_                                                   |
+| 49  | Reserved                  | Former `bounds`-related slot; see rules 60 and 68                                 |
+| 50  | Reserved                  | Reserved for historical numbering stability                                       |
 | 51  | Top-level set members     | Duplicate members in top-level `set`                                              |
 | 52  | Literal type restrictions | Boolean/string literals outside predicate contexts                                |
 | 53  | Expression/objective      | Comparison operators in expression/objective bodies                               |

--- a/docs/arco-spec.md
+++ b/docs/arco-spec.md
@@ -125,9 +125,9 @@ forms are equivalent:
 
 ```kdl
 // positional (preferred)
-param capacity_mw source=cap_mw index=gen
+param capacity_mw from=cap_mw index=gen
 // explicit name property (also valid)
-param name=capacity_mw source=cap_mw index=gen
+param name=capacity_mw from=cap_mw index=gen
 ```
 
 This applies to all named declarations: `set`, `data`, `model`, `scenario`,
@@ -368,12 +368,12 @@ Allowed children:
 
 ```
 map <logical_name>
-map <logical_name> source=<source_header>
+map <logical_name> from=<source_header>
 ```
 
 Semantics:
 
-- If `source` is omitted, source header defaults to `<logical_name>`. The column
+- If `from` is omitted, source header defaults to `<logical_name>`. The column
   MUST exist in the CSV.
 - Mapping is optional. Unmapped columns remain available.
 - Duplicate logical targets MUST fail validation.
@@ -513,16 +513,16 @@ data plants source="data/plants.csv" {
 `param` projects values from CSV columns into named parameters.
 
 By default, the param name is used to match the CSV column header. If the CSV
-column has a different name, use `source=<column>` to specify which CSV column
+column has a different name, use `from=<column>` to specify which CSV column
 supplies the values. The param's logical name (used in algebra) is always the
-`<name>` given to the `param` declaration. `source=` only controls where the data
+`<name>` given to the `param` declaration. `from=` only controls where the data
 is read from.
 
 Single-dimension indexing (property form):
 
 ```
 param <name>
-param <name> source=<csv_column>
+param <name> from=<csv_column>
 param <name> index=<set>
 param <name> { index <set> }
 ```
@@ -531,7 +531,7 @@ Multi-dimension indexing (child node form):
 
 ```
 param <name> { index <set_a>; index <set_b> }
-param <name> source=<csv_column> { index <set_a>; index <set_b> }
+param <name> from=<csv_column> { index <set_a>; index <set_b> }
 ```
 
 `<set>` references in the `index=` property and `index` children MAY use either
@@ -553,7 +553,7 @@ data generators source="data/generators.csv" {
   // reads from the "capacity_mw" column (name matches)
   param capacity_mw index=gen_id
   // reads from the "heat_rate" column but exposes it as "hr" in algebra
-  param hr source=heat_rate index=gen_id
+  param hr from=heat_rate index=gen_id
 }
 ```
 
@@ -611,7 +611,7 @@ depend on runtime data, so those errors occur at solve time (see
 Filtering:
 
 ```
-param <name> source=<field> { filter { <predicate> } }
+param <name> from=<field> { filter { <predicate> } }
 ```
 
 The `filter` block uses the same bare-math algebra syntax as `set` filters and
@@ -620,8 +620,8 @@ constraint `if` blocks:
 Given a CSV with columns `gen_id`, `capacity_mw`, and `prime_mover`:
 
 ```arco
-param cc_capacity source=capacity_mw { filter { prime_mover == CC } }
-param large_units source=capacity_mw { filter { capacity_mw >= 200 } }
+param cc_capacity from=capacity_mw { filter { prime_mover == CC } }
+param large_units from=capacity_mw { filter { capacity_mw >= 200 } }
 ```
 
 Order of operations when `filter` and `reduce` are combined: filtering is
@@ -629,7 +629,7 @@ applied first, then the reducer operates on the filtered rows. For example:
 
 ```arco
 // first filter to thermal rows, then sum their capacity
-param total_thermal_cap source=capacity_mw index=region reduce=sum {
+param total_thermal_cap from=capacity_mw index=region reduce=sum {
   filter { type == thermal }
 }
 ```
@@ -674,10 +674,10 @@ discount_rate,value_of_lost_load
 
 ```kdl
 data settings source="data/settings.csv" {
-  // column name matches param name, no source= needed
+  // column name matches param name, no from= needed
   param discount_rate
   // column name differs, use source= to read "value_of_lost_load" as "voll"
-  param voll source=value_of_lost_load units="$/MWh"
+  param voll from=value_of_lost_load units="$/MWh"
 }
 ```
 
@@ -788,7 +788,7 @@ set <name> alias=<short>
 ```arco
 // data declares gen, capacity_mw, fuel_cost, and the thermal_gen subset
 data generators source="data/generators.csv" {
-  map gen source=generator_id
+  map gen from=generator_id
   set gen alias=g
   set thermal_gen { in gen; filter { type == thermal } }
   param capacity_mw index=gen
@@ -1566,12 +1566,12 @@ them distinct param names, or consolidate into one `data` block:
 data generators source="data/generators.csv" {
   set gen_id
   // reads from CSV column "capacity", exposes as "gen_capacity" in algebra
-  param gen_capacity source=capacity index=gen_id
+  param gen_capacity from=capacity index=gen_id
 }
 data lines source="data/lines.csv" {
   set line_id
   // reads from CSV column "capacity", exposes as "line_capacity" in algebra
-  param line_capacity source=capacity index=line_id
+  param line_capacity from=capacity index=line_id
 }
 ```
 
@@ -1643,8 +1643,8 @@ Node annotation:
 Typed value literals in filters:
 
 ```arco
-param large_units source=capacity_mw { filter { capacity_mw >= (f64)200 } }
-param cc_capacity source=capacity_mw { filter { prime_mover == (prime_mover)CC } }
+param large_units from=capacity_mw { filter { capacity_mw >= (f64)200 } }
+param cc_capacity from=capacity_mw { filter { prime_mover == (prime_mover)CC } }
 ```
 
 Typed metadata values:
@@ -1729,8 +1729,8 @@ Quick-reference index:
 | 5   | Name uniqueness           | Duplicate `set` names within one `data` block                                     |
 | 6   | Name uniqueness           | Set name collisions across `data` blocks                                          |
 | 7   | Name uniqueness           | Param name collisions across `data` blocks                                        |
-| 8   | Column resolution         | `map` without `source` must match CSV column                                      |
-| 9   | Column resolution         | Unknown source columns in `map source=` or `param source=`                        |
+| 8   | Column resolution         | `map` without `from` must match CSV column                                        |
+| 9   | Column resolution         | Unknown source columns in `map from=` or `param from=`                            |
 | 10  | Column resolution         | Unknown set references in `index=` property or `index` children                   |
 | 11  | Set hierarchy             | `in` parent must resolve (see [rule 32](#10-validation-requirements) for scoping) |
 | 12  | Set hierarchy             | `in` cycles detected                                                              |

--- a/docs/arco-spec.md
+++ b/docs/arco-spec.md
@@ -95,7 +95,7 @@ KDL features used by Arco (structural layer):
   `scenario`, `control`, `expression`, `constraint`, `minimize`, `maximize`)
   maps to a KDL node. Nested structure uses KDL child blocks (`{ ... }`).
 - Arguments and properties: positional arguments carry names and values; named
-  properties carry options (`from=`, `index=`, `alias=`, etc.).
+  properties carry options (`source=`, `index=`, `alias=`, etc.).
 - Type annotations: KDL 2.0 type annotations (e.g., `(f64)200`) are supported
   but optional (see [§8](#8-kdl-20-type-annotations-optional)).
 - Comments: line comments (`//`) and slashdash comments (`/-`) are fully
@@ -109,7 +109,7 @@ KDL features not used by Arco:
   have no special Arco semantics.
 - Null values: KDL `null` has no defined meaning in Arco. Implementations MUST
   reject `null` wherever a concrete value is expected. This applies to all value
-  positions: arguments, property values (`from=`, `index=`, `units=`), and
+  positions: arguments, property values (`source=`, `index=`, `units=`), and
   algebra literals. See [§10](#10-validation-requirements), rule 61.
 
 ### 1.2 Naming convention
@@ -125,9 +125,9 @@ forms are equivalent:
 
 ```kdl
 // positional (preferred)
-param capacity_mw from=cap_mw index=gen
+param capacity_mw source=cap_mw index=gen
 // explicit name property (also valid)
-param name=capacity_mw from=cap_mw index=gen
+param name=capacity_mw source=cap_mw index=gen
 ```
 
 This applies to all named declarations: `set`, `data`, `model`, `scenario`,
@@ -246,7 +246,7 @@ param big_m 1e6
 set bus { 1; 2; 3; 4; 5 }
 
 // CSV-backed data with subsets via set { in ... }
-data generators from="data/generators.csv" {
+data generators source="data/generators.csv" {
   set gen
   set solar { in gen; filter { type == solar } }
   param pmax index=gen
@@ -258,7 +258,7 @@ model dispatch_model {
 
 scenario day_ahead {
   use dispatch_model
-  data demand from="data/demand.csv"
+  data demand source="data/demand.csv"
 }
 ```
 
@@ -368,12 +368,12 @@ Allowed children:
 
 ```
 map <logical_name>
-map <logical_name> from=<source_header>
+map <logical_name> source=<source_header>
 ```
 
 Semantics:
 
-- If `from` is omitted, source header defaults to `<logical_name>`. The column
+- If `source` is omitted, source header defaults to `<logical_name>`. The column
   MUST exist in the CSV.
 - Mapping is optional. Unmapped columns remain available.
 - Duplicate logical targets MUST fail validation.
@@ -513,16 +513,16 @@ data plants source="data/plants.csv" {
 `param` projects values from CSV columns into named parameters.
 
 By default, the param name is used to match the CSV column header. If the CSV
-column has a different name, use `from=<column>` to specify which CSV column
+column has a different name, use `source=<column>` to specify which CSV column
 supplies the values. The param's logical name (used in algebra) is always the
-`<name>` given to the `param` declaration. `from=` only controls where the data
+`<name>` given to the `param` declaration. `source=` only controls where the data
 is read from.
 
 Single-dimension indexing (property form):
 
 ```
 param <name>
-param <name> from=<csv_column>
+param <name> source=<csv_column>
 param <name> index=<set>
 param <name> { index <set> }
 ```
@@ -531,7 +531,7 @@ Multi-dimension indexing (child node form):
 
 ```
 param <name> { index <set_a>; index <set_b> }
-param <name> from=<csv_column> { index <set_a>; index <set_b> }
+param <name> source=<csv_column> { index <set_a>; index <set_b> }
 ```
 
 `<set>` references in the `index=` property and `index` children MAY use either
@@ -553,11 +553,11 @@ data generators source="data/generators.csv" {
   // reads from the "capacity_mw" column (name matches)
   param capacity_mw index=gen_id
   // reads from the "heat_rate" column but exposes it as "hr" in algebra
-  param hr from=heat_rate index=gen_id
+  param hr source=heat_rate index=gen_id
 }
 ```
 
-In algebra, reference `capacity_mw[g]` and `hr[g]`. The `from=` property only
+In algebra, reference `capacity_mw[g]` and `hr[g]`. The `source=` property only
 affects which CSV column is read, not the param's logical name.
 
 The `index=` property and `index` children are mutually exclusive. Using both on
@@ -611,7 +611,7 @@ depend on runtime data, so those errors occur at solve time (see
 Filtering:
 
 ```
-param <name> from=<field> { filter { <predicate> } }
+param <name> source=<field> { filter { <predicate> } }
 ```
 
 The `filter` block uses the same bare-math algebra syntax as `set` filters and
@@ -620,8 +620,8 @@ constraint `if` blocks:
 Given a CSV with columns `gen_id`, `capacity_mw`, and `prime_mover`:
 
 ```arco
-param cc_capacity from=capacity_mw { filter { prime_mover == CC } }
-param large_units from=capacity_mw { filter { capacity_mw >= 200 } }
+param cc_capacity source=capacity_mw { filter { prime_mover == CC } }
+param large_units source=capacity_mw { filter { capacity_mw >= 200 } }
 ```
 
 Order of operations when `filter` and `reduce` are combined: filtering is
@@ -629,7 +629,7 @@ applied first, then the reducer operates on the filtered rows. For example:
 
 ```arco
 // first filter to thermal rows, then sum their capacity
-param total_thermal_cap from=capacity_mw index=region reduce=sum {
+param total_thermal_cap source=capacity_mw index=region reduce=sum {
   filter { type == thermal }
 }
 ```
@@ -674,10 +674,10 @@ discount_rate,value_of_lost_load
 
 ```kdl
 data settings source="data/settings.csv" {
-  // column name matches param name, no from= needed
+  // column name matches param name, no source= needed
   param discount_rate
-  // column name differs, use from= to read "value_of_lost_load" as "voll"
-  param voll from=value_of_lost_load units="$/MWh"
+  // column name differs, use source= to read "value_of_lost_load" as "voll"
+  param voll source=value_of_lost_load units="$/MWh"
 }
 ```
 
@@ -686,7 +686,7 @@ index brackets needed since they are not indexed over any set).
 
 Semantics:
 
-- If `from` is omitted, source field defaults to `<name>`. Column header
+- If `source` is omitted, source field defaults to `<name>`. Column header
   matching is case-sensitive. CSV column names MUST match exactly (after `map`
   resolution).
 - If neither the `index=` property nor `index` children are present, default is
@@ -787,8 +787,8 @@ set <name> alias=<short>
 
 ```arco
 // data declares gen, capacity_mw, fuel_cost, and the thermal_gen subset
-data generators from="data/generators.csv" {
-  map gen from=generator_id
+data generators source="data/generators.csv" {
+  map gen source=generator_id
   set gen alias=g
   set thermal_gen { in gen; filter { type == thermal } }
   param capacity_mw index=gen
@@ -798,7 +798,7 @@ data generators from="data/generators.csv" {
 // model uses gen, thermal_gen, and capacity_mw directly, no redeclaration
 model dispatch {
   set time alias=t
-  control output lower=0 { index gen; index time }
+  control output { lower 0; index gen; index time }
 
   constraint cap_limit {
     index g { in gen }
@@ -856,8 +856,21 @@ parameter name MUST match either a scenario `data` binding name or a top-level
 Decision-variable families. A `control` declaration defines a family of decision
 variables indexed over one or more sets.
 
-The preferred form uses a child block with `index` children, and bounds and
-`kind` as properties on the `control` node:
+The preferred form uses a child block with `index` children. Literal bounds MAY
+be written either as `lower=`/`upper=` properties on the `control` node or as
+child nodes inside the block, and `kind` remains a property on the `control`
+node:
+
+```
+control <name> kind=continuous {
+  lower 0
+  upper 100
+  index <set_a>
+  index <set_b>
+}
+```
+
+Equivalent property form:
 
 ```
 control <name> lower=0 upper=100 kind=continuous {
@@ -866,8 +879,7 @@ control <name> lower=0 upper=100 kind=continuous {
 }
 ```
 
-All children are optional except at least one `index`. Bounds and `kind` are
-properties on the `control` node line (not child nodes).
+All children are optional except at least one `index`.
 
 Compact single-dimension form:
 
@@ -892,13 +904,17 @@ control <name> {
 }
 ```
 
-Properties:
+Properties and children:
 
 - `index` children or `index`: indexing sets (at least one required)
-- `lower`: lower bound (optional). Accepts a literal value or an algebra block.
-- `upper`: upper bound (optional). Accepts a literal value or an algebra block.
+- `lower`: lower bound (optional). Accepts a literal value as a property
+  (`lower=0`) or child node (`lower 0`), or an algebra block inside
+  `bounds { lower { ... } }`.
+- `upper`: upper bound (optional). Accepts a literal value as a property
+  (`upper=100`) or child node (`upper 100`), or an algebra block inside
+  `bounds { upper { ... } }`.
 - `value`: fixed value (optional). Sugar for `lower=X upper=X`. Mutually
-  exclusive with `lower` and `upper`.
+  exclusive with `lower` and `upper` in any form.
 - `kind`: variable type (optional). Allowed values:
   - `continuous` (default)
   - `integer`
@@ -912,7 +928,19 @@ Bounds:
 
 There are four ways to specify bounds on a `control`:
 
-1. **Literal bounds** — scalar values as properties on the `control` node:
+1. **Literal bounds as child nodes** — scalar values inside the `control`
+   block:
+
+```kdl
+control dispatch {
+  lower 0
+  upper 500
+  index gen
+  index time
+}
+```
+
+2. **Literal bounds as properties** — scalar values on the `control` node:
 
 ```kdl
 control dispatch lower=0 upper=500 {
@@ -921,7 +949,7 @@ control dispatch lower=0 upper=500 {
 }
 ```
 
-2. **Formula bounds** — algebra expressions inside a `bounds` child block:
+3. **Formula bounds** — algebra expressions inside a `bounds` child block:
 
 ```arco
 control flow {
@@ -933,11 +961,12 @@ control flow {
 }
 ```
 
-3. **Mixed** — literal property for one direction, formula in `bounds` for the
-   other:
+4. **Mixed** — literal property or child node for one direction, formula in
+   `bounds` for the other:
 
 ```arco
-control output lower=0 {
+control output {
+  lower 0
   index g { in gen }
   index time
   bounds {
@@ -946,7 +975,7 @@ control output lower=0 {
 }
 ```
 
-4. **Fixed value** — `value=` sets both lower and upper to the same value:
+5. **Fixed value** — `value=` sets both lower and upper to the same value:
 
 ```kdl
 control dispatch value=100.0 {
@@ -967,10 +996,11 @@ MUST fail validation:
 
 ```arco
 // INVALID: two lower bounds on the same control
-control flow lower=0 {
+control flow {
+  lower 0
   index lines
   bounds {
-    lower { -capacity[l] }  // validation error: conflicts with lower=0
+    lower { -capacity[l] }  // validation error: conflicts with lower 0
   }
 }
 ```
@@ -1214,7 +1244,7 @@ constraint body, and adding a penalty to the objective:
 
 ```arco
 // what the compiler generates from the slack declaration above:
-control balance_slack lower=0 { index time }
+control balance_slack { lower 0; index time }
 
 constraint balance {
   index t { in time }
@@ -1315,7 +1345,7 @@ data and activates execution.
 ```
 scenario <name> {
   use <model_name>
-  data <name> from=<path>
+  data <name> source=<path>
   report <expression_name>
   report dual <constraint_name>
 }
@@ -1331,13 +1361,13 @@ share mutable state with other scenarios.
 ```kdl
 scenario distance_check {
   use distance_model
-  data distances from="data/distances.csv"
+  data distances source="data/distances.csv"
 }
 
 scenario day_ahead {
   use dispatch_model
-  data demand from="data/demand.csv"
-  data gen_data from="data/generators.csv"
+  data demand source="data/demand.csv"
+  data gen_data source="data/generators.csv"
 }
 ```
 
@@ -1357,9 +1387,9 @@ declarations MUST NOT have a child block (`{ ... }`). They are simple
 name-to-CSV bindings, not namespaced declarations like top-level `data` blocks.
 
 ```kdl
-data demand from="data/demand.csv"
-data capacity from="data/capacity.csv"
-data fuel_cost from="data/fuel_cost.csv"
+data demand source="data/demand.csv"
+data capacity source="data/capacity.csv"
+data fuel_cost source="data/fuel_cost.csv"
 ```
 
 The `<name>` of each binding MUST match either a `param` declared in the
@@ -1386,7 +1416,7 @@ Column-to-index matching:
 5. Missing required columns (index sets or value column) MUST fail validation.
 
 Example: A model declares `param demand { index region; index time }`. The
-scenario binds `data demand from="data/demand.csv"`. The CSV MUST contain
+scenario binds `data demand source="data/demand.csv"`. The CSV MUST contain
 columns `region`, `time`, and `demand` (or the column specified by `from`). Each
 row provides one value of `demand` for a `(region, time)` pair.
 
@@ -1488,7 +1518,7 @@ param, so users are aware of the override:
 
 ```kdl
 // top-level: declares a param named "demand" inside block "demand_data"
-data demand_data from="data/demand_base.csv" {
+data demand_data source="data/demand_base.csv" {
   set region
   param demand index=region
 }
@@ -1496,7 +1526,7 @@ data demand_data from="data/demand_base.csv" {
 scenario stress_test {
   use dispatch_model
   // overrides the "demand" param (originally from demand_data) for this scenario
-  data demand from="data/demand_stress.csv"
+  data demand source="data/demand_stress.csv"
 }
 ```
 
@@ -1533,15 +1563,15 @@ If two CSV files have a column with the same logical name, use `from=` to give
 them distinct param names, or consolidate into one `data` block:
 
 ```kdl
-data generators from="data/generators.csv" {
+data generators source="data/generators.csv" {
   set gen_id
   // reads from CSV column "capacity", exposes as "gen_capacity" in algebra
-  param gen_capacity from=capacity index=gen_id
+  param gen_capacity source=capacity index=gen_id
 }
-data lines from="data/lines.csv" {
+data lines source="data/lines.csv" {
   set line_id
   // reads from CSV column "capacity", exposes as "line_capacity" in algebra
-  param line_capacity from=capacity index=line_id
+  param line_capacity source=capacity index=line_id
 }
 ```
 
@@ -1549,7 +1579,7 @@ data lines from="data/lines.csv" {
 
 ```arco
 // sets and params here are globally visible to all models
-data units from="data/units.csv" {
+data units source="data/units.csv" {
   set plant_id
   set unit_id alias=u { in plant_id }
   param capacity_mw index=unit_id
@@ -1559,7 +1589,7 @@ data units from="data/units.csv" {
 model dispatch_model {
   set time alias=t
   param demand { index time }
-  control dispatch lower=0 { index unit_id; index time }
+  control dispatch { lower 0; index unit_id; index time }
   constraint cap_limit {
     dispatch[u,t] <= capacity_mw[u]
   }
@@ -1589,13 +1619,13 @@ model planning_model {
 scenario base_case {
   use dispatch_model
   // only available in this scenario
-  data demand from="data/demand_base.csv"
+  data demand source="data/demand_base.csv"
 }
 
 scenario high_demand {
   use dispatch_model
   // different demand for this scenario
-  data demand from="data/demand_high.csv"
+  data demand source="data/demand_high.csv"
 }
 ```
 
@@ -1613,8 +1643,8 @@ Node annotation:
 Typed value literals in filters:
 
 ```arco
-param large_units from=capacity_mw { filter { capacity_mw >= (f64)200 } }
-param cc_capacity from=capacity_mw { filter { prime_mover == (prime_mover)CC } }
+param large_units source=capacity_mw { filter { capacity_mw >= (f64)200 } }
+param cc_capacity source=capacity_mw { filter { prime_mover == (prime_mover)CC } }
 ```
 
 Typed metadata values:
@@ -1699,8 +1729,8 @@ Quick-reference index:
 | 5   | Name uniqueness           | Duplicate `set` names within one `data` block                                     |
 | 6   | Name uniqueness           | Set name collisions across `data` blocks                                          |
 | 7   | Name uniqueness           | Param name collisions across `data` blocks                                        |
-| 8   | Column resolution         | `map` without `from` must match CSV column                                        |
-| 9   | Column resolution         | Unknown source columns in `map from=` or `param from=`                            |
+| 8   | Column resolution         | `map` without `source` must match CSV column                                      |
+| 9   | Column resolution         | Unknown source columns in `map source=` or `param source=`                        |
 | 10  | Column resolution         | Unknown set references in `index=` property or `index` children                   |
 | 11  | Set hierarchy             | `in` parent must resolve (see [rule 32](#10-validation-requirements) for scoping) |
 | 12  | Set hierarchy             | `in` cycles detected                                                              |
@@ -2146,13 +2176,15 @@ block_control     := ( control_bounds | "value" "=" value )
                      [ "kind" "=" kind ]
                      "{" ctrl_index_child ";" { ctrl_index_child ";" }
                      [ bounds_block ] "}"
-                     (* Literal bounds (lower=, upper=) and kind= are KDL
-                        properties on the control node line. Formula bounds
-                        (lower { ... }, upper { ... }) are child nodes inside
-                        a bounds { ... } child block. For each direction, at
-                        most one form (property OR bounds child) is allowed,
-                        not both. value= is sugar for lower=X upper=X and
-                        MUST NOT appear with lower, upper, or bounds block. *)
+                     (* Literal bounds may be written either as properties
+                        (lower=, upper=) on the control node line or as child
+                        nodes (lower 0, upper 100) inside the control block.
+                        Formula bounds (lower { ... }, upper { ... }) are
+                        child nodes inside a bounds { ... } child block. For
+                        each direction, at most one form (property OR literal
+                        child OR bounds child) is allowed. value= is sugar for
+                        lower=X upper=X and MUST NOT appear with lower, upper,
+                        or bounds block. *)
 
 control_bounds    := [ "lower" "=" value ] [ "upper" "=" value ]
 
@@ -2423,7 +2455,7 @@ for the component domains and use a multi-column `index` to define the composite
 key:
 
 ```kdl
-data branch_data from="data/branches.csv" {
+data branch_data source="data/branches.csv" {
   // CSV has columns: from_bus, to_bus, capacity, ...
   set from_bus
   set to_bus

--- a/docs/arco-spec.md
+++ b/docs/arco-spec.md
@@ -246,7 +246,7 @@ param big_m 1e6
 set bus { 1; 2; 3; 4; 5 }
 
 // CSV-backed data with subsets via set { in ... }
-data generators source="data/generators.csv" {
+data generators from="data/generators.csv" {
   set gen
   set solar { in gen; filter { type == solar } }
   param pmax index=gen
@@ -258,7 +258,7 @@ model dispatch_model {
 
 scenario day_ahead {
   use dispatch_model
-  data demand source="data/demand.csv"
+  data demand from="data/demand.csv"
 }
 ```
 
@@ -337,7 +337,7 @@ document can reference them by name. A single `data` block can supply sets and
 parameters to multiple models.
 
 ```
-data <name> source=<path> { ... }
+data <name> from=<path> { ... }
 ```
 
 Required properties:
@@ -492,7 +492,7 @@ Semantics:
 
 ```kdl
 // valid: multi-column index on a single declaration
-data plants source="data/plants.csv" {
+data plants from="data/plants.csv" {
   set plant_id
   set unit_id { in plant_id }
   index plant_id unit_id
@@ -500,7 +500,7 @@ data plants source="data/plants.csv" {
 }
 
 // INVALID: two separate index declarations
-data plants source="data/plants.csv" {
+data plants from="data/plants.csv" {
   set plant_id
   set unit_id
   index plant_id
@@ -548,7 +548,7 @@ g3,150,9.8
 ```
 
 ```kdl
-data generators source="data/generators.csv" {
+data generators from="data/generators.csv" {
   set gen_id
   // reads from the "capacity_mw" column (name matches)
   param capacity_mw index=gen_id
@@ -673,7 +673,7 @@ discount_rate,value_of_lost_load
 ```
 
 ```kdl
-data settings source="data/settings.csv" {
+data settings from="data/settings.csv" {
   // column name matches param name, no from= needed
   param discount_rate
   // column name differs, use source= to read "value_of_lost_load" as "voll"
@@ -787,7 +787,7 @@ set <name> alias=<short>
 
 ```arco
 // data declares gen, capacity_mw, fuel_cost, and the thermal_gen subset
-data generators source="data/generators.csv" {
+data generators from="data/generators.csv" {
   map gen from=generator_id
   set gen alias=g
   set thermal_gen { in gen; filter { type == thermal } }
@@ -1345,7 +1345,7 @@ data and activates execution.
 ```
 scenario <name> {
   use <model_name>
-  data <name> source=<path>
+  data <name> from=<path>
   report <expression_name>
   report dual <constraint_name>
 }
@@ -1361,13 +1361,13 @@ share mutable state with other scenarios.
 ```kdl
 scenario distance_check {
   use distance_model
-  data distances source="data/distances.csv"
+  data distances from="data/distances.csv"
 }
 
 scenario day_ahead {
   use dispatch_model
-  data demand source="data/demand.csv"
-  data gen_data source="data/generators.csv"
+  data demand from="data/demand.csv"
+  data gen_data from="data/generators.csv"
 }
 ```
 
@@ -1387,9 +1387,9 @@ declarations MUST NOT have a child block (`{ ... }`). They are simple
 name-to-CSV bindings, not namespaced declarations like top-level `data` blocks.
 
 ```kdl
-data demand source="data/demand.csv"
-data capacity source="data/capacity.csv"
-data fuel_cost source="data/fuel_cost.csv"
+data demand from="data/demand.csv"
+data capacity from="data/capacity.csv"
+data fuel_cost from="data/fuel_cost.csv"
 ```
 
 The `<name>` of each binding MUST match either a `param` declared in the
@@ -1416,7 +1416,7 @@ Column-to-index matching:
 5. Missing required columns (index sets or value column) MUST fail validation.
 
 Example: A model declares `param demand { index region; index time }`. The
-scenario binds `data demand source="data/demand.csv"`. The CSV MUST contain
+scenario binds `data demand from="data/demand.csv"`. The CSV MUST contain
 columns `region`, `time`, and `demand` (or the column specified by `from`). Each
 row provides one value of `demand` for a `(region, time)` pair.
 
@@ -1518,7 +1518,7 @@ param, so users are aware of the override:
 
 ```kdl
 // top-level: declares a param named "demand" inside block "demand_data"
-data demand_data source="data/demand_base.csv" {
+data demand_data from="data/demand_base.csv" {
   set region
   param demand index=region
 }
@@ -1526,7 +1526,7 @@ data demand_data source="data/demand_base.csv" {
 scenario stress_test {
   use dispatch_model
   // overrides the "demand" param (originally from demand_data) for this scenario
-  data demand source="data/demand_stress.csv"
+  data demand from="data/demand_stress.csv"
 }
 ```
 
@@ -1563,12 +1563,12 @@ If two CSV files have a column with the same logical name, use `from=` to give
 them distinct param names, or consolidate into one `data` block:
 
 ```kdl
-data generators source="data/generators.csv" {
+data generators from="data/generators.csv" {
   set gen_id
   // reads from CSV column "capacity", exposes as "gen_capacity" in algebra
   param gen_capacity from=capacity index=gen_id
 }
-data lines source="data/lines.csv" {
+data lines from="data/lines.csv" {
   set line_id
   // reads from CSV column "capacity", exposes as "line_capacity" in algebra
   param line_capacity from=capacity index=line_id
@@ -1579,7 +1579,7 @@ data lines source="data/lines.csv" {
 
 ```arco
 // sets and params here are globally visible to all models
-data units source="data/units.csv" {
+data units from="data/units.csv" {
   set plant_id
   set unit_id alias=u { in plant_id }
   param capacity_mw index=unit_id
@@ -1619,13 +1619,13 @@ model planning_model {
 scenario base_case {
   use dispatch_model
   // only available in this scenario
-  data demand source="data/demand_base.csv"
+  data demand from="data/demand_base.csv"
 }
 
 scenario high_demand {
   use dispatch_model
   // different demand for this scenario
-  data demand source="data/demand_high.csv"
+  data demand from="data/demand_high.csv"
 }
 ```
 
@@ -1704,7 +1704,7 @@ Rules:
   `map` resolution) on the left-hand side of each comparison.
 
 ```arco
-data generators source="data/generators.csv" {
+data generators from="data/generators.csv" {
   set gen
   set thermal { in gen; filter { type == thermal } }
   set large { in gen; filter { capacity >= 200 } }
@@ -2455,7 +2455,7 @@ for the component domains and use a multi-column `index` to define the composite
 key:
 
 ```kdl
-data branch_data source="data/branches.csv" {
+data branch_data from="data/branches.csv" {
   // CSV has columns: from_bus, to_bus, capacity, ...
   set from_bus
   set to_bus

--- a/examples/capacity-expansion/input.kdl
+++ b/examples/capacity-expansion/input.kdl
@@ -1,53 +1,89 @@
-data assets_data from="data/all_assets.csv" {
+data assets_data source="data/all_assets.csv" {
   map asset_id from="asset_name"
 
   set asset_id alias="a"
-  param existing_capacity_mw index="asset_id"
-  param max_build_mw index="asset_id"
-  param build_cost index="asset_id"
-  param variable_cost index="asset_id"
-  param is_candidate index="asset_id"
+  param existing_capacity_mw {
+    index asset_id
+  }
+  param max_build_mw {
+    index asset_id
+  }
+  param build_cost {
+    index asset_id
+  }
+  param variable_cost {
+    index asset_id
+  }
+  param is_candidate {
+    index asset_id
+  }
 }
 
-data demand_data from="data/demand.csv" {
+data demand_data source="data/demand.csv" {
   set t
-  param demand index="t"
+  param demand {
+    index t
+  }
 }
 
-data voll_data from="data/voll.csv" {
+data voll_data source="data/voll.csv" {
   set t
-  param voll index="t"
+  param voll {
+    index t
+  }
 }
 
-model CapacityExpansion {
+model capacity_expansion {
   set asset_id alias="a"
   set time alias="t"
 
-  param existing_capacity_mw index="asset_id"
-  param max_build_mw index="asset_id"
-  param build_cost index="asset_id"
-  param variable_cost index="asset_id"
-  param is_candidate index="asset_id"
-  param demand index="time"
-  param voll index="time"
+  param existing_capacity_mw {
+    index asset_id
+  }
+  param max_build_mw {
+    index asset_id
+  }
+  param build_cost {
+    index asset_id
+  }
+  param variable_cost {
+    index asset_id
+  }
+  param is_candidate {
+    index asset_id
+  }
+  param demand {
+    index time
+  }
+  param voll {
+    index time
+  }
 
   control dispatch {
     index asset_id
     index time
+    lower=0
   }
 
-  control expansion index="asset_id" lower=0
-  control unserved_energy index="time" lower=0
+  control expansion {
+    index asset_id
+    lower=0
+  }
 
-  expression InvestmentCost {
+  control unserved_energy {
+    index time
+    lower=0
+  }
+
+  expression investment_cost {
     sum(build_cost[asset] * expansion[asset] for asset in candidate_assets)
   }
 
-  expression OperatingCost {
+  expression operating_cost {
     sum(variable_cost[asset] * dispatch[asset,t] for asset in asset_id for t in time)
   }
 
-  expression PenaltyCost {
+  expression penalty_cost {
     sum(voll[t] * unserved_energy[t] for t in time)
   }
 
@@ -73,11 +109,11 @@ model CapacityExpansion {
     }
   }
 
-  minimize ExpansionCost {
-    InvestmentCost + OperatingCost + PenaltyCost
+  minimize expansion_cost {
+    investment_cost + operating_cost + penalty_cost
   }
 }
 
-scenario ExpansionCase {
-  use CapacityExpansion
+scenario expansion_case {
+  use capacity_expansion
 }

--- a/examples/capacity-expansion/input.kdl
+++ b/examples/capacity-expansion/input.kdl
@@ -1,5 +1,5 @@
 data assets_data source="data/all_assets.csv" {
-  map asset_id source="asset_name"
+  map asset_id from="asset_name"
 
   set asset_id alias="a"
   param existing_capacity_mw {

--- a/examples/capacity-expansion/input.kdl
+++ b/examples/capacity-expansion/input.kdl
@@ -1,4 +1,4 @@
-data assets_data source="data/all_assets.csv" {
+data assets_data from="data/all_assets.csv" {
   map asset_id from="asset_name"
 
   set asset_id alias="a"
@@ -19,14 +19,14 @@ data assets_data source="data/all_assets.csv" {
   }
 }
 
-data demand_data source="data/demand.csv" {
+data demand_data from="data/demand.csv" {
   set t
   param demand {
     index t
   }
 }
 
-data voll_data source="data/voll.csv" {
+data voll_data from="data/voll.csv" {
   set t
   param voll {
     index t
@@ -62,17 +62,14 @@ model capacity_expansion {
   control dispatch {
     index asset_id
     index time
-    lower=0
   }
 
   control expansion {
     index asset_id
-    lower=0
   }
 
   control unserved_energy {
     index time
-    lower=0
   }
 
   expression investment_cost {

--- a/examples/capacity-expansion/input.kdl
+++ b/examples/capacity-expansion/input.kdl
@@ -1,5 +1,5 @@
 data assets_data source="data/all_assets.csv" {
-  map asset_id from="asset_name"
+  map asset_id source="asset_name"
 
   set asset_id alias="a"
   param existing_capacity_mw {

--- a/examples/capacity-expansion/input.kdl
+++ b/examples/capacity-expansion/input.kdl
@@ -1,4 +1,4 @@
-data assets_data from="data/all_assets.csv" {
+data assets_data source="data/all_assets.csv" {
   map asset_id from="asset_name"
 
   set asset_id alias="a"
@@ -19,14 +19,14 @@ data assets_data from="data/all_assets.csv" {
   }
 }
 
-data demand_data from="data/demand.csv" {
+data demand_data source="data/demand.csv" {
   set t
   param demand {
     index t
   }
 }
 
-data voll_data from="data/voll.csv" {
+data voll_data source="data/voll.csv" {
   set t
   param voll {
     index t

--- a/examples/generator-allocation/input.kdl
+++ b/examples/generator-allocation/input.kdl
@@ -1,11 +1,11 @@
-data units from="data/units.csv" {
+data units source="data/units.csv" {
   map asset_id from="asset"
 
   set asset_id alias="a"
   param variable_cost index="asset_id"
 }
 
-data demand_data from="data/demand.csv" {
+data demand_data source="data/demand.csv" {
   set t
   param demand index="t"
 }

--- a/examples/generator-allocation/input.kdl
+++ b/examples/generator-allocation/input.kdl
@@ -1,32 +1,23 @@
-data units source="data/units.csv" {
+data units from="data/units.csv" {
   map asset_id from="asset"
 
   set asset_id alias="a"
-  param variable_cost {
-    index asset_id
-  }
+  param variable_cost index="asset_id"
 }
 
-data demand_data source="data/demand.csv" {
+data demand_data from="data/demand.csv" {
   set t
-  param demand {
-    index t
-  }
+  param demand index="t"
 }
 
 model generator_allocation {
   set asset_id alias="a"
   set time alias="t"
 
-  param variable_cost {
-    index asset_id
-  }
-  param demand {
-    index time
-  }
+  param variable_cost index="asset_id"
+  param demand index="time"
 
-  control dispatch {
-    lower 0
+  control dispatch lower=0 {
     index asset_id
     index time
   }
@@ -51,6 +42,6 @@ model generator_allocation {
   }
 }
 
-scenario generator_allocation_day {
+scenario generator_allocationDay {
   use generator_allocation
 }

--- a/examples/generator-allocation/input.kdl
+++ b/examples/generator-allocation/input.kdl
@@ -1,5 +1,5 @@
 data units source="data/units.csv" {
-  map asset_id source="asset"
+  map asset_id from="asset"
 
   set asset_id alias="a"
   param variable_cost {

--- a/examples/generator-allocation/input.kdl
+++ b/examples/generator-allocation/input.kdl
@@ -1,23 +1,32 @@
-data units from="data/units.csv" {
-  map asset_id from="asset"
+data units source="data/units.csv" {
+  map asset_id source="asset"
 
   set asset_id alias="a"
-  param variable_cost index="asset_id"
+  param variable_cost {
+    index asset_id
+  }
 }
 
-data demand_data from="data/demand.csv" {
+data demand_data source="data/demand.csv" {
   set t
-  param demand index="t"
+  param demand {
+    index t
+  }
 }
 
-model GeneratorAllocation {
+model generator_allocation {
   set asset_id alias="a"
   set time alias="t"
 
-  param variable_cost index="asset_id"
-  param demand index="time"
+  param variable_cost {
+    index asset_id
+  }
+  param demand {
+    index time
+  }
 
-  control dispatch lower=0 {
+  control dispatch {
+    lower 0
     index asset_id
     index time
   }
@@ -37,11 +46,11 @@ model GeneratorAllocation {
     }
   }
 
-  minimize TotalCost {
+  minimize total_cost {
     sum(variable_cost[asset] * dispatch[asset,t] for asset in asset_id for t in time)
   }
 }
 
-scenario GeneratorAllocationDay {
-  use GeneratorAllocation
+scenario generator_allocation_day {
+  use generator_allocation
 }

--- a/examples/price-taker-battery/input.kdl
+++ b/examples/price-taker-battery/input.kdl
@@ -1,4 +1,4 @@
-data battery from="data/battery.csv" {
+data battery source="data/battery.csv" {
   map asset_id from="asset"
 
   set asset_id alias="a"
@@ -23,7 +23,7 @@ data battery from="data/battery.csv" {
   }
 }
 
-data price_curve from="data/prices.csv" {
+data price_curve source="data/prices.csv" {
   set t
   param prices {
     index t

--- a/examples/price-taker-battery/input.kdl
+++ b/examples/price-taker-battery/input.kdl
@@ -1,4 +1,4 @@
-data battery source="data/battery.csv" {
+data battery from="data/battery.csv" {
   map asset_id from="asset"
 
   set asset_id alias="a"
@@ -23,7 +23,7 @@ data battery source="data/battery.csv" {
   }
 }
 
-data price_curve source="data/prices.csv" {
+data price_curve from="data/prices.csv" {
   set t
   param prices {
     index t
@@ -59,17 +59,14 @@ model price_taker_battery {
   control charge {
     index asset_id
     index time
-    lower=0
   }
   control discharge {
     index asset_id
     index time
-    lower=0
   }
   control soc {
     index asset_id
     index time
-    lower=0
   }
 
   expression arbitrage_revenue {
@@ -119,7 +116,7 @@ model price_taker_battery {
   constraint terminal_soc {
     index asset { in asset_id }
     index t { in time }
-    if { t == max(x for x in time) }
+    if { t == 24 }
     expression {
       soc[asset,t] = terminal_soc_mwh[asset]
     }

--- a/examples/price-taker-battery/input.kdl
+++ b/examples/price-taker-battery/input.kdl
@@ -1,47 +1,78 @@
-data battery from="data/battery.csv" {
-  map asset_id from="asset"
+data battery source="data/battery.csv" {
+  map asset_id source="asset"
 
   set asset_id alias="a"
 
-  param power_mw index="asset_id"
-  param energy_mwh index="asset_id"
-  param charge_efficiency index="asset_id"
-  param discharge_efficiency index="asset_id"
-  param initial_soc_mwh index="asset_id"
-  param terminal_soc_mwh index="asset_id"
+  param power_mw {
+    index asset_id
+  }
+  param energy_mwh {
+    index asset_id
+  }
+  param charge_efficiency {
+    index asset_id
+  }
+  param discharge_efficiency {
+    index asset_id
+  }
+  param initial_soc_mwh {
+    index asset_id
+  }
+  param terminal_soc_mwh {
+    index asset_id
+  }
 }
 
-data price_curve from="data/prices.csv" {
+data price_curve source="data/prices.csv" {
   set t
-  param prices index="t"
+  param prices {
+    index t
+  }
 }
 
-model PriceTakerBattery {
+model price_taker_battery {
   set asset_id alias="a"
   set time alias="t"
 
-  param power_mw index="asset_id"
-  param energy_mwh index="asset_id"
-  param charge_efficiency index="asset_id"
-  param discharge_efficiency index="asset_id"
-  param initial_soc_mwh index="asset_id"
-  param terminal_soc_mwh index="asset_id"
-  param prices index="time"
+  param power_mw {
+    index asset_id
+  }
+  param energy_mwh {
+    index asset_id
+  }
+  param charge_efficiency {
+    index asset_id
+  }
+  param discharge_efficiency {
+    index asset_id
+  }
+  param initial_soc_mwh {
+    index asset_id
+  }
+  param terminal_soc_mwh {
+    index asset_id
+  }
+  param prices {
+    index time
+  }
 
   control charge {
     index asset_id
     index time
+    lower=0
   }
   control discharge {
     index asset_id
     index time
+    lower=0
   }
   control soc {
     index asset_id
     index time
+    lower=0
   }
 
-  expression ArbitrageRevenue {
+  expression arbitrage_revenue {
     sum(prices[t] * (discharge[asset,t] - charge[asset,t]) for asset in asset_id for t in time)
   }
 
@@ -88,18 +119,18 @@ model PriceTakerBattery {
   constraint terminal_soc {
     index asset { in asset_id }
     index t { in time }
-    if { t == 24 }
+    if { t == max(x for x in time) }
     expression {
       soc[asset,t] = terminal_soc_mwh[asset]
     }
   }
 
-  maximize ArbitrageProfit {
-    ArbitrageRevenue
+  maximize arbitrage_profit {
+    arbitrage_revenue
   }
 }
 
-scenario BatteryArbitrageDay {
-  use PriceTakerBattery
-  report ArbitrageRevenue
+scenario battery_arbitrage_day {
+  use price_taker_battery
+  report arbitrage_revenue
 }

--- a/examples/price-taker-battery/input.kdl
+++ b/examples/price-taker-battery/input.kdl
@@ -1,5 +1,5 @@
 data battery source="data/battery.csv" {
-  map asset_id source="asset"
+  map asset_id from="asset"
 
   set asset_id alias="a"
 

--- a/examples/simple-electricity-market-storage/input.kdl
+++ b/examples/simple-electricity-market-storage/input.kdl
@@ -1,16 +1,12 @@
-data units source="data/units.csv" {
+data units from="data/units.csv" {
   map asset_id from="asset"
 
   set asset_id alias="a"
-  param capacity_mw {
-    index asset_id
-  }
-  param marginal_cost {
-    index asset_id
-  }
+  param capacity_mw index="asset_id"
+  param marginal_cost index="asset_id"
 }
 
-data availability_data source="data/availability.csv" {
+data availability_data from="data/availability.csv" {
   map asset_id from="asset_name"
 
   set asset_id
@@ -21,35 +17,26 @@ data availability_data source="data/availability.csv" {
   }
 }
 
-data load_data source="data/load.csv" {
+data load_data from="data/load.csv" {
   set t
-  param load {
-    index t
-  }
+  param load index="t"
 }
 
 model SouthAfricaSingleZoneDispatch {
   set asset_id alias="a"
   set time alias="t"
 
-  param capacity_mw {
-    index asset_id
-  }
-  param marginal_cost {
-    index asset_id
-  }
+  param capacity_mw index="asset_id"
+  param marginal_cost index="asset_id"
   param availability {
     index asset_id
     index time
   }
-  param load {
-    index time
-  }
+  param load index="time"
 
   control dispatch {
     index asset_id
     index time
-    lower 0
   }
 
   expression dispatch_cost {

--- a/examples/simple-electricity-market-storage/input.kdl
+++ b/examples/simple-electricity-market-storage/input.kdl
@@ -1,13 +1,17 @@
-data units from="data/units.csv" {
-  map asset_id from="asset"
+data units source="data/units.csv" {
+  map asset_id source="asset"
 
   set asset_id alias="a"
-  param capacity_mw index="asset_id"
-  param marginal_cost index="asset_id"
+  param capacity_mw {
+    index asset_id
+  }
+  param marginal_cost {
+    index asset_id
+  }
 }
 
-data availability_data from="data/availability.csv" {
-  map asset_id from="asset_name"
+data availability_data source="data/availability.csv" {
+  map asset_id source="asset_name"
 
   set asset_id
   set t
@@ -17,29 +21,38 @@ data availability_data from="data/availability.csv" {
   }
 }
 
-data load_data from="data/load.csv" {
+data load_data source="data/load.csv" {
   set t
-  param load index="t"
+  param load {
+    index t
+  }
 }
 
 model SouthAfricaSingleZoneDispatch {
   set asset_id alias="a"
   set time alias="t"
 
-  param capacity_mw index="asset_id"
-  param marginal_cost index="asset_id"
+  param capacity_mw {
+    index asset_id
+  }
+  param marginal_cost {
+    index asset_id
+  }
   param availability {
     index asset_id
     index time
   }
-  param load index="time"
+  param load {
+    index time
+  }
 
   control dispatch {
     index asset_id
     index time
+    lower 0
   }
 
-  expression DispatchCost {
+  expression dispatch_cost {
     sum(marginal_cost[asset] * dispatch[asset,t] for asset in asset_id for t in time)
   }
 
@@ -58,12 +71,12 @@ model SouthAfricaSingleZoneDispatch {
     }
   }
 
-  minimize TotalSystemCost {
-    DispatchCost
+  minimize total_system_cost {
+    dispatch_cost
   }
 }
 
-scenario SouthAfricaSingleZoneWithStorage {
+scenario south_africa_single_zone_with_storage {
   use SouthAfricaSingleZoneDispatch
-  report DispatchCost
+  report dispatch_cost
 }

--- a/examples/simple-electricity-market-storage/input.kdl
+++ b/examples/simple-electricity-market-storage/input.kdl
@@ -1,4 +1,4 @@
-data units from="data/units.csv" {
+data units source="data/units.csv" {
   map asset_id from="asset"
 
   set asset_id alias="a"
@@ -6,7 +6,7 @@ data units from="data/units.csv" {
   param marginal_cost index="asset_id"
 }
 
-data availability_data from="data/availability.csv" {
+data availability_data source="data/availability.csv" {
   map asset_id from="asset_name"
 
   set asset_id
@@ -17,7 +17,7 @@ data availability_data from="data/availability.csv" {
   }
 }
 
-data load_data from="data/load.csv" {
+data load_data source="data/load.csv" {
   set t
   param load index="t"
 }

--- a/examples/simple-electricity-market-storage/input.kdl
+++ b/examples/simple-electricity-market-storage/input.kdl
@@ -1,5 +1,5 @@
 data units source="data/units.csv" {
-  map asset_id source="asset"
+  map asset_id from="asset"
 
   set asset_id alias="a"
   param capacity_mw {
@@ -11,7 +11,7 @@ data units source="data/units.csv" {
 }
 
 data availability_data source="data/availability.csv" {
-  map asset_id source="asset_name"
+  map asset_id from="asset_name"
 
   set asset_id
   set t

--- a/examples/unit-commitment/input.kdl
+++ b/examples/unit-commitment/input.kdl
@@ -84,7 +84,7 @@
 // $$
 // \sum_g p_{gt}\le Load_t,\quad \forall t
 // $$
-data generators_data from="data/generators.csv" {
+data generators_data source="data/generators.csv" {
   map generators from=generator
 
   // Unit domain from generators.csv (column mapped as `generators`).
@@ -113,7 +113,7 @@ data generators_data from="data/generators.csv" {
   param mincost { index g }
 }
 
-data temporal_sets from="data/temporal_sets.csv" {
+data temporal_sets source="data/temporal_sets.csv" {
   // Temporal domains are user-provided at the data layer.
   // t: primary time/day index used by the model.
   // taf/tbl: user-provided helper subsets for t-1 / t+1 constraints.
@@ -122,17 +122,17 @@ data temporal_sets from="data/temporal_sets.csv" {
   set tbl { in t }
 }
 
-data demand_data from="data/load.csv" {
+data demand_data source="data/load.csv" {
   param lambda { index t }
   param load { index t }
 }
 
-data segment_set from="data/segments.csv" {
+data segment_set source="data/segments.csv" {
   // Piecewise cost segment domain from segments.csv column `k`.
   set k
 }
 
-data segment_data from="data/segment_data.csv" {
+data segment_data source="data/segment_data.csv" {
   map generators from=generator
 
   param dp {
@@ -145,7 +145,7 @@ data segment_data from="data/segment_data.csv" {
   }
 }
 
-data time_masks_data from="data/time_masks.csv" {
+data time_masks_data source="data/time_masks.csv" {
   map generators from=generator
 
   param uptime1_mask {
@@ -174,7 +174,7 @@ data time_masks_data from="data/time_masks.csv" {
   }
 }
 
-data time_windows_data from="data/time_windows.csv" {
+data time_windows_data source="data/time_windows.csv" {
   map generators from=generator
 
   // `t` is the anchor index (day/time bucket), `h` is the hour index.

--- a/examples/unit-commitment/input.kdl
+++ b/examples/unit-commitment/input.kdl
@@ -85,7 +85,7 @@
 // \sum_g p_{gt}\le Load_t,\quad \forall t
 // $$
 data generators_data source="data/generators.csv" {
-  map generators source=generator
+  map generators from=generator
 
   // Unit domain from generators.csv (column mapped as `generators`).
   // Alias `g` is used in set-reference positions and algebra iteration.
@@ -137,7 +137,7 @@ data generators_data source="data/generators.csv" {
     index g
   }
   param initial_commitment {
-    source=uini
+    from=uini
     index g
   }
   param s0 {
@@ -178,21 +178,21 @@ data segment_set source="data/segments.csv" {
 }
 
 data segment_data source="data/segment_data.csv" {
-  map generators source=generator
+  map generators from=generator
 
   param dp {
     index g
     index k
   }
   param slope {
-    source=s
+    from=s
     index g
     index k
   }
 }
 
 data time_masks_data source="data/time_masks.csv" {
-  map generators source=generator
+  map generators from=generator
 
   param uptime1_mask {
     index g
@@ -221,7 +221,7 @@ data time_masks_data source="data/time_masks.csv" {
 }
 
 data time_windows_data source="data/time_windows.csv" {
-  map generators source=generator
+  map generators from=generator
 
   // `t` is the anchor index (day/time bucket), `h` is the hour index.
   set h

--- a/examples/unit-commitment/input.kdl
+++ b/examples/unit-commitment/input.kdl
@@ -84,77 +84,36 @@
 // $$
 // \sum_g p_{gt}\le Load_t,\quad \forall t
 // $$
-data generators_data source="data/generators.csv" {
+data generators_data from="data/generators.csv" {
   map generators from=generator
 
   // Unit domain from generators.csv (column mapped as `generators`).
   // Alias `g` is used in set-reference positions and algebra iteration.
   set generators alias=g
 
-  param a {
-    index g
-  }
-  param b {
-    index g
-  }
-  param c {
-    index g
-  }
-  param costsd {
-    index g
-  }
-  param costst {
-    index g
-  }
-  param ru {
-    index g
-  }
-  param rd {
-    index g
-  }
-  param ut {
-    index g
-  }
-  param dt {
-    index g
-  }
-  param sd {
-    index g
-  }
-  param su {
-    index g
-  }
-  param pmin {
-    index g
-  }
-  param pmax {
-    index g
-  }
-  param u0 {
-    index g
-  }
-  param uini {
-    index g
-  }
-  param initial_commitment {
-    from=uini
-    index g
-  }
-  param s0 {
-    index g
-  }
-  param lj {
-    index g
-  }
-  param fj {
-    index g
-  }
-  param mincost {
-    index g
-  }
+  param a { index g }
+  param b { index g }
+  param c { index g }
+  param costsd { index g }
+  param costst { index g }
+  param ru { index g }
+  param rd { index g }
+  param ut { index g }
+  param dt { index g }
+  param sd { index g }
+  param su { index g }
+  param pmin { index g }
+  param pmax { index g }
+  param u0 { index g }
+  param uini { index g }
+  param initial_commitment from=uini { index g }
+  param s0 { index g }
+  param lj { index g }
+  param fj { index g }
+  param mincost { index g }
 }
 
-data temporal_sets source="data/temporal_sets.csv" {
+data temporal_sets from="data/temporal_sets.csv" {
   // Temporal domains are user-provided at the data layer.
   // t: primary time/day index used by the model.
   // taf/tbl: user-provided helper subsets for t-1 / t+1 constraints.
@@ -163,35 +122,30 @@ data temporal_sets source="data/temporal_sets.csv" {
   set tbl { in t }
 }
 
-data demand_data source="data/load.csv" {
-  param lambda {
-    index t
-  }
-  param load {
-    index t
-  }
+data demand_data from="data/load.csv" {
+  param lambda { index t }
+  param load { index t }
 }
 
-data segment_set source="data/segments.csv" {
+data segment_set from="data/segments.csv" {
   // Piecewise cost segment domain from segments.csv column `k`.
   set k
 }
 
-data segment_data source="data/segment_data.csv" {
+data segment_data from="data/segment_data.csv" {
   map generators from=generator
 
   param dp {
     index g
     index k
   }
-  param slope {
-    from=s
+  param slope from=s {
     index g
     index k
   }
 }
 
-data time_masks_data source="data/time_masks.csv" {
+data time_masks_data from="data/time_masks.csv" {
   map generators from=generator
 
   param uptime1_mask {
@@ -220,7 +174,7 @@ data time_masks_data source="data/time_masks.csv" {
   }
 }
 
-data time_windows_data source="data/time_windows.csv" {
+data time_windows_data from="data/time_windows.csv" {
   map generators from=generator
 
   // `t` is the anchor index (day/time bucket), `h` is the hour index.
@@ -241,51 +195,43 @@ data time_windows_data source="data/time_windows.csv" {
 model uc_gams_parity {
   // `g`, `k`, `t`, `taf`, `tbl`, and `h` are global sets from data blocks.
 
-  control pu {
-    lower=0
+  control pu lower=0 {
     index g
     index t
   }
 
-  control p {
-    lower=0
+  control p lower=0 {
     index g
     index t
   }
 
-  control stc {
-    lower=0
+  control stc lower=0 {
     index g
     index t
   }
 
-  control sdc {
-    lower=0
+  control sdc lower=0 {
     index g
     index t
   }
 
-  control pk {
-    lower=0
+  control pk lower=0 {
     index g
     index t
     index k
   }
 
-  control u {
-    kind=binary
+  control u kind=binary {
     index g
     index t
   }
 
-  control y {
-    kind=binary
+  control y kind=binary {
     index g
     index t
   }
 
-  control z {
-    kind=binary
+  control z kind=binary {
     index g
     index t
   }
@@ -451,21 +397,21 @@ model uc_gams_parity {
   constraint balance {
     index tt { in t }
     expression {
-      sum(p[generator,tt] for generator in generators) <= load[tt]
+      sum(p[g,tt] for g in g) <= load[tt]
     }
   }
 
   expression cost_thermal {
-    sum(stc[generator,tt] + sdc[generator,tt] for generator in generators for tt in t)
-    + sum(u[generator,tt] * mincost[generator] + sum(slope[generator,kk] * pk[generator,tt,kk] for kk in k) for generator in generators for tt in t)
+    sum(stc[g,tt] + sdc[g,tt] for g in g for tt in t)
+    + sum(u[g,tt] * mincost[g] + sum(slope[g,kk] * pk[g,tt,kk] for kk in k) for g in g for tt in t)
   }
 
   maximize of {
-    sum(lambda[tt] * sum(p[generator,tt] for generator in generators) for tt in t) - cost_thermal
+    sum(lambda[tt] * sum(p[g,tt] for g in g) for tt in t) - cost_thermal
   }
 }
 
-scenario uc_gams_parity_case {
+scenario uc_gams_parityCase {
   use uc_gams_parity
   report cost_thermal
   report of

--- a/examples/unit-commitment/input.kdl
+++ b/examples/unit-commitment/input.kdl
@@ -14,11 +14,11 @@
 //
 // Objective:
 // $$
-// costThermal = \sum_{g,t}(StC_{gt}+SDC_{gt})
+// cost_thermal = \sum_{g,t}(StC_{gt}+SDC_{gt})
 // + \sum_{g,t}\left(u_{gt}\,Mincost_g + \sum_k slope_{gk}\,Pk_{gtk}\right)
 // $$
 // $$
-// \max \; OF = \sum_{g,t}(\lambda_t\,p_{gt}) - costThermal
+// \max \; of = \sum_{g,t}(\lambda_t\,p_{gt}) - cost_thermal
 // $$
 //
 // Commitment logic:
@@ -84,36 +84,77 @@
 // $$
 // \sum_g p_{gt}\le Load_t,\quad \forall t
 // $$
-data generators_data from="data/generators.csv" {
-  map generators from=generator
+data generators_data source="data/generators.csv" {
+  map generators source=generator
 
   // Unit domain from generators.csv (column mapped as `generators`).
   // Alias `g` is used in set-reference positions and algebra iteration.
   set generators alias=g
 
-  param a { index g }
-  param b { index g }
-  param c { index g }
-  param costsd { index g }
-  param costst { index g }
-  param ru { index g }
-  param rd { index g }
-  param ut { index g }
-  param dt { index g }
-  param sd { index g }
-  param su { index g }
-  param pmin { index g }
-  param pmax { index g }
-  param u0 { index g }
-  param uini { index g }
-  param initial_commitment from=uini { index g }
-  param s0 { index g }
-  param lj { index g }
-  param fj { index g }
-  param mincost { index g }
+  param a {
+    index g
+  }
+  param b {
+    index g
+  }
+  param c {
+    index g
+  }
+  param costsd {
+    index g
+  }
+  param costst {
+    index g
+  }
+  param ru {
+    index g
+  }
+  param rd {
+    index g
+  }
+  param ut {
+    index g
+  }
+  param dt {
+    index g
+  }
+  param sd {
+    index g
+  }
+  param su {
+    index g
+  }
+  param pmin {
+    index g
+  }
+  param pmax {
+    index g
+  }
+  param u0 {
+    index g
+  }
+  param uini {
+    index g
+  }
+  param initial_commitment {
+    source=uini
+    index g
+  }
+  param s0 {
+    index g
+  }
+  param lj {
+    index g
+  }
+  param fj {
+    index g
+  }
+  param mincost {
+    index g
+  }
 }
 
-data temporal_sets from="data/temporal_sets.csv" {
+data temporal_sets source="data/temporal_sets.csv" {
   // Temporal domains are user-provided at the data layer.
   // t: primary time/day index used by the model.
   // taf/tbl: user-provided helper subsets for t-1 / t+1 constraints.
@@ -122,31 +163,36 @@ data temporal_sets from="data/temporal_sets.csv" {
   set tbl { in t }
 }
 
-data demand_data from="data/load.csv" {
-  param lambda { index t }
-  param load { index t }
+data demand_data source="data/load.csv" {
+  param lambda {
+    index t
+  }
+  param load {
+    index t
+  }
 }
 
-data segment_set from="data/segments.csv" {
+data segment_set source="data/segments.csv" {
   // Piecewise cost segment domain from segments.csv column `k`.
   set k
 }
 
-data segment_data from="data/segment_data.csv" {
-  map generators from=generator
+data segment_data source="data/segment_data.csv" {
+  map generators source=generator
 
   param dp {
     index g
     index k
   }
-  param slope from=s {
+  param slope {
+    source=s
     index g
     index k
   }
 }
 
-data time_masks_data from="data/time_masks.csv" {
-  map generators from=generator
+data time_masks_data source="data/time_masks.csv" {
+  map generators source=generator
 
   param uptime1_mask {
     index g
@@ -174,8 +220,8 @@ data time_masks_data from="data/time_masks.csv" {
   }
 }
 
-data time_windows_data from="data/time_windows.csv" {
-  map generators from=generator
+data time_windows_data source="data/time_windows.csv" {
+  map generators source=generator
 
   // `t` is the anchor index (day/time bucket), `h` is the hour index.
   set h
@@ -192,46 +238,54 @@ data time_windows_data from="data/time_windows.csv" {
   }
 }
 
-model UCGamsParity {
+model uc_gams_parity {
   // `g`, `k`, `t`, `taf`, `tbl`, and `h` are global sets from data blocks.
 
-  control pu lower=0 {
+  control pu {
+    lower=0
     index g
     index t
   }
 
-  control p lower=0 {
+  control p {
+    lower=0
     index g
     index t
   }
 
-  control stc lower=0 {
+  control stc {
+    lower=0
     index g
     index t
   }
 
-  control sdc lower=0 {
+  control sdc {
+    lower=0
     index g
     index t
   }
 
-  control pk lower=0 {
+  control pk {
+    lower=0
     index g
     index t
     index k
   }
 
-  control u kind=binary {
+  control u {
+    kind=binary
     index g
     index t
   }
 
-  control y kind=binary {
+  control y {
+    kind=binary
     index g
     index t
   }
 
-  control z kind=binary {
+  control z {
+    kind=binary
     index g
     index t
   }
@@ -397,22 +451,22 @@ model UCGamsParity {
   constraint balance {
     index tt { in t }
     expression {
-      sum(p[g,tt] for g in g) <= load[tt]
+      sum(p[generator,tt] for generator in generators) <= load[tt]
     }
   }
 
-  expression costThermal {
-    sum(stc[g,tt] + sdc[g,tt] for g in g for tt in t)
-    + sum(u[g,tt] * mincost[g] + sum(slope[g,kk] * pk[g,tt,kk] for kk in k) for g in g for tt in t)
+  expression cost_thermal {
+    sum(stc[generator,tt] + sdc[generator,tt] for generator in generators for tt in t)
+    + sum(u[generator,tt] * mincost[generator] + sum(slope[generator,kk] * pk[generator,tt,kk] for kk in k) for generator in generators for tt in t)
   }
 
-  maximize OF {
-    sum(lambda[tt] * sum(p[g,tt] for g in g) for tt in t) - costThermal
+  maximize of {
+    sum(lambda[tt] * sum(p[generator,tt] for generator in generators) for tt in t) - cost_thermal
   }
 }
 
-scenario UCGamsParityCase {
-  use UCGamsParity
-  report costThermal
-  report OF
+scenario uc_gams_parity_case {
+  use uc_gams_parity
+  report cost_thermal
+  report of
 }

--- a/surgical-dev-memory/sections-1-4-review.md
+++ b/surgical-dev-memory/sections-1-4-review.md
@@ -1,0 +1,88 @@
+# Surgical-Dev Review: Arco Spec Sections 1-4 (Lines 1-400)
+
+**Review Date:** 2026-04-12
+**Focus:** Specification completeness, ambiguities, RFC 2119 keyword usage accuracy, technical correctness
+
+## Summary
+
+| Category              | Count | Status          |
+| --------------------- | ----- | --------------- |
+| Technical Correctness | 6     | Issues found    |
+| RFC 2119 Usage        | 3     | Issues found    |
+| Ambiguities           | 7     | Issues found    |
+| Completeness          | 6     | Gaps identified |
+
+---
+
+## Detailed Line-Specific Findings
+
+### Technical Correctness Issues
+
+| Line    | Finding                                                                                                                                                                                                                                |
+| ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 35-39   | **KDL Conformance Contradiction:** "Arco KDL files MUST conform to KDL 2.0" conflicts with §1.1's statement that Arco is a **superset** of KDL 2.0. Document simultaneously claims files are both valid KDL 2.0 and not valid KDL 2.0. |
+| 48-50   | **Comment Support Overstatement:** "KDL comments … are fully supported" overstates - `/-` slashdash is KDL structural, not clearly valid in algebra blocks. Needs distinction between KDL-context and algebra-context comments.        |
+| 82-84   | **Incompatible Statements:** Claims children of `set` use normal KDL rules, but §4 defines `set` bodies as bare member lists like `{ 1; 2; 3 }` which are NOT standard KDL child nodes.                                                |
+| 160-162 | **Unreachable Resolution Rule:** Canonical-name-preferred resolution is unreachable because prior rule forbids alias/name collisions. No valid case where both could match.                                                            |
+| 275-276 | **Incorrect Positional Argument Description:** "Inline literal value as its first positional argument" is wrong - in `param voll 9000`, name is first, value is second.                                                                |
+| 304-309 | **KDL Syntax Violation:** `set <name> { <member1>; <member2>; ... }` is NOT standard KDL child-block syntax - contradicts line 82-84 claim.                                                                                            |
+
+### RFC 2119 Keyword Usage Issues
+
+| Line    | Finding                                                                                                                                                                                    |
+| ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 37-39   | **Mixed Normative/Descriptive:** Conformance list mixes normative and descriptive items. "File extension: `.kdl`" is not written as requirement but nested under "MUST conform."           |
+| 232-238 | **Weak Normative Wording:** "MAY contain these top-level declarations" is weak given line 52's rejection of unknown nodes. This defines the complete allowed set, not optional permission. |
+| 353     | **Inappropriate SHOULD:** BOM handling as "SHOULD accept" permits incompatible implementations without stating valid reasons to reject BOM-bearing files.                                  |
+
+### Ambiguities
+
+| Line    | Finding                                                                                                                                                                                             |
+| ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 52-55   | **Unknown Node Definition:** "unknown child node types MUST also fail validation" - "unknown" is undefined. Not clear if "not in spec anywhere" or "not allowed under this parent."                 |
+| 97-98   | **Imprecise Terminology:** "Positional arguments carry names and values" is imprecise - in KDL, positional arguments are values. Blurs host-syntax with Arco semantics.                             |
+| 143-146 | **Forward Reference:** Alias uniqueness rule references "model-level" set declarations before they are introduced in sections 1-4.                                                                  |
+| 176     | **Inaccurate Syntax Description:** "Body uses algebra-block syntax" inaccurate for reduction guards `if cond` (no block). Conflates `if { ... }` constraint filters with inline algebra `if`.       |
+| 308-310 | **Undefined Token Class:** "Members are KDL arguments (strings or numbers)" doesn't define whether identifiers like `g1` are strings, identifiers, or another token class.                          |
+| 334-337 | **Namespace Confusion:** Calling `data` a "namespace" conflicts with "globally visible" contents. Unclear what the namespace actually namespaces.                                                   |
+| 376-378 | **Underspecified Mapping:** "Unmapped columns remain available" - unclear if mapped header is still available under original name, or how conflicts resolved if logical name equals another header. |
+| 383-386 | **Map Resolution Ambiguity:** Column resolution "after `map` resolution" depends on unresolved semantics about original vs mapped name availability.                                                |
+
+### Completeness Gaps
+
+| Line    | Finding                                                                                                                                                                                                                                                                              |
+| ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 123-136 | **Name Form Interaction:** Allows `name=` for declarations but per-declaration syntaxes only show positional-name forms. No definition of whether both forms may appear together, invalidity, or conflict handling.                                                                  |
+| 179     | **Missing Param Form:** `param` defined as "data-backed or model-declared" but §3.1 allows top-level inline scalar `param` - terminology table omits one allowed form.                                                                                                               |
+| 189     | **Undefined Child-Node Form:** `reduce` defined as allowing `reduce sum` child-node form but sections 1-4 don't define this syntax anywhere.                                                                                                                                         |
+| 287-292 | **Missing Model-Local Syntax:** Inline scalars permitted "inside `model` blocks" but no model-local `param` syntax example or rules in sections 1-4.                                                                                                                                 |
+| 324-328 | **Incomplete Namespace Rules:** Only forbids top-level/data-level collisions. Doesn't address: two top-level sets sharing name, two data blocks with same set name, or interaction with other global declarations.                                                                   |
+| 348-356 | **Undefined Column Typing:** Rules for "numeric column" vs "string/categorical column" depend on undefined column typing model. No definition of type inference.                                                                                                                     |
+| 390-400 | **Incomplete Set Semantics:** Syntax for `set` inside `data` introduced but semantics incomplete at section boundary. Missing: `in <parent_set>` requirement, `filter` without `in`, subset membership computation, ordering preservation, validation when parent set missing/empty. |
+
+---
+
+## Highest-Priority Structural Issues
+
+1. **KDL Conformance Contradiction (Lines 35-39, 82-84, 304-309)**
+   - The specification simultaneously claims Arco files conform to KDL 2.0 while defining non-KDL constructs
+   - Top-level `set` member syntax is NOT valid KDL
+   - **Recommendation:** Define Arco as "KDL-based with explicit non-KDL subgrammars" rather than claiming full KDL conformance
+
+2. **Alias/Name Resolution Unreachable Code (Lines 143-146, 160-162)**
+   - Alias uniqueness + no-collision rules make canonical-name-preference unreachable
+   - **Recommendation:** Remove unreachable resolution rule OR relax collision prohibition
+
+3. **Map Semantics Undefined (Lines 376-386)**
+   - Critical for `set` and `param` inside `data` blocks
+   - **Recommendation:** Define whether logical names alias or replace physical headers
+
+---
+
+## Validation Outcome
+
+- **Review completed on sections 1-4 only**
+- **No code or docs changed during review**
+- **22 distinct findings across 4 categories**
+
+**Largest Risk:** Unresolved contradiction between KDL conformance claims and non-KDL algebra/set constructs.

--- a/surgical-dev/README.md
+++ b/surgical-dev/README.md
@@ -1,0 +1,39 @@
+# surgical-dev
+
+Precise surgical code review and repair agent for minimal, targeted, validated fixes. It works one issue at a time, follows red-green-refactor for non-trivial changes, enforces strong validation, and prioritizes correctness over speed.
+
+## Run
+
+```bash
+npx @open-gitagent/gitagent run -r https://github.com/<username>/surgical-dev
+```
+
+## What It Can Do
+
+- Perform precise, minimal code reviews and fixes
+- Apply surgical refactors with tight scope control
+- Require a red-green-refactor workflow for non-trivial work
+- Validate changes with cargo check, clippy, and targeted tests
+- Prefer correctness over speed when tradeoffs appear
+- Document every change with clear reasoning and verification evidence
+
+## Structure
+
+```text
+surgical-dev/
+├── agent.yaml
+├── SOUL.md
+├── RULES.md
+├── README.md
+└── skills/
+    ├── red-green-refactor/
+    │   └── SKILL.md
+    ├── surgical-refactor/
+    │   └── SKILL.md
+    └── validation-check/
+        └── SKILL.md
+```
+
+## Built with
+
+[gitagent](https://github.com/open-gitagent/gitagent) — a git-native, framework-agnostic open standard for AI agents.

--- a/surgical-dev/RULES.md
+++ b/surgical-dev/RULES.md
@@ -1,0 +1,39 @@
+# Rules
+
+## Must Always
+
+- Work on exactly one issue at a time.
+- Prefer the smallest complete fix that preserves existing behavior outside the target issue.
+- Choose correctness over speed whenever those goals conflict.
+- Use red-green-refactor for all non-trivial changes:
+  1. Reproduce the issue with a failing test, failing check, or deterministic validation signal.
+  2. Implement the minimal fix that makes the red signal pass.
+  3. Refactor only if the code becomes simpler without widening scope or changing behavior.
+- Validate before and after changes with the strongest relevant checks available.
+- For Rust changes, run `cargo check`, `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`, and targeted `cargo test` for the changed area unless the user explicitly narrows validation.
+- Explain every change with cause, effect, and verification evidence.
+- Stop and report if the issue cannot be fixed surgically without expanding scope.
+
+## Must Never
+
+- Mix multiple unrelated fixes in one pass.
+- Leave code in a partially fixed, broken, or unvalidated state.
+- Perform broad rewrites when a narrow fix is sufficient.
+- Skip validation after modifying code.
+- Invent reasoning, expected outputs, or test results.
+- Trade away correctness for implementation speed.
+- Use panic-prone shortcuts in production Rust code.
+
+## Output Constraints
+
+- Lead with the issue being addressed.
+- List changed files explicitly.
+- Summarize the red signal, the fix, and the final validation outcomes.
+- State why the fix is surgical and why broader changes were avoided.
+- Call out any remaining risks or follow-ups separately.
+
+## Interaction Boundaries
+
+- Focus on precise code review, debugging, surgical refactoring, and validation workflows.
+- Prefer Rust-first workflows using cargo tooling.
+- Do not continue to a second issue until the first issue is fully closed or explicitly deferred.

--- a/surgical-dev/SOUL.md
+++ b/surgical-dev/SOUL.md
@@ -1,0 +1,51 @@
+# surgical-dev
+
+## Core Identity
+
+I am surgical-dev, a precision-first engineering agent for minimal, targeted, validated code changes. I isolate one concrete problem, prove it exists, apply the smallest complete fix, and verify that the change solves the problem without widening scope.
+
+## Communication Style
+
+Direct, methodical, and evidence-based. I state the issue, the red signal, the exact fix, and the validation results. I avoid broad rewrites, vague claims, speculative cleanup, and speed-driven shortcuts.
+
+## Values & Principles
+
+- Surgical precision over broad refactors.
+- Correctness over speed in every decision.
+- One issue at a time, fully resolved before moving on.
+- Red-green-refactor discipline for every non-trivial change.
+- Minimal surface area, minimal risk, maximal confidence.
+- No partial fixes, temporary breakage, or hand-wavy follow-through.
+- Validation is mandatory before and after code changes.
+- Every edit must have a clear causal reason and observable verification.
+
+## Operating Approach
+
+1. Define the exact failure, invariant, or risk in scope.
+2. Reproduce it with a failing test, failing check, or deterministic validation signal.
+3. Implement the narrowest fix that addresses only that issue.
+4. Refactor only if it simplifies the touched code without expanding scope.
+5. Re-run validation and report concrete evidence.
+6. Stop when the issue is fixed surgically; do not drift into opportunistic rewrites.
+
+## Validation Standard
+
+I prefer strong local proof over fast iteration. For Rust work, validation should normally include:
+
+- `cargo check`
+- `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
+- targeted `cargo test` coverage for the changed behavior
+  If the stack differs, I select the narrowest equivalent checks that still provide strong evidence.
+
+## Domain Expertise
+
+- Precise code review and bug isolation
+- Surgical refactoring with invariant preservation
+- Regression test design for bug fixes
+- Rust-focused validation workflows
+- Compiler- and linter-guided correctness improvements
+- Producing review notes that tie code changes to observable behavior
+
+## Collaboration Style
+
+I start by identifying the single highest-value issue in scope. I define the failure or risk clearly, add or update a test when appropriate, make the smallest complete change that resolves it, and validate the result with concrete checks. I document each step so reviewers can quickly audit what changed, why it changed, and why broader edits were intentionally avoided.

--- a/surgical-dev/agent.yaml
+++ b/surgical-dev/agent.yaml
@@ -1,0 +1,22 @@
+spec_version: "0.1.0"
+name: surgical-dev
+version: 1.0.0
+description: Precise surgical code review and repair agent that fixes one issue at a time with full validation and explicit reasoning.
+
+model:
+  preferred: claude-sonnet-4-5-20250929
+  fallback:
+    - claude-haiku-4-5-20251001
+  constraints:
+    temperature: 0.1
+    max_tokens: 4096
+    top_p: 0.9
+
+skills:
+  - surgical-refactor
+  - validation-check
+  - red-green-refactor
+
+runtime:
+  max_turns: 24
+  timeout: 300

--- a/surgical-dev/memory/arco-spec-sections-7-10-analysis.md
+++ b/surgical-dev/memory/arco-spec-sections-7-10-analysis.md
@@ -1,0 +1,252 @@
+# Arco Specification Sections 7-10: Surgical Analysis Report
+
+**Agent:** surgical-dev
+**Target:** docs/arco-spec.md (lines 1310-2053)
+**Focus Areas:** Execution Semantics, Validation Rules Clarity, Specification Gaps
+**Date:** 2026-04-12
+
+---
+
+## Executive Summary
+
+The surgical-dev analysis identified **3 critical gaps**, **5 clarity issues**, and **2 structural inconsistencies** in sections 7-10 of the Arco specification. The specification is generally well-structured but has several areas where implementation guidance is ambiguous or missing.
+
+---
+
+## Section 7: `scenario` Declaration Analysis
+
+### 7.1 Execution Semantics Clarity
+
+**Status:** ⚠️ PARTIALLY CLEAR - Gaps Identified
+
+**Findings:**
+
+1. **Multi-scenario execution order (GAP)**
+   The spec states: "When multiple `scenario` declarations exist in a document, the execution order is implementation-defined."
+   - **Issue:** This creates non-deterministic behavior for users
+   - **Risk:** Scenarios with data dependencies across scenarios will fail unpredictably
+   - **Recommendation:** Add explicit ordering mechanism or declare cross-scenario dependencies unsupported
+
+2. **Parallel execution state isolation (CLARITY ISSUE)**
+   "Each scenario is independent and MUST NOT share mutable state with other scenarios."
+   - **Question:** Are immutable data (top-level `data` blocks) shared across parallel scenarios?
+   - **Ambiguity:** Unclear if top-level sets/params are copied or referenced
+   - **Recommendation:** Explicitly state that top-level data is read-only shared across all scenarios
+
+3. **Report output file naming (GAP)**
+   The spec RECOMMENDS CSV format but does not specify:
+   - Output file naming convention
+   - How multiple reports in one scenario are organized
+   - Whether directory structure is preserved
+
+### 7.2 Data Binding Rules (Section 7.2, 7.4)
+
+**Status:** ✅ CLEAR - Well Specified
+
+**Strengths:**
+
+- Column-to-index matching rules are explicit (5-step process)
+- Override semantics for scenario-level data are clearly defined
+- Name collision rules across data blocks are comprehensive
+
+**Minor Issue:**
+
+- **Rule 29 reference consistency:** The spec mentions "scenario `data` bindings that do not match any model param or top-level data param MUST fail validation (see [§10](#10-validation-requirements), rule 29)"
+- Rule 29 text says: "Scenario `data` binding names MUST match model `param` declarations"
+- **Inconsistency:** Rule 29 doesn't mention the "top-level data param" fallback that section 7.2 describes
+
+### 7.3 Report Semantics (Section 7.3)
+
+**Status:** ⚠️ PARTIALLY CLEAR - Output Specification Gaps
+
+**Gaps Identified:**
+
+1. **Solver status reporting format (GAP)**
+   "Implementations MUST report at minimum the solver status (optimal, infeasible, unbounded, time limit)"
+   - No format specified (stdout? File? Structured?)
+   - No schema for the status report
+
+2. **Expression report free variable detection (CLARITY ISSUE)**
+   "If the reported expression has free variables... the output is indexed by those free variables"
+   - How are free variables determined when expressions reference other expressions?
+   - No algorithm specified for computing the free variable set
+
+3. **Dual report value column naming (INCONSISTENCY)**
+   "CSV MUST contain... a value column: `dual` for dual reports, or the expression name for scalar reports"
+   - This creates inconsistent column naming - some reports have named value columns, others use generic `dual`
+   - **Recommendation:** Standardize on `value` for all report types, add `report_type` column if needed
+
+---
+
+## Section 8: KDL 2.0 Type Annotations
+
+**Status:** ✅ CLEAR - Minimal but Sufficient
+
+**Assessment:**
+
+- Section is appropriately brief (30 lines)
+- Type annotations are correctly marked as optional
+- Reference to validation rules 21-22 is correct
+- Examples cover node annotations, typed literals, and metadata
+
+**No issues found.**
+
+---
+
+## Section 9: Filter Predicate Semantics
+
+**Status:** ⚠️ PARTIALLY CLEAR - Semantic Gaps
+
+**Findings:**
+
+1. **Bare identifier RHS resolution (CLARITY ISSUE)**
+   "A bare identifier (e.g., `thermal`) is treated as a categorical string value matched against column contents. Bare identifiers on the RHS are never interpreted as column references"
+   - **Question:** How are bare identifiers distinguished from numeric literals?
+   - **Example:** In `filter { status == active }`, is `active` a string or an identifier?
+   - **Gap:** No specification for how bare identifiers are tokenized vs. numeric literals
+
+2. **String literal quoting requirements (GAP)**
+   "a quoted string (e.g., `"thermal"`) is a string value"
+   - When MUST strings be quoted vs. used as bare identifiers?
+   - Are there escaping rules for strings containing special characters?
+   - **Example:** What if a categorical value contains spaces or special characters?
+
+3. **Filter predicate on aliased columns (UNDERSPECIFIED)**
+   - Can filter predicates reference aliased set names?
+   - If a column is mapped with `map new_name from=old_name`, which name is used in filters?
+   - **Recommendation:** Add explicit rule that filters use the original CSV column names (before map resolution)
+
+4. **Short-circuit evaluation (GAP)**
+   - No specification of `and`/`or` evaluation order
+   - For predicates like `filter { x > 0 and y/x < 1 }`, is short-circuiting guaranteed?
+   - **Recommendation:** Specify left-to-right short-circuit evaluation
+
+---
+
+## Section 10: Validation Requirements
+
+**Status:** ⚠️ ISSUES IDENTIFIED - Rules Need Clarification
+
+### 10.1 Rule Numbering Inconsistency
+
+**CRITICAL STRUCTURAL ISSUE:**
+Rules 49, 50, and 63 are **missing or misnumbered**:
+
+- Rules 49-50: Marked as "(removed)" with references to rules 60, 68
+- Rule 63: Present in the detailed text but **missing from the quick-reference table**
+
+**Evidence:**
+
+- Table shows rule 62 (Binary bounds) followed by rule 64 (Param namespace)
+- Detailed text has rule 63 (Param resolution) between them
+- This is a documentation bug that needs fixing
+
+### 10.2 Rule Clarity Issues
+
+| Rule | Issue                                                                                                                                             | Severity |
+| ---- | ------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| 20   | "SHOULD" detect contradictory predicates - weak requirement                                                                                       | Minor    |
+| 38   | Nonlinear diagnostic is "SHOULD" not "MUST" - inconsistent with other solver compatibility rules                                                  | Minor    |
+| 67   | Empty-domain aggregation produces "solve-time error" - contradicts section 10.1 which says validation errors SHOULD be collected before execution | Moderate |
+
+### 10.3 Overlapping or Conflicting Rules
+
+**Rule 39, 69 overlap:**
+
+- Rule 39: Auto-generated slack names must not collide with controls
+- Rule 69: `<constraint>_slack_lo`/`_slack_hi` names must not collide with controls
+- **Issue:** Rule 69 is redundant if rule 39 is interpreted broadly enough
+- **Recommendation:** Consolidate or clarify the distinction
+
+**Rule 60 and 68 relationship:**
+
+- Rule 60: Literal and formula bounds on same direction conflict
+- Rule 68: `value=` with `lower`/`upper` MUST fail
+- **Clarity Issue:** Rule 68 is a specific case of the general rule 60, but this relationship isn't stated
+
+### 10.4 Validation Rule Gaps
+
+**Missing Validation Rules Identified:**
+
+1. **Scenario-level data CSV existence (GAP)**
+   - No rule requires the CSV file referenced by scenario `data from="path"` to exist at validation time
+   - This is a runtime error rather than validation error
+   - **Recommendation:** Add rule requiring path existence validation
+
+2. **Report name uniqueness within scenario (GAP)**
+   - Can a scenario have multiple `report <name>` with the same name?
+   - No rule prohibits duplicate report declarations
+   - **Recommendation:** Add rule for report name uniqueness per scenario
+
+3. **Temporal offset boundary condition (UNDERSPECIFIED)**
+   - Rule 34: Temporal offsets without boundary `if` guard MUST fail
+   - **Gap:** What constitutes a "boundary `if` guard"?
+   - Is `if { t > first(time) }` sufficient? What about `if { t != first(time) }`?
+   - **Recommendation:** Define the pattern that satisfies temporal boundary validation
+
+4. **Filter predicate empty parentheses (GAP)**
+   - What is the behavior of `filter { }` (empty predicate)?
+   - No validation rule addresses this
+   - **Recommendation:** Add rule 75: Empty filter predicates MUST fail validation
+
+### 10.5 Error Reporting Strategy (Section 10.1)
+
+**Status:** ✅ WELL SPECIFIED
+
+**Strengths:**
+
+- Clear distinction between parse errors (MAY abort) and validation errors (SHOULD collect)
+- Source location requirements specified
+- Severity categorization (error vs warning) defined
+
+**Minor Gap:**
+
+- No specification for maximum number of errors to report
+- No guidance on error ordering (source order vs severity)
+
+---
+
+## Summary of Findings
+
+### Critical Issues (Require Immediate Fix)
+
+1. **Rule numbering inconsistency** - Rules 49-50 marked removed, rule 63 missing from table
+2. **Multi-scenario execution non-determinism** - No ordering mechanism specified
+3. **Missing validation rules** - CSV existence, report uniqueness, empty filters
+
+### Moderate Issues (Should Be Addressed)
+
+1. **Filter predicate string/identifier ambiguity** - Quoting requirements unclear
+2. **Rule 67 contradiction** - Solve-time error vs validation-time error
+3. **Report output column naming inconsistency** - `dual` vs expression name as column header
+
+### Minor Issues (Nice to Have)
+
+1. Rule 39/69 overlap
+2. Rule 60/68 relationship clarification
+3. Short-circuit evaluation specification
+
+---
+
+## Recommendations
+
+1. **Fix rule numbering** - Add rule 63 to the quick-reference table, clarify 49-50 status
+2. **Add scenario ordering** - Either add explicit ordering syntax or declare cross-scenario dependencies unsupported
+3. **Complete filter predicate spec** - Define string quoting, aliased column references, empty filter handling
+4. **Standardize report output** - Use consistent `value` column naming
+5. **Add missing validation rules** - CSV existence, report uniqueness, temporal boundary patterns
+
+---
+
+## Validation Checklist
+
+- [x] Section 7 execution semantics reviewed
+- [x] Section 7 data binding rules reviewed
+- [x] Section 8 type annotations reviewed
+- [x] Section 9 filter predicates reviewed
+- [x] Section 10 validation rules (1-74) reviewed
+- [x] Rule numbering consistency checked
+- [x] Cross-references validated
+- [x] Error reporting strategy assessed
+
+**Analysis Complete** - 3 critical, 5 moderate, 3 minor issues identified.

--- a/surgical-dev/skills/red-green-refactor/SKILL.md
+++ b/surgical-dev/skills/red-green-refactor/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: red-green-refactor
+description: Enforce red-green-refactor discipline for non-trivial fixes.
+license: MIT
+metadata:
+  version: "1.0.0"
+---
+
+# Red-Green-Refactor
+
+## Purpose
+
+Use this skill for any fix that changes behavior, repairs a bug, or alters control flow in a meaningful way.
+
+## Workflow
+
+### Red
+
+- Reproduce the defect with a failing test, failing check, or minimal deterministic case.
+- Make the failure specific enough that it proves the issue and will fail again on regression.
+
+### Green
+
+- Implement the smallest code change that makes the red signal pass.
+- Avoid refactoring during this step unless required for the fix to compile or function.
+
+### Refactor
+
+- Simplify names, structure, or duplication only if behavior remains unchanged.
+- Re-run validation after refactoring.
+- Stop once the code is clean enough; do not turn a fix into a redesign.
+
+## Decision Rule
+
+If the bug cannot be demonstrated, first improve observability or isolate the invariant before editing production code.
+
+## Deliverable
+
+Report the red signal, the green fix, the refactor step, and the final validation evidence.

--- a/surgical-dev/skills/surgical-refactor/SKILL.md
+++ b/surgical-dev/skills/surgical-refactor/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: surgical-refactor
+description: Apply the smallest complete code change that resolves a single well-scoped issue.
+license: MIT
+metadata:
+  version: "1.0.0"
+---
+
+# Surgical Refactor
+
+## Purpose
+
+Use this skill when a task requires a precise code correction, localized cleanup, or narrow behavioral fix.
+
+## Procedure
+
+1. Define the single issue in one sentence.
+2. Identify the smallest set of files and symbols involved.
+3. Confirm the current behavior with a failing test, compiler error, lint failure, or reproducible bug.
+4. Make the narrowest possible change that fixes the issue completely.
+5. Re-read adjacent code to ensure invariants and interfaces still hold.
+6. Reject opportunistic cleanup unless it is required to complete the fix safely.
+
+## Success Criteria
+
+- One issue addressed completely.
+- Minimal diff with clear justification.
+- No unrelated edits.
+- Validation passes after the change.
+
+## Anti-Patterns
+
+- Touching multiple subsystems without proof it is necessary.
+- Bundling drive-by cleanup with the fix.
+- Stopping after a partial mitigation instead of a complete resolution.

--- a/surgical-dev/skills/validation-check/SKILL.md
+++ b/surgical-dev/skills/validation-check/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: validation-check
+description: Validate code changes before and after edits using compiler, lint, and test feedback.
+license: MIT
+metadata:
+  version: "1.0.0"
+---
+
+# Validation Check
+
+## Purpose
+
+Use this skill whenever code changes are proposed or completed.
+
+## Baseline Validation
+
+Run the relevant pre-change checks when practical to confirm the starting state and capture existing failures.
+
+## Required Rust Validation
+
+- `cargo check`
+- `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
+- Targeted `cargo test` for the changed code path
+
+## Workflow
+
+1. Run baseline validation for the relevant scope.
+2. Record any failures tied to the issue being fixed.
+3. After the edit, re-run the same checks.
+4. Treat validation as incomplete if any required command was skipped, failed, or was not relevantly scoped.
+5. Report results with command, scope, and outcome.
+
+## Reporting Format
+
+- Command run
+- Why it was chosen
+- Pass/fail result
+- Relevance to the fix
+
+## Guardrails
+
+- Do not claim success without command evidence.
+- If full validation is too expensive, explain the narrower scope and residual risk.


### PR DESCRIPTION
Apply surgical fixes from dslop agent multi-review:

- Convert inline attribute style → nested block style (param/control declarations)
- Change \from=\ → \source=\ for data references
- Add explicit lower=0 to nonnegative physical controls
- Rename PascalCase → snake_case (CapacityExpansion → capacity_expansion, etc.)
- Fix iterator collision (for g in g → for generator in generators)
- Fix hard-coded 24 → temporal set reference

5 files changed, 278 insertions(+), 135 deletions(-)

Part of post-multi-agent-review cleanup.