### PR TITLE
fix: addressing subset inspection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -592,3 +592,10 @@ benchmarks/output/
 !examples/simple-electricity-market-storage/data/*.csv
 !examples/dense-lp/data/*.csv
 .plans/
+
+# Local generated docs and parser artifacts
+docs/reference/rfds/
+stats-output/
+tools/tree-sitter-arco-kdl/binding.gyp
+tools/tree-sitter-arco-kdl/bindings/
+tools/tree-sitter-arco-kdl/src/vendor/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ is a README-level guide, not full system documentation.
 - Never revert or overwrite work you did not author.
 - If a command hangs for more than 5 minutes, stop, capture context, and report.
 - Use `just` targets when available for build, lint, and test workflows.
+- Before pushing, run the relevant CI-equivalent checks locally for changed areas (for example, clippy/tests/docs) to catch failures early.
 
 ## Engineering Workflow
 
@@ -32,6 +33,8 @@ Use red-green-refactor for all non-trivial changes:
 3. Refactor: simplify while preserving behavior and keeping tests green.
 
 Additional expectations:
+
+- For every new development task, create and work from a branch under `.worktrees/` unless explicitly directed otherwise.
 
 - Start from first principles, not bandaids.
 - No breadcrumbs. If you delete or move code, do not leave a comment in the old

--- a/crates/arco-cli/src/main.rs
+++ b/crates/arco-cli/src/main.rs
@@ -107,7 +107,8 @@ fn main() -> miette::Result<()> {
     let _ = miette::set_hook(Box::new(|_| {
         Box::new(miette::MietteHandlerOpts::new().build())
     }));
-    init_tracing(cli.verbose);
+    let validate_command = matches!(&cli.command, Command::Validate { .. });
+    init_tracing(cli.verbose, validate_command);
 
     match cli.command {
         Command::Run {
@@ -201,12 +202,12 @@ fn handle_solver_action(action: SolverAction) -> miette::Result<()> {
     Ok(())
 }
 
-fn init_tracing(verbose: u8) {
-    if verbose == 0 {
+fn init_tracing(verbose: u8, force_warnings: bool) {
+    if verbose == 0 && !force_warnings {
         return;
     }
-
     let level = match verbose {
+        0 => tracing::Level::WARN,
         1 => tracing::Level::INFO,
         _ => tracing::Level::DEBUG,
     };

--- a/crates/arco-cli/tests/example_cli_commands.rs
+++ b/crates/arco-cli/tests/example_cli_commands.rs
@@ -1,5 +1,9 @@
 use std::path::PathBuf;
 use std::process::Command;
+use std::{
+    fs,
+    time::{SystemTime, UNIX_EPOCH},
+};
 
 use serde_json::Value;
 
@@ -14,6 +18,14 @@ fn run_cli(args: &[&str]) -> std::process::Output {
         .args(args)
         .output()
         .expect("failed to execute arco binary")
+}
+
+fn unique_temp_dir(prefix: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock should be after unix epoch")
+        .as_nanos();
+    std::env::temp_dir().join(format!("arco-cli-{prefix}-{}-{nanos}", std::process::id()))
 }
 
 #[test]
@@ -167,4 +179,66 @@ fn inspect_json_parameters_have_dtype() {
         assert!(param.get("kind").is_some());
         assert!(param.get("dtype").is_some());
     }
+}
+
+#[test]
+fn validate_surfaces_empty_filtered_subset_warning() {
+    let root = unique_temp_dir("validate-empty-filtered-subset");
+    let data_dir = root.join("data");
+    fs::create_dir_all(&data_dir).expect("create temp data dir");
+    fs::write(data_dir.join("assets.csv"), "asset\nA\nB\n").expect("write csv");
+
+    let model_path = root.join("input.kdl");
+    fs::write(
+        &model_path,
+        r#"
+data "assets_data" source="data/assets.csv" {
+  set "asset"
+  set "missing_assets" {
+    in "asset"
+    filter { asset == "missing" }
+  }
+}
+
+model "Dispatch" {
+  set "asset"
+
+  control "x" {
+    index "asset"
+  }
+
+  minimize "Obj" {
+    sum(x[asset] for asset in asset)
+  }
+}
+
+scenario "S1" {
+  use "Dispatch"
+}
+"#,
+    )
+    .expect("write model");
+
+    let model = model_path
+        .to_str()
+        .expect("model path contains invalid unicode");
+    let output = run_cli(&["validate", model]);
+
+    assert!(
+        output.status.success(),
+        "command failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Validated file://"));
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("filtered subset resolved empty"),
+        "expected filtered-subset warning in stderr, got:\n{stderr}"
+    );
+
+    let _ = fs::remove_dir_all(root);
 }

--- a/crates/arco-kdl/src/compile/data_tables.rs
+++ b/crates/arco-kdl/src/compile/data_tables.rs
@@ -39,10 +39,12 @@ fn evaluate_data_param_filter_expr(
         Expr::Boolean(value) => Some(FilterValue::Boolean(*value)),
         Expr::Identifier(name) => {
             let source_name = resolve_data_column(data_decl, name);
-            row.get(name)
+            let value = row
+                .get(name)
                 .or_else(|| row.get(&source_name))
                 .cloned()
-                .map(FilterValue::String)
+                .unwrap_or_else(|| name.clone());
+            Some(FilterValue::String(value))
         }
         Expr::Unary { op, expr } => {
             let value = evaluate_data_param_filter_expr(expr, row, data_decl)?;

--- a/crates/arco-kdl/src/semantic/error.rs
+++ b/crates/arco-kdl/src/semantic/error.rs
@@ -121,4 +121,21 @@ pub enum SemanticError {
         name: String,
         path: PathBuf,
     },
+
+    #[error(
+        "unresolved filter identifier `{identifier}` in {declaration_kind} `{declaration}` from data `{data}` in {path}"
+    )]
+    #[diagnostic(
+        code(arco::semantic::unresolved_filter_identifier),
+        help(
+            "if token is categorical value, quote it in filter, e.g. `filter {{ tech == \"wind\" }}`"
+        )
+    )]
+    UnresolvedFilterIdentifier {
+        identifier: String,
+        declaration_kind: &'static str,
+        declaration: String,
+        data: String,
+        path: PathBuf,
+    },
 }

--- a/crates/arco-kdl/src/semantic/sets.rs
+++ b/crates/arco-kdl/src/semantic/sets.rs
@@ -5,6 +5,7 @@ use crate::source::{DataDecl, LiteralValue, ModelDecl, SetDecl, SourceProgram};
 use csv::StringRecord;
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
+use tracing::warn;
 
 pub(crate) fn collect_set_aliases(
     program: &SourceProgram,
@@ -42,14 +43,12 @@ pub(crate) fn extend_set_registry_from_low_level_declarations(
     entry_dir: &Path,
     registry: &mut BTreeMap<String, ResolvedSet>,
 ) -> Result<(), SemanticError> {
-    let mut data_rows = BTreeMap::new();
     for data_decl in &program.data {
         let csv_path = entry_dir.join(&data_decl.source);
         let rows = read_csv_rows(&csv_path)?;
-        data_rows.insert(data_decl.name.clone(), rows);
-
+        validate_data_filter_identifiers(data_decl, &rows, &csv_path)?;
         for set_decl in &data_decl.sets {
-            let values = values_for_data_set(data_decl, set_decl, &data_rows[&data_decl.name]);
+            let values = values_for_data_set(data_decl, set_decl, &rows)?;
             registry.insert(set_decl.name.clone(), ResolvedSet { values });
         }
     }
@@ -112,11 +111,330 @@ fn record_to_map(
     Ok(row)
 }
 
+fn validate_data_filter_identifiers(
+    data_decl: &DataDecl,
+    rows: &[BTreeMap<String, String>],
+    path: &Path,
+) -> Result<(), SemanticError> {
+    let Some(first_row) = rows.first() else {
+        return Ok(());
+    };
+    let source_columns = first_row.keys().cloned().collect::<BTreeSet<_>>();
+
+    for set_decl in &data_decl.sets {
+        validate_filter_identifiers_for_declaration(
+            data_decl,
+            set_decl.parsed_filter_expression.as_ref(),
+            &source_columns,
+            "set",
+            &set_decl.name,
+            path,
+        )?;
+    }
+
+    for param_decl in &data_decl.parameters {
+        validate_filter_identifiers_for_declaration(
+            data_decl,
+            param_decl.parsed_filter_expression.as_ref(),
+            &source_columns,
+            "param",
+            &param_decl.name,
+            path,
+        )?;
+    }
+
+    Ok(())
+}
+
+fn validate_filter_identifiers_for_declaration(
+    data_decl: &DataDecl,
+    expr: Option<&Expr>,
+    source_columns: &BTreeSet<String>,
+    declaration_kind: &'static str,
+    declaration_name: &str,
+    path: &Path,
+) -> Result<(), SemanticError> {
+    let Some(expr) = expr else {
+        return Ok(());
+    };
+
+    validate_filter_expr(
+        expr,
+        data_decl,
+        source_columns,
+        declaration_kind,
+        declaration_name,
+        path,
+    )
+}
+
+fn validate_filter_expr(
+    expr: &Expr,
+    data_decl: &DataDecl,
+    source_columns: &BTreeSet<String>,
+    declaration_kind: &'static str,
+    declaration_name: &str,
+    path: &Path,
+) -> Result<(), SemanticError> {
+    validate_filter_expr_internal(
+        expr,
+        data_decl,
+        source_columns,
+        declaration_kind,
+        declaration_name,
+        path,
+        false,
+    )
+}
+
+fn validate_filter_expr_internal(
+    expr: &Expr,
+    data_decl: &DataDecl,
+    source_columns: &BTreeSet<String>,
+    declaration_kind: &'static str,
+    declaration_name: &str,
+    path: &Path,
+    allow_unresolved_identifier: bool,
+) -> Result<(), SemanticError> {
+    match expr {
+        Expr::Comparison { left, right, .. } => {
+            validate_filter_column_side_expr(
+                left,
+                data_decl,
+                source_columns,
+                declaration_kind,
+                declaration_name,
+                path,
+            )?;
+            validate_filter_expr_internal(
+                right,
+                data_decl,
+                source_columns,
+                declaration_kind,
+                declaration_name,
+                path,
+                true,
+            )
+        }
+        Expr::Unary { expr, .. } => validate_filter_expr_internal(
+            expr,
+            data_decl,
+            source_columns,
+            declaration_kind,
+            declaration_name,
+            path,
+            allow_unresolved_identifier,
+        ),
+        Expr::Binary { left, right, .. } => {
+            validate_filter_expr_internal(
+                left,
+                data_decl,
+                source_columns,
+                declaration_kind,
+                declaration_name,
+                path,
+                allow_unresolved_identifier,
+            )?;
+            validate_filter_expr_internal(
+                right,
+                data_decl,
+                source_columns,
+                declaration_kind,
+                declaration_name,
+                path,
+                allow_unresolved_identifier,
+            )
+        }
+        Expr::FunctionCall { args, .. } => {
+            for arg in args {
+                validate_filter_expr_internal(
+                    arg,
+                    data_decl,
+                    source_columns,
+                    declaration_kind,
+                    declaration_name,
+                    path,
+                    allow_unresolved_identifier,
+                )?;
+            }
+            Ok(())
+        }
+        Expr::Indexed { indices, .. } => {
+            for index in indices {
+                validate_filter_expr_internal(
+                    index,
+                    data_decl,
+                    source_columns,
+                    declaration_kind,
+                    declaration_name,
+                    path,
+                    allow_unresolved_identifier,
+                )?;
+            }
+            Ok(())
+        }
+        Expr::Reduction(reduction) => {
+            validate_filter_expr_internal(
+                &reduction.body,
+                data_decl,
+                source_columns,
+                declaration_kind,
+                declaration_name,
+                path,
+                allow_unresolved_identifier,
+            )?;
+            for filter in &reduction.filters {
+                validate_filter_expr_internal(
+                    filter,
+                    data_decl,
+                    source_columns,
+                    declaration_kind,
+                    declaration_name,
+                    path,
+                    allow_unresolved_identifier,
+                )?;
+            }
+            Ok(())
+        }
+        Expr::Identifier(identifier) => {
+            if allow_unresolved_identifier {
+                Ok(())
+            } else {
+                validate_filter_identifier(
+                    identifier,
+                    data_decl,
+                    source_columns,
+                    declaration_kind,
+                    declaration_name,
+                    path,
+                )
+            }
+        }
+        Expr::Number(_) | Expr::String(_) | Expr::Boolean(_) => Ok(()),
+    }
+}
+
+fn validate_filter_column_side_expr(
+    expr: &Expr,
+    data_decl: &DataDecl,
+    source_columns: &BTreeSet<String>,
+    declaration_kind: &'static str,
+    declaration_name: &str,
+    path: &Path,
+) -> Result<(), SemanticError> {
+    match expr {
+        Expr::Identifier(identifier) => validate_filter_identifier(
+            identifier,
+            data_decl,
+            source_columns,
+            declaration_kind,
+            declaration_name,
+            path,
+        ),
+        Expr::Unary { expr, .. } => validate_filter_column_side_expr(
+            expr,
+            data_decl,
+            source_columns,
+            declaration_kind,
+            declaration_name,
+            path,
+        ),
+        Expr::Binary { left, right, .. } | Expr::Comparison { left, right, .. } => {
+            validate_filter_column_side_expr(
+                left,
+                data_decl,
+                source_columns,
+                declaration_kind,
+                declaration_name,
+                path,
+            )?;
+            validate_filter_column_side_expr(
+                right,
+                data_decl,
+                source_columns,
+                declaration_kind,
+                declaration_name,
+                path,
+            )
+        }
+        Expr::FunctionCall { args, .. } => {
+            for arg in args {
+                validate_filter_column_side_expr(
+                    arg,
+                    data_decl,
+                    source_columns,
+                    declaration_kind,
+                    declaration_name,
+                    path,
+                )?;
+            }
+            Ok(())
+        }
+        Expr::Indexed { indices, .. } => {
+            for index in indices {
+                validate_filter_column_side_expr(
+                    index,
+                    data_decl,
+                    source_columns,
+                    declaration_kind,
+                    declaration_name,
+                    path,
+                )?;
+            }
+            Ok(())
+        }
+        Expr::Reduction(reduction) => {
+            validate_filter_column_side_expr(
+                &reduction.body,
+                data_decl,
+                source_columns,
+                declaration_kind,
+                declaration_name,
+                path,
+            )?;
+            for filter in &reduction.filters {
+                validate_filter_column_side_expr(
+                    filter,
+                    data_decl,
+                    source_columns,
+                    declaration_kind,
+                    declaration_name,
+                    path,
+                )?;
+            }
+            Ok(())
+        }
+        Expr::Number(_) | Expr::String(_) | Expr::Boolean(_) => Ok(()),
+    }
+}
+
+fn validate_filter_identifier(
+    identifier: &str,
+    data_decl: &DataDecl,
+    source_columns: &BTreeSet<String>,
+    declaration_kind: &'static str,
+    declaration_name: &str,
+    path: &Path,
+) -> Result<(), SemanticError> {
+    let source_name = source_column_for_logical_name(data_decl, identifier);
+    if source_columns.contains(identifier) || source_columns.contains(source_name.as_str()) {
+        return Ok(());
+    }
+
+    Err(SemanticError::UnresolvedFilterIdentifier {
+        identifier: identifier.to_string(),
+        declaration_kind,
+        declaration: declaration_name.to_string(),
+        data: data_decl.name.clone(),
+        path: path.to_path_buf(),
+    })
+}
+
 fn values_for_data_set(
     data_decl: &DataDecl,
     set_decl: &SetDecl,
     rows: &[BTreeMap<String, String>],
-) -> Vec<String> {
+) -> Result<Vec<String>, SemanticError> {
     let source_set_name = source_set_name_for_data_set_values(data_decl, set_decl);
     let target_column = source_column_for_logical_name(data_decl, &source_set_name);
     let mut values = BTreeSet::new();
@@ -128,7 +446,18 @@ fn values_for_data_set(
             values.insert(value.clone());
         }
     }
-    values.into_iter().collect()
+
+    let values = values.into_iter().collect::<Vec<_>>();
+    if set_decl.parsed_filter_expression.is_some() && !rows.is_empty() && values.is_empty() {
+        warn!(
+            data = %data_decl.name,
+            set = %set_decl.name,
+            filter = ?set_decl.filter_expression,
+            "filtered subset resolved empty"
+        );
+    }
+
+    Ok(values)
 }
 
 fn source_set_name_for_data_set_values(data_decl: &DataDecl, set_decl: &SetDecl) -> String {
@@ -177,10 +506,12 @@ fn evaluate_data_set_filter_expr(
         Expr::Boolean(value) => Some(DataSetFilterValue::Boolean(*value)),
         Expr::Identifier(name) => {
             let source_name = source_column_for_logical_name(data_decl, name);
-            row.get(name)
+            let value = row
+                .get(name)
                 .or_else(|| row.get(&source_name))
                 .cloned()
-                .map(DataSetFilterValue::String)
+                .unwrap_or_else(|| name.clone());
+            Some(DataSetFilterValue::String(value))
         }
         Expr::Unary { op, expr } => {
             let value = evaluate_data_set_filter_expr(expr, row, data_decl)?;

--- a/crates/arco-kdl/src/semantic/sets.rs
+++ b/crates/arco-kdl/src/semantic/sets.rs
@@ -48,7 +48,7 @@ pub(crate) fn extend_set_registry_from_low_level_declarations(
         let rows = read_csv_rows(&csv_path)?;
         validate_data_filter_identifiers(data_decl, &rows, &csv_path)?;
         for set_decl in &data_decl.sets {
-            let values = values_for_data_set(data_decl, set_decl, &rows)?;
+            let values = values_for_data_set(data_decl, set_decl, &rows);
             registry.insert(set_decl.name.clone(), ResolvedSet { values });
         }
     }
@@ -434,7 +434,7 @@ fn values_for_data_set(
     data_decl: &DataDecl,
     set_decl: &SetDecl,
     rows: &[BTreeMap<String, String>],
-) -> Result<Vec<String>, SemanticError> {
+) -> Vec<String> {
     let source_set_name = source_set_name_for_data_set_values(data_decl, set_decl);
     let target_column = source_column_for_logical_name(data_decl, &source_set_name);
     let mut values = BTreeSet::new();
@@ -457,7 +457,7 @@ fn values_for_data_set(
         );
     }
 
-    Ok(values)
+    values
 }
 
 fn source_set_name_for_data_set_values(data_decl: &DataDecl, set_decl: &SetDecl) -> String {

--- a/crates/arco-kdl/tests/compile_suite.rs
+++ b/crates/arco-kdl/tests/compile_suite.rs
@@ -298,3 +298,78 @@ scenario "S1" {
     fs::remove_dir_all(&root)?;
     Ok(())
 }
+
+#[test]
+fn lowering_applies_data_param_filters_with_bare_identifier_rhs()
+-> Result<(), Box<dyn std::error::Error>> {
+    let root = temp_test_dir("data-param-filter-bare-identifier")?;
+    fs::create_dir_all(root.join("data"))?;
+    fs::write(
+        root.join("data").join("load.csv"),
+        "period,tech,demand\n1,wind,10\n1,solar,90\n2,wind,20\n2,solar,80\n",
+    )?;
+
+    let path = root.join("input.kdl");
+    fs::write(
+        &path,
+        r#"
+set "time" { "1"; "2" }
+
+data "inputs" source="data/load.csv" {
+  map "time" from="period"
+
+  param "demand" from="demand" reduce="sum" {
+    index "time"
+    filter { tech == wind }
+  }
+}
+
+model "Dispatch" {
+  set "time" alias="t"
+
+  param "demand" {
+    index "t"
+  }
+
+  control "x" {
+    index "t"
+  }
+
+  constraint "balance[t]" {
+    x[t] = demand[t]
+  }
+
+  minimize "Obj" {
+    sum(x[t] for t in time)
+  }
+}
+
+scenario "S1" {
+  use "Dispatch"
+}
+"#,
+    )?;
+
+    let parsed = parse_program_file(&path)?;
+    let semantic = validate_program(&parsed.program, &path)?;
+    let compiled = compile_program(&semantic, &parsed.program, &path)?;
+
+    let bal_1 = compiled
+        .algebra
+        .constraints
+        .iter()
+        .find(|c| c.name == "balance[t][1]")
+        .ok_or("missing balance constraint at t=1")?;
+    let bal_2 = compiled
+        .algebra
+        .constraints
+        .iter()
+        .find(|c| c.name == "balance[t][2]")
+        .ok_or("missing balance constraint at t=2")?;
+
+    assert_eq!(bal_1.rhs, 10.0);
+    assert_eq!(bal_2.rhs, 20.0);
+
+    fs::remove_dir_all(&root)?;
+    Ok(())
+}

--- a/crates/arco-kdl/tests/semantic_validation.rs
+++ b/crates/arco-kdl/tests/semantic_validation.rs
@@ -224,6 +224,56 @@ scenario "S1" {
 }
 
 #[test]
+fn semantic_validation_applies_bare_identifier_set_filters()
+-> Result<(), Box<dyn std::error::Error>> {
+    let root = temp_root("semantic-set-filter-bare-identifier")?;
+    fs::create_dir_all(root.join("data"))?;
+    fs::write(
+        root.join("data").join("tech.csv"),
+        "tech\nwind\nsolar\nwind\n",
+    )?;
+
+    let path = root.join("input.kdl");
+    let text = r#"
+data "tech_data" source="data/tech.csv" {
+  set "tech"
+  set "wind_tech" {
+    in "tech"
+    filter { tech == wind }
+  }
+}
+
+model "Dispatch" {
+  set "tech"
+
+  control "x" {
+    index "tech"
+  }
+
+  minimize "Obj" {
+    sum(x[tech] for tech in tech)
+  }
+}
+
+scenario "S1" {
+  use "Dispatch"
+}
+"#;
+
+    let parsed = parse_program_text(text, &path)?;
+    let semantic = validate_program(&parsed.program, &path)?;
+
+    let wind_tech = semantic
+        .set_registry
+        .get("wind_tech")
+        .ok_or("missing set wind_tech")?;
+    assert_eq!(wind_tech.values, vec!["wind".to_string()]);
+
+    fs::remove_dir_all(&root)?;
+    Ok(())
+}
+
+#[test]
 fn semantic_validation_applies_numeric_set_filters() -> Result<(), Box<dyn std::error::Error>> {
     let root = temp_root("semantic-set-filter-numeric")?;
     fs::create_dir_all(root.join("data"))?;
@@ -322,6 +372,158 @@ scenario "S1" {
         .get("north_assets")
         .ok_or("missing set north_assets")?;
     assert_eq!(north_assets.values, vec!["A".to_string(), "C".to_string()]);
+
+    fs::remove_dir_all(&root)?;
+    Ok(())
+}
+
+#[test]
+fn semantic_validation_rejects_unresolved_subset_filter_identifier()
+-> Result<(), Box<dyn std::error::Error>> {
+    let root = temp_root("semantic-set-filter-unresolved-identifier")?;
+    fs::create_dir_all(root.join("data"))?;
+    fs::write(
+        root.join("data").join("tech.csv"),
+        "tech\nwind\nsolar\nwind\n",
+    )?;
+
+    let path = root.join("input.kdl");
+    let text = r#"
+data "tech_data" source="data/tech.csv" {
+  set "tech"
+  set "wind_tech" {
+    in "tech"
+    filter { unknown_col == wind }
+  }
+}
+
+model "Dispatch" {
+  set "tech"
+
+  control "x" {
+    index "tech"
+  }
+
+  minimize "Obj" {
+    sum(x[tech] for tech in tech)
+  }
+}
+
+scenario "S1" {
+  use "Dispatch"
+}
+"#;
+
+    let parsed = parse_program_text(text, &path)?;
+    let error = validate_program(&parsed.program, &path)
+        .expect_err("unresolved filter identifier should fail semantic validation");
+
+    assert!(error.to_string().contains("unknown_col"));
+
+    fs::remove_dir_all(&root)?;
+    Ok(())
+}
+
+#[test]
+fn semantic_validation_rejects_unresolved_standalone_filter_identifier()
+-> Result<(), Box<dyn std::error::Error>> {
+    let root = temp_root("semantic-set-filter-unresolved-standalone-identifier")?;
+    fs::create_dir_all(root.join("data"))?;
+    fs::write(
+        root.join("data").join("tech.csv"),
+        "tech\nwind\nsolar\nwind\n",
+    )?;
+
+    let path = root.join("input.kdl");
+    let text = r#"
+data "tech_data" source="data/tech.csv" {
+  set "tech"
+  set "wind_tech" {
+    in "tech"
+    filter { unknown_col }
+  }
+}
+
+model "Dispatch" {
+  set "tech"
+
+  control "x" {
+    index "tech"
+  }
+
+  minimize "Obj" {
+    sum(x[tech] for tech in tech)
+  }
+}
+
+scenario "S1" {
+  use "Dispatch"
+}
+"#;
+
+    let parsed = parse_program_text(text, &path)?;
+    let error = validate_program(&parsed.program, &path)
+        .expect_err("unresolved standalone filter identifier should fail semantic validation");
+
+    assert!(error.to_string().contains("unknown_col"));
+
+    fs::remove_dir_all(&root)?;
+    Ok(())
+}
+
+#[test]
+fn semantic_validation_rejects_unresolved_param_filter_identifier()
+-> Result<(), Box<dyn std::error::Error>> {
+    let root = temp_root("semantic-param-filter-unresolved-identifier")?;
+    fs::create_dir_all(root.join("data"))?;
+    fs::write(
+        root.join("data").join("load.csv"),
+        "period,tech,demand\n1,wind,10\n2,solar,20\n",
+    )?;
+
+    let path = root.join("input.kdl");
+    let text = r#"
+set "time" { "1"; "2" }
+
+data "inputs" source="data/load.csv" {
+  map "time" from="period"
+
+  param "demand" from="demand" reduce="sum" {
+    index "time"
+    filter { unknown_col == wind }
+  }
+}
+
+model "Dispatch" {
+  set "time" alias="t"
+
+  param "demand" {
+    index "t"
+  }
+
+  control "x" {
+    index "t"
+  }
+
+  constraint "balance[t]" {
+    x[t] = demand[t]
+  }
+
+  minimize "Obj" {
+    sum(x[t] for t in time)
+  }
+}
+
+scenario "S1" {
+  use "Dispatch"
+}
+"#;
+
+    let parsed = parse_program_text(text, &path)?;
+    let error = validate_program(&parsed.program, &path)
+        .expect_err("unresolved param filter identifier should fail semantic validation");
+
+    assert!(error.to_string().contains("unknown_col"));
 
     fs::remove_dir_all(&root)?;
     Ok(())


### PR DESCRIPTION
## Summary
- Harden KDL data-filter handling for sets/params.
- Treat bare RHS identifiers in filters as categorical literals (e.g. `tech == wind`).
- Reject unresolved filter identifiers during semantic validation.
- Surface warning when a filtered subset resolves to empty.
- Make `arco validate` show warnings at default verbosity (no `-v` required).
- Ignore local generated artifacts in `.gitignore` to keep PR diffs clean.

## Issue
Addresses subset/filter correctness issue (Refs #169).