### PR TITLE
feat(kdl): parse new syntax aliases with compatibility tests

### DIFF
--- a/crates/arco-kdl/src/source/parser.rs
+++ b/crates/arco-kdl/src/source/parser.rs
@@ -82,7 +82,7 @@ fn parse_model(node: &KdlNode, context: &ParseContext<'_>) -> Result<ModelDecl, 
         match child.name().value() {
             "set" => sets.push(parse_set(child, context)?),
             "param" => parameters.push(parse_param(child, context)?),
-            "control" => controls.push(parse_control(child, context)?),
+            "control" | "var" => controls.push(parse_control(child, context)?),
             "expression" => expressions.push(parse_expression(child, context)?),
             "constraint" => {}
             "minimize" => {
@@ -135,6 +135,10 @@ fn parse_data(node: &KdlNode, context: &ParseContext<'_>) -> Result<DataDecl, So
                 name: first_arg_string(child, 0, context)?,
                 source: optional_property_string(child, "from", context)?,
             }),
+            "alias" => maps.push(crate::source::MapDecl {
+                name: first_arg_string(child, 0, context)?,
+                source: optional_property_string(child, "column", context)?,
+            }),
             "set" => sets.push(parse_set(child, context)?),
             "index" => {
                 let mut columns = Vec::new();
@@ -161,7 +165,15 @@ fn parse_data(node: &KdlNode, context: &ParseContext<'_>) -> Result<DataDecl, So
 
     Ok(DataDecl {
         name: first_arg_string(node, 0, context)?,
-        source: property_string(node, "source", context)?,
+        source: optional_property_string(node, "source", context)?
+            .or(optional_property_string(node, "from", context)?)
+            .ok_or_else(|| SourceError::MissingProperty {
+                node: node.name().value().to_string(),
+                property: "source",
+                path: context.path.to_path_buf(),
+                source_text: Box::new(context.source_text.clone()),
+                span: node.span(),
+            })?,
         maps,
         sets,
         indices,
@@ -232,7 +244,7 @@ fn parse_set(node: &KdlNode, context: &ParseContext<'_>) -> Result<SetDecl, Sour
     for child in node.iter_children() {
         match child.name().value() {
             "in" => subset_of = Some(first_arg_string(child, 0, context)?),
-            "filter" => {
+            "filter" | "where" => {
                 filter_expression = Some(algebra_text_from_node(child, context)?);
             }
             member => {
@@ -253,7 +265,8 @@ fn parse_set(node: &KdlNode, context: &ParseContext<'_>) -> Result<SetDecl, Sour
     Ok(SetDecl {
         name: first_arg_string(node, 0, context)?,
         alias: node
-            .get("alias")
+            .get("as")
+            .or_else(|| node.get("alias"))
             .and_then(KdlValue::as_string)
             .map(ToString::to_string),
         subset_of,

--- a/crates/arco-kdl/src/source/parser.rs
+++ b/crates/arco-kdl/src/source/parser.rs
@@ -461,4 +461,184 @@ scenario "Base" {
         assert_eq!(parsed.program.models.len(), 1);
         assert_eq!(parsed.program.scenarios.len(), 1);
     }
+
+    #[test]
+    fn var_keyword_parses_same_as_control() {
+        let path = PathBuf::from("test.kdl");
+
+        let with_var = r#"
+model "M" {
+  var "x" lower=0 {
+    index "a"
+  }
+  minimize "Obj" { x[a] }
+}
+scenario "S" { use "M" }
+"#;
+
+        let with_control = r#"
+model "M" {
+  control "x" lower=0 {
+    index "a"
+  }
+  minimize "Obj" { x[a] }
+}
+scenario "S" { use "M" }
+"#;
+
+        let var_parsed = parse_program_text(with_var, &path).expect("var syntax parses");
+        let control_parsed =
+            parse_program_text(with_control, &path).expect("control syntax parses");
+
+        // Both should produce identical control declarations
+        assert_eq!(var_parsed.program.models.len(), 1);
+        assert_eq!(control_parsed.program.models.len(), 1);
+
+        let var_controls = &var_parsed.program.models[0].controls;
+        let control_controls = &control_parsed.program.models[0].controls;
+
+        assert_eq!(var_controls.len(), control_controls.len());
+        assert_eq!(var_controls[0].name, control_controls[0].name);
+        assert_eq!(
+            var_controls[0].indices.len(),
+            control_controls[0].indices.len()
+        );
+    }
+
+    #[test]
+    fn alias_keyword_parses_same_as_map() {
+        let path = PathBuf::from("test.kdl");
+
+        let with_alias = r#"
+data "D" source="file.csv" {
+  alias "X" column="name"
+}
+"#;
+
+        let with_map = r#"
+data "D" source="file.csv" {
+  map "X" from="name"
+}
+"#;
+
+        let alias_parsed = parse_program_text(with_alias, &path).expect("alias syntax parses");
+        let map_parsed = parse_program_text(with_map, &path).expect("map syntax parses");
+
+        assert_eq!(alias_parsed.program.data.len(), 1);
+        assert_eq!(map_parsed.program.data.len(), 1);
+
+        let alias_maps = &alias_parsed.program.data[0].maps;
+        let map_maps = &map_parsed.program.data[0].maps;
+
+        assert_eq!(alias_maps.len(), map_maps.len());
+        assert_eq!(alias_maps[0].name, map_maps[0].name);
+        assert_eq!(alias_maps[0].source, map_maps[0].source);
+    }
+
+    #[test]
+    fn data_from_property_parses_same_as_source() {
+        let path = PathBuf::from("test.kdl");
+
+        let with_source = r#"
+data "D" source="file.csv" {
+  map "X" from="name"
+}
+"#;
+
+        let with_from = r#"
+data "D" from="file.csv" {
+  map "X" from="name"
+}
+"#;
+
+        let source_parsed = parse_program_text(with_source, &path).expect("source= syntax parses");
+        let from_parsed = parse_program_text(with_from, &path).expect("from= syntax parses");
+
+        assert_eq!(source_parsed.program.data.len(), 1);
+        assert_eq!(from_parsed.program.data.len(), 1);
+        assert_eq!(
+            source_parsed.program.data[0].source,
+            from_parsed.program.data[0].source
+        );
+        assert_eq!(from_parsed.program.data[0].source, "file.csv");
+    }
+
+    #[test]
+    fn set_as_property_parses_same_as_alias() {
+        let path = PathBuf::from("test.kdl");
+
+        let with_as = r#"set "X" as="g""#;
+        let with_alias = r#"set "X" alias="g""#;
+
+        let as_parsed = parse_program_text(with_as, &path).expect("as= syntax parses");
+        let alias_parsed = parse_program_text(with_alias, &path).expect("alias= syntax parses");
+
+        assert_eq!(as_parsed.program.sets.len(), 1);
+        assert_eq!(alias_parsed.program.sets.len(), 1);
+
+        assert_eq!(
+            as_parsed.program.sets[0].alias,
+            alias_parsed.program.sets[0].alias
+        );
+        assert_eq!(as_parsed.program.sets[0].alias, Some("g".to_string()));
+    }
+
+    #[test]
+    fn where_keyword_parses_same_as_filter() {
+        let path = PathBuf::from("test.kdl");
+
+        let with_where = r#"set "thermal" { in "gen"; where { type == "thermal" } }"#;
+        let with_filter = r#"set "thermal" { in "gen"; filter { type == "thermal" } }"#;
+
+        let where_parsed = parse_program_text(with_where, &path).expect("where syntax parses");
+        let filter_parsed = parse_program_text(with_filter, &path).expect("filter syntax parses");
+
+        assert_eq!(where_parsed.program.sets.len(), 1);
+        assert_eq!(filter_parsed.program.sets.len(), 1);
+
+        assert_eq!(
+            where_parsed.program.sets[0].filter_expression,
+            filter_parsed.program.sets[0].filter_expression
+        );
+        assert!(where_parsed.program.sets[0].filter_expression.is_some());
+    }
+
+    #[test]
+    fn mixed_old_and_new_syntax_parses() {
+        let path = PathBuf::from("test.kdl");
+
+        // Mix of old (control, map, alias=, filter) and new (var, alias, as=, where)
+        let mixed = r#"
+data "D" source="file.csv" {
+  map "old_col" from="x"
+  alias "new_col" column="y"
+}
+
+set "old_set" alias="o"
+set "new_set" as="n"
+
+model "M" {
+  control "old_var" { index "a" }
+  var "new_var" { index "b" }
+  minimize "Obj" { old_var[a] + new_var[b] }
+}
+
+scenario "S" { use "M" }
+"#;
+
+        let parsed = parse_program_text(mixed, &path).expect("mixed syntax parses");
+
+        // Verify data block
+        assert_eq!(parsed.program.data.len(), 1);
+        assert_eq!(parsed.program.data[0].maps.len(), 2);
+
+        // Verify sets
+        assert_eq!(parsed.program.sets.len(), 2);
+        assert_eq!(parsed.program.sets[0].alias, Some("o".to_string()));
+        assert_eq!(parsed.program.sets[1].alias, Some("n".to_string()));
+
+        // Verify model controls (both var and control)
+        assert_eq!(parsed.program.models.len(), 1);
+        assert_eq!(parsed.program.models[0].controls.len(), 2);
+    }
 }

--- a/crates/arco-kdl/src/source/parser_helpers.rs
+++ b/crates/arco-kdl/src/source/parser_helpers.rs
@@ -51,7 +51,7 @@ pub(super) fn parse_optional_filter_expression(
     context: &ParseContext<'_>,
 ) -> Result<Option<String>, SourceError> {
     for child in node.iter_children() {
-        if child.name().value() == "filter" {
+        if matches!(child.name().value(), "filter" | "where") {
             return Ok(Some(algebra_text_from_node(child, context)?));
         }
     }
@@ -91,7 +91,7 @@ pub(super) fn declaration_indices(
 
     for child in node.iter_children() {
         match child.name().value() {
-            "filter" | "bounds" => {}
+            "filter" | "where" | "bounds" => {}
             "index" => {
                 let index_name = first_arg_string(child, 0, context)?;
                 let domain = child

--- a/crates/arco-kdl/src/source/surface.rs
+++ b/crates/arco-kdl/src/source/surface.rs
@@ -1,34 +1,34 @@
 pub(super) fn normalize_surface_syntax(text: &str) -> String {
-    let math_keywords = [
-        "constraint",
-        "expression",
-        "minimize",
-        "maximize",
-        "lower",
-        "upper",
-        "if",
-        "filter",
-        "where",
-    ];
     let mut normalized = String::with_capacity(text.len());
     let bytes = text.as_bytes();
     let mut index = 0;
-
     while index < bytes.len() {
-        let rewritten = math_keywords
-            .iter()
-            .find_map(|keyword| rewrite_math_block(text, index, keyword));
+        let rewritten = rewrite_math_block_at(text, index);
         if let Some((replacement, end)) = rewritten {
             normalized.push_str(&replacement);
             index = end;
             continue;
         }
-
         normalized.push(bytes[index] as char);
         index += 1;
     }
-
     normalized
+}
+
+fn rewrite_math_block_at(text: &str, start: usize) -> Option<(String, usize)> {
+    let byte = *text.as_bytes().get(start)?;
+    match byte {
+        b'c' => rewrite_math_block(text, start, "constraint"),
+        b'e' => rewrite_math_block(text, start, "expression"),
+        b'f' => rewrite_math_block(text, start, "filter"),
+        b'i' => rewrite_math_block(text, start, "if"),
+        b'l' => rewrite_math_block(text, start, "lower"),
+        b'm' => rewrite_math_block(text, start, "minimize")
+            .or_else(|| rewrite_math_block(text, start, "maximize")),
+        b'u' => rewrite_math_block(text, start, "upper"),
+        b'w' => rewrite_math_block(text, start, "where"),
+        _ => None,
+    }
 }
 
 fn rewrite_math_block(text: &str, start: usize, keyword: &str) -> Option<(String, usize)> {

--- a/crates/arco-kdl/src/source/surface.rs
+++ b/crates/arco-kdl/src/source/surface.rs
@@ -8,6 +8,7 @@ pub(super) fn normalize_surface_syntax(text: &str) -> String {
         "upper",
         "if",
         "filter",
+        "where",
     ];
     let mut normalized = String::with_capacity(text.len());
     let bytes = text.as_bytes();
@@ -118,7 +119,7 @@ fn rewrite_math_block(text: &str, start: usize, keyword: &str) -> Option<(String
         "constraint" => format!("{header} expression={encoded_body}"),
         "expression" => format!("{header} {{ formula {encoded_body} }}"),
         "minimize" | "maximize" => format!("{header} expression={encoded_body}"),
-        "lower" | "upper" | "if" | "filter" => {
+        "lower" | "upper" | "if" | "filter" | "where" => {
             format!("{header} expression={encoded_body}")
         }
         _ => return None,

--- a/docs/arco-spec.md
+++ b/docs/arco-spec.md
@@ -344,16 +344,17 @@ Required properties:
 
 - `source`: CSV file path. Relative paths are resolved from the directory
   containing the `.kdl` file being parsed. Absolute paths are also accepted.
-
-CSV parsing: Arco expects RFC 4180-compliant CSV files (comma-delimited,
-optional double-quote escaping, CRLF or LF line endings). The first row MUST be
-a header row containing column names. Column names in the header MUST be unique;
-duplicate column names MUST fail validation (see
-[§10](#10-validation-requirements), rule 73). CSV files MUST be UTF-8 encoded.
-Implementations SHOULD accept files with or without a UTF-8 BOM. Empty cells in
-a numeric column MUST fail validation. Empty cells in a string/categorical
-column are treated as empty strings. Column matching is always by name, not by
-position.
+  - `from`: compatibility alias for `source` (legacy syntax). Prefer `source` in
+    new files.
+    CSV parsing: Arco expects RFC 4180-compliant CSV files (comma-delimited,
+    optional double-quote escaping, CRLF or LF line endings). The first row MUST be
+    a header row containing column names. Column names in the header MUST be unique;
+    duplicate column names MUST fail validation (see
+    [§10](#10-validation-requirements), rule 73). CSV files MUST be UTF-8 encoded.
+    Implementations SHOULD accept files with or without a UTF-8 BOM. Empty cells in
+    a numeric column MUST fail validation. Empty cells in a string/categorical
+    column are treated as empty strings. Column matching is always by name, not by
+    position.
 
 Allowed children:
 


### PR DESCRIPTION
## Summary
- accept new parser syntax aliases: `var`, `alias ... column=`, `set ... as=`, and `where { ... }`
- keep old syntax working (`control`, `map ... from=`, `set ... alias=`, `filter { ... }`)
- support `data ... from=` as a compatibility alias for `data ... source=`
- add parser regression tests for old/new equivalence and mixed syntax usage

## Why
Implements parser-side behavior for #179 and addresses the non-blocking review callout to make `from`/`source` compatibility explicit and tested.

## Validation
- `cargo test -p arco-kdl`
- `cargo clippy -p arco-kdl -- -D warnings`

## Notes
Deprecation warnings are intentionally deferred until #178 lands.

Refs #179
