### PR TITLE
feat(kdl): explicit tuple subset declarations for constraints

### DIFF
--- a/crates/arco-cli/src/benchmark.rs
+++ b/crates/arco-cli/src/benchmark.rs
@@ -324,6 +324,7 @@ mod tests {
             ResolvedSet {
                 values: vec!["g1".to_string(), "g2".to_string()],
                 tuple_components: None,
+                tuple_component_domains: None,
                 tuple_rows: None,
             },
         );

--- a/crates/arco-kdl/src/compile/constraints.rs
+++ b/crates/arco-kdl/src/compile/constraints.rs
@@ -42,6 +42,7 @@ fn compile_constraint_instances(
                 inputs,
                 program,
                 entrypoint,
+                &constraint.name,
             )?;
             for scope in generation_scopes {
                 if let Some(filter) = &constraint.generation_filter {

--- a/crates/arco-kdl/src/compile/expressions_domains.rs
+++ b/crates/arco-kdl/src/compile/expressions_domains.rs
@@ -3,7 +3,13 @@ fn expand_generation_bindings(
     inputs: &ScenarioInputs,
     program: &SemanticProgram,
     entrypoint: &Path,
+    binding_context: &str,
 ) -> Result<Vec<LinearizationBindings>, CompileError> {
+    if let Some(tuple_scopes) =
+        expand_tuple_generation_bindings(bindings, program, entrypoint, binding_context)?
+    {
+        return Ok(tuple_scopes);
+    }
     let mut scopes = vec![LinearizationBindings::default()];
     for binding in bindings {
         let values = reduction_domain_values(&binding.domain, inputs, program, entrypoint)?;
@@ -18,6 +24,81 @@ fn expand_generation_bindings(
         scopes = next;
     }
     Ok(scopes)
+}
+
+fn expand_tuple_generation_bindings(
+    bindings: &[GenerationBinding],
+    program: &SemanticProgram,
+    entrypoint: &Path,
+    binding_context: &str,
+) -> Result<Option<Vec<LinearizationBindings>>, CompileError> {
+    if bindings.is_empty() {
+        return Ok(None);
+    }
+
+    let reverse_aliases = build_reverse_alias_lookup(program);
+    let first_domain = bindings[0].domain.as_str();
+    let Some(first_key) = resolve_set_registry_key(first_domain, program, &reverse_aliases) else {
+        return Ok(None);
+    };
+
+    for binding in bindings.iter().skip(1) {
+        let Some(key) = resolve_set_registry_key(binding.domain.as_str(), program, &reverse_aliases)
+        else {
+            return Ok(None);
+        };
+        if key != first_key {
+            return Ok(None);
+        }
+    }
+
+    let Some(set) = resolve_set_struct_by_name(first_key, program, &reverse_aliases) else {
+        return Ok(None);
+    };
+    let (Some(tuple_components), Some(tuple_rows)) =
+        (set.tuple_components.as_ref(), set.tuple_rows.as_ref())
+    else {
+        return Ok(None);
+    };
+
+    let received_components = bindings
+        .iter()
+        .map(|binding| binding.variable.clone())
+        .collect::<Vec<_>>();
+    if tuple_components != &received_components {
+        return Err(CompileError::InvalidFormulation {
+            message: format!(
+                "index order mismatch for `{binding_context}`: expected `{}`, received `{}`",
+                tuple_components.join(","),
+                received_components.join(",")
+            ),
+            path: entrypoint.to_path_buf(),
+        });
+    }
+
+    let mut scopes = Vec::with_capacity(tuple_rows.len());
+    for row in tuple_rows {
+        if row.len() != bindings.len() {
+            return Err(CompileError::InvalidFormulation {
+                message: format!(
+                    "tuple row arity mismatch for `{binding_context}`: expected `{}`, received `{}`",
+                    bindings.len(),
+                    row.len()
+                ),
+                path: entrypoint.to_path_buf(),
+            });
+        }
+
+        let mut scope = LinearizationBindings::default();
+        for (binding, value) in bindings.iter().zip(row.iter()) {
+            scope
+                .values
+                .insert(binding.variable.clone(), FilterValue::String(value.clone()));
+        }
+        scopes.push(scope);
+    }
+
+    Ok(Some(scopes))
 }
 
 fn reduction_domain_values(

--- a/crates/arco-kdl/src/semantic/error.rs
+++ b/crates/arco-kdl/src/semantic/error.rs
@@ -153,6 +153,35 @@ pub enum SemanticError {
     },
 
     #[error(
+        "tuple subset index `{index}` in `{set}` resolves ambiguously to multiple parent components `{candidates}` in {path}"
+    )]
+    #[diagnostic(
+        code(arco::semantic::ambiguous_tuple_subset_index),
+        help("disambiguate by using the canonical tuple component name for the parent tuple set")
+    )]
+    AmbiguousTupleSubsetIndex {
+        set: String,
+        index: String,
+        candidates: String,
+        path: PathBuf,
+    },
+
+    #[error(
+        "tuple subset index `{index}` in `{set}` declares domain `{received_domain}` but parent tuple domain is `{expected_domain}` in {path}"
+    )]
+    #[diagnostic(
+        code(arco::semantic::tuple_subset_domain_mismatch),
+        help("align subset index `in` domain with the matched parent tuple component domain")
+    )]
+    TupleSubsetDomainMismatch {
+        set: String,
+        index: String,
+        expected_domain: String,
+        received_domain: String,
+        path: PathBuf,
+    },
+
+    #[error(
         "tuple component schema mismatch for merged tuple set `{set}` in {path}: existing `{existing_components}` vs incoming `{incoming_components}`"
     )]
     #[diagnostic(

--- a/crates/arco-kdl/src/semantic/sets.rs
+++ b/crates/arco-kdl/src/semantic/sets.rs
@@ -109,6 +109,10 @@ fn intersect_tuple_set_sources(
     Ok(Some(ResolvedSet {
         values: Vec::new(),
         tuple_components: Some(existing_components.clone()),
+        tuple_component_domains: existing
+            .tuple_component_domains
+            .clone()
+            .or_else(|| Some(existing_components.clone())),
         tuple_rows: Some(intersected_rows),
     }))
 }
@@ -128,10 +132,10 @@ fn resolved_set_for_program_set(
         return Ok(ResolvedSet {
             values,
             tuple_components: None,
+            tuple_component_domains: None,
             tuple_rows: None,
         });
     }
-
     let tuple_rows = tuple_rows_for_rule_set(set_decl, registry, set_aliases, path)?;
     Ok(ResolvedSet {
         values: Vec::new(),
@@ -142,16 +146,23 @@ fn resolved_set_for_program_set(
                 .map(|tuple_index| tuple_index.name.clone())
                 .collect(),
         ),
+        tuple_component_domains: Some(tuple_component_domains_for_decl(set_decl)),
         tuple_rows: Some(tuple_rows),
     })
 }
-
 fn tuple_rows_for_rule_set(
     set_decl: &SetDecl,
     registry: &BTreeMap<String, ResolvedSet>,
     set_aliases: &BTreeMap<String, String>,
     path: &Path,
 ) -> Result<Vec<Vec<String>>, SemanticError> {
+    if let Some(parent_name) = set_decl.subset_of.as_deref() {
+        if let Some(parent_set) = resolve_set_for_rule_domain(parent_name, registry, set_aliases) {
+            if parent_set.tuple_components.is_some() && parent_set.tuple_rows.is_some() {
+                return tuple_rows_for_rule_subset(set_decl, parent_set, set_aliases, path);
+            }
+        }
+    }
     let mut domain_values = Vec::with_capacity(set_decl.tuple_indices.len());
     for tuple_index in &set_decl.tuple_indices {
         let domain_name = tuple_index
@@ -173,10 +184,8 @@ fn tuple_rows_for_rule_set(
         }
         domain_values.push(domain_set.values.clone());
     }
-
     let allowed_identifiers = tuple_rule_filter_identifiers(set_decl, set_aliases);
     validate_rule_set_filter_identifiers(set_decl, &allowed_identifiers, path)?;
-
     let mut combinations = vec![Vec::new()];
     for values in &domain_values {
         let mut next = Vec::new();
@@ -202,13 +211,135 @@ fn tuple_rows_for_rule_set(
                 .unwrap_or(tuple_index.name.as_str());
             add_tuple_rule_binding_aliases(&mut binding_values, domain_name, value, set_aliases);
         }
-
         if matches_rule_set_filter(&binding_values, set_decl) {
             tuples.insert(combo);
         }
     }
 
     Ok(tuples.into_iter().collect())
+}
+
+fn tuple_rows_for_rule_subset(
+    set_decl: &SetDecl,
+    parent_set: &ResolvedSet,
+    set_aliases: &BTreeMap<String, String>,
+    path: &Path,
+) -> Result<Vec<Vec<String>>, SemanticError> {
+    let parent_components = parent_set
+        .tuple_components
+        .as_ref()
+        .expect("checked by caller");
+    let parent_rows = parent_set.tuple_rows.as_ref().expect("checked by caller");
+    let parent_domains = parent_set
+        .tuple_component_domains
+        .as_ref()
+        .filter(|domains| domains.len() == parent_components.len())
+        .cloned()
+        .unwrap_or_else(|| parent_components.clone());
+
+    let mut projection_positions = Vec::with_capacity(set_decl.tuple_indices.len());
+    for tuple_index in &set_decl.tuple_indices {
+        let requested_domain = tuple_index
+            .domain
+            .as_deref()
+            .unwrap_or(tuple_index.name.as_str());
+        let position = parent_components
+            .iter()
+            .zip(parent_domains.iter())
+            .position(|(component, domain)| {
+                component == &tuple_index.name
+                    || domain == &tuple_index.name
+                    || component == requested_domain
+                    || domain == requested_domain
+            })
+            .ok_or_else(|| SemanticError::MissingDeclaration {
+                kind: "tuple component",
+                name: tuple_index.name.clone(),
+                path: path.to_path_buf(),
+            })?;
+        projection_positions.push(position);
+    }
+
+    let allowed_identifiers = tuple_rule_filter_identifiers_for_tuple_source(
+        parent_components,
+        &parent_domains,
+        set_aliases,
+    );
+    validate_rule_set_filter_identifiers(set_decl, &allowed_identifiers, path)?;
+
+    let mut tuples = BTreeSet::new();
+    for (row_index, row) in parent_rows.iter().enumerate() {
+        let mut binding_values = BTreeMap::new();
+        for (position, component_name) in parent_components.iter().enumerate() {
+            let value = row
+                .get(position)
+                .cloned()
+                .ok_or_else(|| SemanticError::MissingCell {
+                    column: component_name.clone(),
+                    row: row_index + 1,
+                    path: path.to_path_buf(),
+                })?;
+            let domain_name = parent_domains
+                .get(position)
+                .map_or(component_name.as_str(), String::as_str);
+            binding_values.insert(component_name.clone(), value.clone());
+            add_tuple_rule_binding_aliases(
+                &mut binding_values,
+                component_name,
+                value.clone(),
+                set_aliases,
+            );
+            if domain_name != component_name {
+                add_tuple_rule_binding_aliases(
+                    &mut binding_values,
+                    domain_name,
+                    value,
+                    set_aliases,
+                );
+            }
+        }
+
+        if !matches_rule_set_filter(&binding_values, set_decl) {
+            continue;
+        }
+
+        let projected = projection_positions
+            .iter()
+            .map(|position| row[*position].clone())
+            .collect::<Vec<_>>();
+        tuples.insert(projected);
+    }
+
+    Ok(tuples.into_iter().collect())
+}
+
+fn tuple_component_domains_for_decl(set_decl: &SetDecl) -> Vec<String> {
+    set_decl
+        .tuple_indices
+        .iter()
+        .map(|tuple_index| {
+            tuple_index
+                .domain
+                .clone()
+                .unwrap_or_else(|| tuple_index.name.clone())
+        })
+        .collect()
+}
+
+fn tuple_rule_filter_identifiers_for_tuple_source(
+    components: &[String],
+    domains: &[String],
+    set_aliases: &BTreeMap<String, String>,
+) -> BTreeSet<String> {
+    let mut identifiers = BTreeSet::new();
+    for (component, domain) in components.iter().zip(domains.iter()) {
+        identifiers.insert(component.clone());
+        collect_domain_aliases_for_rule_filter(&mut identifiers, component, set_aliases);
+        identifiers.insert(domain.clone());
+        collect_domain_aliases_for_rule_filter(&mut identifiers, domain, set_aliases);
+    }
+
+    identifiers
 }
 
 fn resolve_set_for_rule_domain<'a>(
@@ -855,6 +986,7 @@ fn resolved_set_for_data_set(
                     .map(|index| index.name.clone())
                     .collect(),
             ),
+            tuple_component_domains: Some(tuple_component_domains_for_decl(set_decl)),
             tuple_rows: Some(tuple_rows),
         });
     }
@@ -882,6 +1014,7 @@ fn resolved_set_for_data_set(
     Ok(ResolvedSet {
         values,
         tuple_components: None,
+        tuple_component_domains: None,
         tuple_rows: None,
     })
 }

--- a/crates/arco-kdl/src/semantic/sets.rs
+++ b/crates/arco-kdl/src/semantic/sets.rs
@@ -100,6 +100,25 @@ fn intersect_tuple_set_sources(
             path: merge_path.to_path_buf(),
         });
     }
+
+    let existing_domains = tuple_component_domains_for_resolved_set(existing, existing_components);
+    let next_domains = tuple_component_domains_for_resolved_set(next, next_components);
+    if existing_domains != next_domains {
+        return Err(SemanticError::TupleSetSchemaMismatch {
+            set: set_name.to_string(),
+            existing_components: format!(
+                "{} (domains: {})",
+                existing_components.join(","),
+                existing_domains.join(",")
+            ),
+            incoming_components: format!(
+                "{} (domains: {})",
+                next_components.join(","),
+                next_domains.join(",")
+            ),
+            path: merge_path.to_path_buf(),
+        });
+    }
     let existing_rows = existing_rows.iter().cloned().collect::<BTreeSet<_>>();
     let next_rows = next_rows.iter().cloned().collect::<BTreeSet<_>>();
     let intersected_rows = existing_rows
@@ -109,10 +128,7 @@ fn intersect_tuple_set_sources(
     Ok(Some(ResolvedSet {
         values: Vec::new(),
         tuple_components: Some(existing_components.clone()),
-        tuple_component_domains: existing
-            .tuple_component_domains
-            .clone()
-            .or_else(|| Some(existing_components.clone())),
+        tuple_component_domains: Some(existing_domains.clone()),
         tuple_rows: Some(intersected_rows),
     }))
 }
@@ -230,34 +246,19 @@ fn tuple_rows_for_rule_subset(
         .as_ref()
         .expect("checked by caller");
     let parent_rows = parent_set.tuple_rows.as_ref().expect("checked by caller");
-    let parent_domains = parent_set
-        .tuple_component_domains
-        .as_ref()
-        .filter(|domains| domains.len() == parent_components.len())
-        .cloned()
-        .unwrap_or_else(|| parent_components.clone());
+    let parent_domains = tuple_component_domains_for_resolved_set(parent_set, parent_components);
 
     let mut projection_positions = Vec::with_capacity(set_decl.tuple_indices.len());
     for tuple_index in &set_decl.tuple_indices {
-        let requested_domain = tuple_index
-            .domain
-            .as_deref()
-            .unwrap_or(tuple_index.name.as_str());
-        let position = parent_components
-            .iter()
-            .zip(parent_domains.iter())
-            .position(|(component, domain)| {
-                component == &tuple_index.name
-                    || domain == &tuple_index.name
-                    || component == requested_domain
-                    || domain == requested_domain
-            })
-            .ok_or_else(|| SemanticError::MissingDeclaration {
-                kind: "tuple component",
-                name: tuple_index.name.clone(),
-                path: path.to_path_buf(),
-            })?;
-        projection_positions.push(position);
+        let projection_position = resolve_subset_projection_position(
+            set_decl,
+            tuple_index,
+            parent_components,
+            &parent_domains,
+            set_aliases,
+            path,
+        )?;
+        projection_positions.push(projection_position);
     }
 
     let allowed_identifiers = tuple_rule_filter_identifiers_for_tuple_source(
@@ -326,6 +327,18 @@ fn tuple_component_domains_for_decl(set_decl: &SetDecl) -> Vec<String> {
         .collect()
 }
 
+fn tuple_component_domains_for_resolved_set(
+    resolved_set: &ResolvedSet,
+    components: &[String],
+) -> Vec<String> {
+    resolved_set
+        .tuple_component_domains
+        .as_ref()
+        .filter(|domains| domains.len() == components.len())
+        .cloned()
+        .unwrap_or_else(|| components.to_vec())
+}
+
 fn tuple_rule_filter_identifiers_for_tuple_source(
     components: &[String],
     domains: &[String],
@@ -340,6 +353,91 @@ fn tuple_rule_filter_identifiers_for_tuple_source(
     }
 
     identifiers
+}
+
+fn resolve_subset_projection_position(
+    set_decl: &SetDecl,
+    tuple_index: &crate::source::IndexDecl,
+    parent_components: &[String],
+    parent_domains: &[String],
+    set_aliases: &BTreeMap<String, String>,
+    path: &Path,
+) -> Result<usize, SemanticError> {
+    let mut matches = parent_components
+        .iter()
+        .enumerate()
+        .filter_map(|(position, component)| {
+            if component == &tuple_index.name {
+                Some(position)
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>();
+
+    if matches.is_empty() {
+        matches = parent_domains
+            .iter()
+            .enumerate()
+            .filter_map(|(position, domain)| {
+                if set_name_matches(domain, &tuple_index.name, set_aliases) {
+                    Some(position)
+                } else {
+                    None
+                }
+            })
+            .collect();
+    }
+
+    if matches.is_empty() {
+        return Err(SemanticError::MissingDeclaration {
+            kind: "tuple component",
+            name: tuple_index.name.clone(),
+            path: path.to_path_buf(),
+        });
+    }
+
+    if matches.len() > 1 {
+        let candidates = matches
+            .iter()
+            .map(|position| {
+                let component = &parent_components[*position];
+                let domain = &parent_domains[*position];
+                format!("{component}:{domain}")
+            })
+            .collect::<Vec<_>>()
+            .join(",");
+        return Err(SemanticError::AmbiguousTupleSubsetIndex {
+            set: set_decl.name.clone(),
+            index: tuple_index.name.clone(),
+            candidates,
+            path: path.to_path_buf(),
+        });
+    }
+
+    let position = matches[0];
+    if let Some(received_domain) = tuple_index.domain.as_deref() {
+        let expected_domain = parent_domains[position].as_str();
+        if !set_name_matches(expected_domain, received_domain, set_aliases) {
+            return Err(SemanticError::TupleSubsetDomainMismatch {
+                set: set_decl.name.clone(),
+                index: tuple_index.name.clone(),
+                expected_domain: expected_domain.to_string(),
+                received_domain: received_domain.to_string(),
+                path: path.to_path_buf(),
+            });
+        }
+    }
+
+    Ok(position)
+}
+
+fn set_name_matches(left: &str, right: &str, set_aliases: &BTreeMap<String, String>) -> bool {
+    left == right || canonical_set_name(left, set_aliases) == canonical_set_name(right, set_aliases)
+}
+
+fn canonical_set_name<'a>(name: &'a str, set_aliases: &'a BTreeMap<String, String>) -> &'a str {
+    set_aliases.get(name).map_or(name, String::as_str)
 }
 
 fn resolve_set_for_rule_domain<'a>(

--- a/crates/arco-kdl/src/semantic/types.rs
+++ b/crates/arco-kdl/src/semantic/types.rs
@@ -172,6 +172,7 @@ pub struct ResolvedTimeSet {
 pub struct ResolvedSet {
     pub values: Vec<String>,
     pub tuple_components: Option<Vec<String>>,
+    pub tuple_component_domains: Option<Vec<String>>,
     pub tuple_rows: Option<Vec<Vec<String>>>,
 }
 

--- a/crates/arco-kdl/tests/compile_suite.rs
+++ b/crates/arco-kdl/tests/compile_suite.rs
@@ -586,3 +586,157 @@ scenario "S1" {
     fs::remove_dir_all(&root)?;
     Ok(())
 }
+
+#[test]
+fn lowering_instantiates_constraint_bindings_from_tuple_subset_rows()
+-> Result<(), Box<dyn std::error::Error>> {
+    let root = temp_test_dir("tuple-subset-constraint-bindings")?;
+    fs::create_dir_all(root.join("data"))?;
+    fs::write(
+        root.join("data").join("links.csv"),
+        "area,tech,gen,bus,feasible\n1,wind,g1,b1,1\n1,wind,g1,b2,1\n1,solar,g2,b3,1\n2,solar,g3,b4,1\n",
+    )?;
+
+    let path = root.join("input.kdl");
+    fs::write(
+        &path,
+        r#"
+data "links" source="data/links.csv" {
+  alias "generators" column="gen"
+  alias "buses" column="bus"
+
+  set "area" as="a"
+  set "tech" as="i"
+  set "generators" as="g"
+  set "buses" as="b"
+
+  set "feasible_links" {
+    index "a" { in "area" }
+    index "i" { in "tech" }
+    index "g" { in "generators" }
+    index "b" { in "buses" }
+    where { feasible > 0 }
+  }
+}
+
+set "target_pairs" {
+  in "feasible_links"
+  index "a" { in "area" }
+  index "i" { in "tech" }
+  where { generators == "g1" }
+}
+
+model "TupleDispatch" {
+  control "x" lower=0 {
+    index "a" { in "feasible_links" }
+    index "i" { in "feasible_links" }
+    index "g" { in "feasible_links" }
+    index "b" { in "feasible_links" }
+  }
+
+  constraint "capacity_target" {
+    index "a" { in "target_pairs" }
+    index "i" { in "target_pairs" }
+    expression {
+      0 == 0
+    }
+  }
+
+  minimize "Obj" { 0 }
+}
+
+scenario "S1" {
+  use "TupleDispatch"
+}
+"#,
+    )?;
+
+    let parsed = parse_program_file(&path)?;
+    let semantic = validate_program(&parsed.program, &path)?;
+    let compiled = compile_program(&semantic, &parsed.program, &path)?;
+
+    let constraint_names = compiled
+        .algebra
+        .constraints
+        .iter()
+        .map(|constraint| constraint.name.clone())
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        constraint_names,
+        vec!["capacity_target[1,wind]".to_string()]
+    );
+
+    fs::remove_dir_all(&root)?;
+    Ok(())
+}
+
+#[test]
+fn lowering_rejects_constraint_auto_projection_from_high_dim_tuple_domain()
+-> Result<(), Box<dyn std::error::Error>> {
+    let root = temp_test_dir("tuple-subset-auto-projection")?;
+    fs::create_dir_all(root.join("data"))?;
+    fs::write(
+        root.join("data").join("links.csv"),
+        "area,tech,gen,bus,feasible\n1,wind,g1,b1,1\n",
+    )?;
+
+    let path = root.join("input.kdl");
+    fs::write(
+        &path,
+        r#"
+data "links" source="data/links.csv" {
+  alias "generators" column="gen"
+  alias "buses" column="bus"
+
+  set "area" as="a"
+  set "tech" as="i"
+  set "generators" as="g"
+  set "buses" as="b"
+
+  set "feasible_links" {
+    index "a" { in "area" }
+    index "i" { in "tech" }
+    index "g" { in "generators" }
+    index "b" { in "buses" }
+    where { feasible > 0 }
+  }
+}
+
+model "TupleDispatch" {
+  control "x" lower=0 {
+    index "a" { in "feasible_links" }
+    index "i" { in "feasible_links" }
+    index "g" { in "feasible_links" }
+    index "b" { in "feasible_links" }
+  }
+
+  constraint "bad_projection" {
+    index "a" { in "feasible_links" }
+    expression { 0 == 0 }
+  }
+
+  minimize "Obj" { 0 }
+}
+
+scenario "S1" {
+  use "TupleDispatch"
+}
+"#,
+    )?;
+
+    let parsed = parse_program_file(&path)?;
+    let semantic = validate_program(&parsed.program, &path)?;
+    let error = compile_program(&semantic, &parsed.program, &path)
+        .expect_err("auto projection from tuple domains should fail in V1");
+
+    match error {
+        CompileError::InvalidFormulation { message, .. } => {
+            assert!(message.contains("index order mismatch for `bad_projection`"));
+        }
+        other => panic!("expected InvalidFormulation, got {other:?}"),
+    }
+
+    fs::remove_dir_all(&root)?;
+    Ok(())
+}

--- a/crates/arco-kdl/tests/semantic_validation.rs
+++ b/crates/arco-kdl/tests/semantic_validation.rs
@@ -665,3 +665,102 @@ scenario "S1" {
     fs::remove_dir_all(&root)?;
     Ok(())
 }
+
+#[test]
+fn semantic_validation_rejects_tuple_set_domain_schema_mismatch_across_sources()
+-> Result<(), Box<dyn std::error::Error>> {
+    let root = temp_root("semantic-tuple-set-domain-schema-mismatch")?;
+    let path = root.join("input.kdl");
+    let text = r#"
+set "area" { "1"; "2" }
+set "region" { "1"; "2" }
+set "tech" { "wind"; "solar" }
+
+set "feasible_links" {
+  index "a" { in "area" }
+  index "i" { in "tech" }
+}
+
+set "feasible_links" {
+  index "a" { in "region" }
+  index "i" { in "tech" }
+}
+
+model "Dispatch" {
+  control "x" {
+    index "a" { in "feasible_links" }
+    index "i" { in "feasible_links" }
+  }
+
+  minimize "Obj" { 0 }
+}
+
+scenario "S1" {
+  use "Dispatch"
+}
+"#;
+
+    let parsed = parse_program_text(text, &path)?;
+    let error = validate_program(&parsed.program, &path).expect_err(
+        "tuple set domain schema mismatch across tuple sources should fail semantic validation",
+    );
+
+    assert!(
+        error
+            .to_string()
+            .contains("tuple component schema mismatch")
+    );
+    assert!(error.to_string().contains("domains: area,tech"));
+    assert!(error.to_string().contains("domains: region,tech"));
+
+    fs::remove_dir_all(&root)?;
+    Ok(())
+}
+
+#[test]
+fn semantic_validation_rejects_tuple_subset_with_component_domain_mismatch()
+-> Result<(), Box<dyn std::error::Error>> {
+    let root = temp_root("semantic-tuple-subset-domain-mismatch")?;
+    let path = root.join("input.kdl");
+    let text = r#"
+set "area" { "1"; "2" }
+set "tech" { "wind"; "solar" }
+
+set "feasible_links" {
+  index "a" { in "area" }
+  index "i" { in "tech" }
+}
+
+set "target_pairs" {
+  in "feasible_links"
+  index "a" { in "tech" }
+}
+
+model "Dispatch" {
+  control "x" {
+    index "a" { in "feasible_links" }
+    index "i" { in "feasible_links" }
+  }
+
+  minimize "Obj" { 0 }
+}
+
+scenario "S1" {
+  use "Dispatch"
+}
+"#;
+
+    let parsed = parse_program_text(text, &path)?;
+    let error = validate_program(&parsed.program, &path)
+        .expect_err("tuple subset domain mismatch should fail semantic validation");
+
+    assert!(
+        error
+            .to_string()
+            .contains("tuple subset index `a` in `target_pairs` declares domain `tech`")
+    );
+    assert!(error.to_string().contains("parent tuple domain is `area`"));
+
+    fs::remove_dir_all(&root)?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- implement explicit tuple-subset resolution for `set ... { in ...; where { ... } }` over tuple domains
- keep V1 auto-projection deferred (hard compile error on partial high-dim tuple binding)
- instantiate constraint generation bindings from tuple rows so reduced-scope constraints remain feasible-set bounded
- preserve/track tuple component domains in semantic set metadata
- add compile regression tests for subset-driven constraint instantiation and projection rejection

## Validation
- `cargo fmt --all`
- `cargo test -p arco-kdl`
- `cargo clippy -p arco-kdl --all-targets -- -D warnings`

Closes #186
Part of #183
