### PR TITLE
feat(kdl): tuple-domain validation + nodal allocation tracer

### DIFF
--- a/crates/arco-cli/tests/example_cli_commands.rs
+++ b/crates/arco-cli/tests/example_cli_commands.rs
@@ -182,6 +182,59 @@ fn inspect_json_parameters_have_dtype() {
 }
 
 #[test]
+fn run_compact_nodal_allocation_tracer_bullet_succeeds() {
+    let model_path = example_path("examples/nodal-allocation/input.kdl");
+    let model = model_path
+        .to_str()
+        .expect("example path contains invalid unicode");
+
+    let inspect_output = run_cli(&["inspect", model, "--json"]);
+    assert!(
+        inspect_output.status.success(),
+        "inspect failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&inspect_output.stdout),
+        String::from_utf8_lossy(&inspect_output.stderr)
+    );
+
+    let inspect_payload: Value =
+        serde_json::from_slice(&inspect_output.stdout).expect("valid inspect json");
+    let variables = inspect_payload["variable"]
+        .as_array()
+        .expect("variable array");
+    let dispatch = variables
+        .iter()
+        .find(|record| record["name"] == "dispatch")
+        .expect("dispatch variable record");
+    let sets = dispatch["set"].as_array().expect("dispatch set array");
+    assert_eq!(
+        sets.len(),
+        4,
+        "tuple-domain variable should keep four components"
+    );
+    for binding in sets {
+        assert_eq!(binding["name"], "feasible_links");
+    }
+
+    let run_output = run_cli(&["run", model, "--compact"]);
+    assert!(
+        run_output.status.success(),
+        "run failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&run_output.stdout),
+        String::from_utf8_lossy(&run_output.stderr)
+    );
+
+    let summary: Value = serde_json::from_slice(&run_output.stdout).expect("valid run json");
+    assert_eq!(summary["active_scenario"], "NodalAllocationDay");
+    assert_eq!(summary["objective"]["name"], "tuple_membership_tracer");
+    assert_eq!(summary["objective"]["value"], 0.0);
+    assert_eq!(summary["solve_status"], "optimal");
+
+    let counts = summary["counts"].as_object().expect("counts object");
+    assert_eq!(counts.get("variables"), Some(&Value::from(1)));
+    assert_eq!(counts.get("constraints"), Some(&Value::from(2)));
+}
+
+#[test]
 fn validate_surfaces_empty_filtered_subset_warning() {
     let root = unique_temp_dir("validate-empty-filtered-subset");
     let data_dir = root.join("data");

--- a/crates/arco-kdl/src/compile/algebra.rs
+++ b/crates/arco-kdl/src/compile/algebra.rs
@@ -362,10 +362,11 @@ fn resolve_tuple_domain_rows<'a>(
 
     if tuple_components != &signature.indices {
         return Err(CompileError::InvalidFormulation {
-            message: format!(
-                "index order mismatch for `{family}`: expected `{}`, received `{}`",
-                tuple_components.join(","),
-                signature.indices.join(",")
+            message: tuple_domain_index_order_mismatch_message(
+                family,
+                first_key,
+                tuple_components,
+                &signature.indices,
             ),
             path: entrypoint.to_path_buf(),
         });

--- a/crates/arco-kdl/src/compile/error.rs
+++ b/crates/arco-kdl/src/compile/error.rs
@@ -1,3 +1,16 @@
+fn tuple_domain_index_order_mismatch_message(
+    provenance: &str,
+    tuple_domain: &str,
+    expected: &[String],
+    received: &[String],
+) -> String {
+    format!(
+        "index order mismatch for `{provenance}` over tuple domain `{tuple_domain}`: expected `{}`, received `{}`",
+        expected.join(","),
+        received.join(",")
+    )
+}
+
 #[derive(Debug, Error, Diagnostic)]
 pub enum CompileError {
     #[error("missing scenario `{name}` during compilation in {path}")]

--- a/crates/arco-kdl/src/compile/expressions_domains.rs
+++ b/crates/arco-kdl/src/compile/expressions_domains.rs
@@ -67,10 +67,11 @@ fn expand_tuple_generation_bindings(
         .collect::<Vec<_>>();
     if tuple_components != &received_components {
         return Err(CompileError::InvalidFormulation {
-            message: format!(
-                "index order mismatch for `{binding_context}`: expected `{}`, received `{}`",
-                tuple_components.join(","),
-                received_components.join(",")
+            message: tuple_domain_index_order_mismatch_message(
+                binding_context,
+                first_key,
+                tuple_components,
+                &received_components,
             ),
             path: entrypoint.to_path_buf(),
         });

--- a/crates/arco-kdl/tests/compile_suite.rs
+++ b/crates/arco-kdl/tests/compile_suite.rs
@@ -17,6 +17,12 @@ fn temp_test_dir(name: &str) -> Result<PathBuf, Box<dyn std::error::Error>> {
     Ok(root)
 }
 
+fn repo_example_path(relative: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join(relative)
+}
+
 #[test]
 fn lowering_loads_top_level_data_block_params() -> Result<(), Box<dyn std::error::Error>> {
     let root = temp_test_dir("top-level-data")?;
@@ -733,8 +739,72 @@ scenario "S1" {
     match error {
         CompileError::InvalidFormulation { message, .. } => {
             assert!(message.contains("index order mismatch for `bad_projection`"));
+            assert!(message.contains("tuple domain `feasible_links`"));
             assert!(message.contains("expected `a,i,g,b`"));
             assert!(message.contains("received `a`"));
+        }
+        other => panic!("expected InvalidFormulation, got {other:?}"),
+    }
+
+    fs::remove_dir_all(&root)?;
+    Ok(())
+}
+
+#[test]
+fn lowering_reports_tuple_domain_provenance_for_variable_index_order_mismatches()
+-> Result<(), Box<dyn std::error::Error>> {
+    let root = temp_test_dir("tuple-domain-variable-order")?;
+    fs::create_dir_all(root.join("data"))?;
+    fs::write(
+        root.join("data").join("links.csv"),
+        "area,tech,gen,bus,feasible\n1,wind,g1,b1,1\n",
+    )?;
+
+    let path = root.join("input.kdl");
+    fs::write(
+        &path,
+        r#"
+data "links" source="data/links.csv" {
+  alias "generators" column="gen"
+  alias "buses" column="bus"
+
+  set "feasible_links" {
+    index "a" { in "area" }
+    index "i" { in "tech" }
+    index "g" { in "generators" }
+    index "b" { in "buses" }
+    where { feasible > 0 }
+  }
+}
+
+model "TupleDispatch" {
+  control "x" lower=0 {
+    index "a" { in "feasible_links" }
+    index "g" { in "feasible_links" }
+    index "i" { in "feasible_links" }
+    index "b" { in "feasible_links" }
+  }
+
+  minimize "Obj" { 0 }
+}
+
+scenario "S1" {
+  use "TupleDispatch"
+}
+"#,
+    )?;
+
+    let parsed = parse_program_file(&path)?;
+    let semantic = validate_program(&parsed.program, &path)?;
+    let error = compile_program(&semantic, &parsed.program, &path)
+        .expect_err("tuple-domain variable order mismatches should fail compilation");
+
+    match error {
+        CompileError::InvalidFormulation { message, .. } => {
+            assert!(message.contains("index order mismatch for `x[a,g,i,b]`"));
+            assert!(message.contains("tuple domain `feasible_links`"));
+            assert!(message.contains("expected `a,i,g,b`"));
+            assert!(message.contains("received `a,g,i,b`"));
         }
         other => panic!("expected InvalidFormulation, got {other:?}"),
     }
@@ -861,6 +931,49 @@ scenario "S1" {
 }
 
 #[test]
+fn lowering_example_nodal_allocation_preserves_sparse_tuple_membership()
+-> Result<(), Box<dyn std::error::Error>> {
+    let path = repo_example_path("examples/nodal-allocation/input.kdl");
+
+    let parsed = parse_program_file(&path)?;
+    let semantic = validate_program(&parsed.program, &path)?;
+    let compiled = compile_program(&semantic, &parsed.program, &path)?;
+
+    let dispatch_instances = compiled
+        .algebra
+        .variable_instances
+        .iter()
+        .map(|instance| instance.name.clone())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        dispatch_instances,
+        vec![
+            "dispatch[north,wind,g1,b1]".to_string(),
+            "dispatch[north,wind,g2,b2]".to_string(),
+            "dispatch[south,gas,g4,b3]".to_string(),
+            "dispatch[south,solar,g3,b3]".to_string(),
+        ]
+    );
+
+    let priority_constraints = compiled
+        .algebra
+        .constraints
+        .iter()
+        .filter(|constraint| constraint.name.starts_with("priority_floor"))
+        .map(|constraint| constraint.name.clone())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        priority_constraints,
+        vec![
+            "priority_floor[south,b3,g3,solar]".to_string(),
+            "priority_floor[south,b3,g4,gas]".to_string(),
+        ]
+    );
+
+    Ok(())
+}
+
+#[test]
 fn lowering_reports_scoped_inferred_constraint_ids_in_tuple_projection_errors()
 -> Result<(), Box<dyn std::error::Error>> {
     let root = temp_test_dir("tuple-projection-scoped-constraint-id")?;
@@ -917,6 +1030,7 @@ scenario "S1" {
     match error {
         CompileError::InvalidFormulation { message, .. } => {
             assert!(message.contains("index order mismatch for `S1.TupleDispatch.constraint_1`"));
+            assert!(message.contains("tuple domain `feasible_links`"));
             assert!(message.contains("expected `a,i,g,b`"));
             assert!(message.contains("received `a`"));
         }

--- a/docs/appendix-a-ergonomic-profile.md
+++ b/docs/appendix-a-ergonomic-profile.md
@@ -65,6 +65,60 @@ data branch_data from="data/branches.csv" {
 >   constraint).
 > - Use `filter` to distinguish connected vs. disconnected edges, directional
 >   subsets, or capacity tiers.
+>
+> Tuple-domain feasible-set pattern for nodal allocation:
+>
+> ```kdl
+> data links source="data/links.csv" {
+>   set area as=a
+>   set tech as=i
+>   alias generators column=gen
+>   alias buses column=bus
+>   set generators as=g
+>   set buses as=b
+>
+>   set feasible_links {
+>     index a { in area }
+>     index i { in tech }
+>     index g { in generators }
+>     index b { in buses }
+>     where { feasible > 0 }
+>   }
+> }
+>
+> set priority_links {
+>   in feasible_links
+>   index a { in area }
+>   index i { in tech }
+>   index g { in generators }
+>   index b { in buses }
+>   where { area == "south" }
+> }
+>
+> model nodal_allocation {
+>   control dispatch lower=0 {
+>     index a { in feasible_links }
+>     index i { in feasible_links }
+>     index g { in feasible_links }
+>     index b { in feasible_links }
+>   }
+>
+>   constraint priority_floor {
+>     index a { in priority_links }
+>     index i { in priority_links }
+>     index g { in priority_links }
+>     index b { in priority_links }
+>     expression { dispatch[a,i,g,b] >= 0 }
+>   }
+> }
+> ```
+>
+> In V1, tuple-domain variables mean membership in `feasible_links`, not
+> Cartesian expansion over `area × tech × generators × buses`. Projection stays
+> explicit: define a named subset and iterate that subset directly. If the index
+> order is wrong, diagnostics report both the scoped source ID and the canonical
+> tuple domain. Empty-subset diagnostics list every offending key in
+> deterministic tuple order.
 
 ## A.4 Ergonomic grammar
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -13,10 +13,10 @@ Most example folders follow the same layout:
 From the repository root, validate, inspect, print, or solve an example with `arco-cli`:
 
 ```bash
-cargo run -p arco-cli -- validate examples/generator-allocation/input.kdl
-cargo run -p arco-cli -- inspect examples/generator-allocation/input.kdl --section constraints
-cargo run -p arco-cli -- print-model examples/generator-allocation/input.kdl
-cargo run -p arco-cli -- run examples/generator-allocation/input.kdl
+cargo run -p arco-cli -- validate examples/nodal-allocation/input.kdl
+cargo run -p arco-cli -- inspect examples/nodal-allocation/input.kdl --section constraints
+cargo run -p arco-cli -- print-model examples/nodal-allocation/input.kdl
+cargo run -p arco-cli -- run examples/nodal-allocation/input.kdl
 ```
 
 For larger models, `--compact` keeps the solver output readable:
@@ -29,7 +29,8 @@ cargo run -p arco-cli -- run examples/unit-commitment/input.kdl --compact
 
 | Example                                | Path                                                   | Purpose                                                                                                                         | Status                                    |
 | -------------------------------------- | ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
-| Generator allocation                   | `examples/generator-allocation/input.kdl`              | Smallest end-to-end dispatch-style example for validating the core CLI flow.                                                    | Ready                                     |
+| Nodal allocation                       | `examples/nodal-allocation/input.kdl`                  | Tuple-domain tracer bullet for feasible node-generator allocations, explicit subsets, and sparse tuple-membership lowering.     | Ready                                     |
+| Generator allocation                   | `examples/generator-allocation/input.kdl`              | Smallest Cartesian indexed dispatch example for validating the legacy core CLI flow.                                            | Ready                                     |
 | Price-taker battery                    | `examples/price-taker-battery/input.kdl`               | Battery charge and discharge scheduling against an exogenous price curve.                                                       | Ready                                     |
 | Simple electricity market with storage | `examples/simple-electricity-market-storage/input.kdl` | Single-zone dispatch with time-varying availability, load, and storage decisions.                                               | Ready                                     |
 | Capacity expansion                     | `examples/capacity-expansion/input.kdl`                | Build versus dispatch tradeoffs, candidate assets, and unmet-demand penalties.                                                  | Ready                                     |
@@ -61,11 +62,29 @@ This leaves `model`, `solve()`, `solution`, and `payload` available in the promp
 
 If you are new to the repo, this order ramps up nicely:
 
-1. `generator-allocation`, to learn the basic data and model structure
-2. `price-taker-battery`, to see time coupling and storage dynamics
-3. `capacity-expansion`, to see investment-style modeling
-4. `dcopf-angle` and `dcopf-ptdf`, to compare equivalent network formulations
-5. `unit-commitment` or `sdom`, when you want a heavier mixed-integer case
+1. `nodal-allocation`, to see tuple-domain feasible-set semantics and explicit subsets in a small end-to-end flow
+2. `generator-allocation`, to compare against a simple Cartesian indexed formulation
+3. `price-taker-battery`, to see time coupling and storage dynamics
+4. `capacity-expansion`, to see investment-style modeling
+5. `dcopf-angle` and `dcopf-ptdf`, to compare equivalent network formulations
+6. `unit-commitment` or `sdom`, when you want a heavier mixed-integer case
+
+## Tuple-domain diagnostics contract
+
+The `nodal-allocation` example is the user-facing tracer bullet for tuple-domain
+V1 behavior:
+
+- `dispatch[a,i,g,b]` is instantiated only for members of `feasible_links`.
+  There is no Cartesian fallback.
+- Reduced or filtered scopes are modeled with named subsets such as
+  `priority_links`; V1 does not auto-project high-dimensional tuple domains.
+- Compile-time diagnostics use scoped identifiers and canonical ordering. For
+  example:
+
+  ```text
+  index order mismatch for `NodalAllocationDay.NodalAllocation.constraint_1` over tuple domain `feasible_links`
+  empty constraint-relevant tuple subset for `NodalAllocationDay.NodalAllocation.capacity_target` at keys: north,solar; north,wind; south,gas; south,solar
+  ```
 
 ## Current caveats
 

--- a/examples/nodal-allocation/data/links.csv
+++ b/examples/nodal-allocation/data/links.csv
@@ -1,0 +1,6 @@
+area,tech,gen,bus,feasible,capacity_mw,priority_floor_mw
+north,wind,g1,b1,1,10,4
+north,wind,g2,b2,1,8,0
+south,solar,g3,b3,1,6,2
+south,gas,g4,b3,1,12,0
+north,solar,g5,b4,0,9,0

--- a/examples/nodal-allocation/input.kdl
+++ b/examples/nodal-allocation/input.kdl
@@ -1,0 +1,89 @@
+data "links" source="data/links.csv" {
+  set "area" as="a"
+  set "tech" as="i"
+  alias "generators" column="gen"
+  alias "buses" column="bus"
+
+  set "generators" as="g"
+  set "buses" as="b"
+
+  set "feasible_links" {
+    index "a" { in "area" }
+    index "i" { in "tech" }
+    index "g" { in "generators" }
+    index "b" { in "buses" }
+    where { feasible > 0 }
+  }
+
+  param "capacity_mw" {
+    index "a"
+    index "i"
+    index "g"
+    index "b"
+  }
+
+  param "priority_floor_mw" {
+    index "a"
+    index "i"
+    index "g"
+    index "b"
+  }
+}
+
+set "priority_links" {
+  in "feasible_links"
+  index "a" { in "area" }
+  index "i" { in "tech" }
+  index "g" { in "generators" }
+  index "b" { in "buses" }
+  where { area == "south" }
+}
+
+model "NodalAllocation" {
+  param "capacity_mw" {
+    index "a"
+    index "i"
+    index "g"
+    index "b"
+  }
+
+  param "priority_floor_mw" {
+    index "a"
+    index "i"
+    index "g"
+    index "b"
+  }
+
+  control "dispatch" lower=0 {
+    index "a" { in "feasible_links" }
+    index "i" { in "feasible_links" }
+    index "g" { in "feasible_links" }
+    index "b" { in "feasible_links" }
+  }
+
+  constraint "dispatch_capacity" {
+    index "a" { in "feasible_links" }
+    index "i" { in "feasible_links" }
+    index "g" { in "feasible_links" }
+    index "b" { in "feasible_links" }
+    expression {
+      dispatch[a,i,g,b] <= capacity_mw[a,i,g,b]
+    }
+  }
+
+  constraint "priority_floor" {
+    index "a" { in "priority_links" }
+    index "i" { in "priority_links" }
+    index "g" { in "priority_links" }
+    index "b" { in "priority_links" }
+    expression {
+      dispatch[a,i,g,b] >= priority_floor_mw[a,i,g,b]
+    }
+  }
+
+  minimize "tuple_membership_tracer" { 0 }
+}
+
+scenario "NodalAllocationDay" {
+  use "NodalAllocation"
+}

--- a/scripts/test_example_formulations.py
+++ b/scripts/test_example_formulations.py
@@ -10,6 +10,7 @@ import shutil
 import subprocess
 
 DEFAULT_EXAMPLES: tuple[str, ...] = (
+    "nodal-allocation",
     "generator-allocation",
     "price-taker-battery",
     "simple-electricity-market-storage",


### PR DESCRIPTION
## Summary
- Add V1 tuple-domain compile-time diagnostics with tuple-domain provenance for index-order mismatch errors.
- Improve tuple-domain validation surfacing (scoped + domain context).
- Add nodal-allocation tracer-bullet example demonstrating sparse tuple membership and explicit tuple subsets.
- Add regression tests for diagnostic and lowering behavior.
- Update docs and example defaults to include the new tracer-bullet flow.

## Testing
- cargo test -p arco-kdl
- cargo test -p arco-cli --test example_cli_commands

## Related issues
Closes #187
Closes #189
Part of #183