### PR TITLE
ci: gate benchmark alerts to pull requests

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -128,7 +128,7 @@ jobs:
           external-data-json-path: ./cache/benchmark-data.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
           summary-always: true
-          comment-on-alert: true
+          comment-on-alert: ${{ github.event_name == 'pull_request' }}
           alert-threshold: "125%"
           fail-on-alert: false
 


### PR DESCRIPTION
This fixes benchmark workflow failures on push-to-main.

## Why
Benchmark workflow pushes to main were failing in the `Store benchmark results` step with: `Resource not accessible by integration` after performance alerts.

## Fix
Gate alert posting to pull request context only:

- `comment-on-alert: ${{ github.event_name == 'pull_request' }}`

## Outcome
Prevents push-to-main from failing in the PR-comment/alert publishing path while keeping benchmark alert comments on PR checks.

## Scope
No runtime behavior change to benchmark measurements.
