### PR TITLE
test: expand filter RHS conformance coverage

### DIFF
--- a/crates/arco-kdl/tests/compile_suite.rs
+++ b/crates/arco-kdl/tests/compile_suite.rs
@@ -381,6 +381,83 @@ scenario "S1" {
 }
 
 #[test]
+fn lowering_applies_data_param_filters_with_mapped_identifier_rhs()
+-> Result<(), Box<dyn std::error::Error>> {
+    let root = temp_test_dir("data-param-filter-mapped-identifier")?;
+    fs::create_dir_all(root.join("data"))?;
+    fs::write(
+        root.join("data").join("load.csv"),
+        "period,technology,demand\n1,wind,10\n1,solar,90\n2,wind,20\n2,solar,80\n",
+    )?;
+
+    let path = root.join("input.kdl");
+    fs::write(
+        &path,
+        r#"
+set "time" { "1"; "2" }
+
+data "inputs" source="data/load.csv" {
+  map "time" from="period"
+  map "tech" from="technology"
+
+  param "demand" from="demand" reduce="sum" {
+    index "time"
+    // Spec: §9 — map applies to lhs lookup; bare RHS remains literal.
+    filter { tech == wind }
+  }
+}
+
+model "Dispatch" {
+  set "time" alias="t"
+
+  param "demand" {
+    index "t"
+  }
+
+  control "x" {
+    index "t"
+  }
+
+  constraint "balance[t]" {
+    x[t] = demand[t]
+  }
+
+  minimize "Obj" {
+    sum(x[t] for t in time)
+  }
+}
+
+scenario "S1" {
+  use "Dispatch"
+}
+"#,
+    )?;
+
+    let parsed = parse_program_file(&path)?;
+    let semantic = validate_program(&parsed.program, &path)?;
+    let compiled = compile_program(&semantic, &parsed.program, &path)?;
+
+    let bal_1 = compiled
+        .algebra
+        .constraints
+        .iter()
+        .find(|c| c.name == "balance[t][1]")
+        .ok_or("missing balance constraint at t=1")?;
+    let bal_2 = compiled
+        .algebra
+        .constraints
+        .iter()
+        .find(|c| c.name == "balance[t][2]")
+        .ok_or("missing balance constraint at t=2")?;
+
+    assert_eq!(bal_1.rhs, 10.0);
+    assert_eq!(bal_2.rhs, 20.0);
+
+    fs::remove_dir_all(&root)?;
+    Ok(())
+}
+
+#[test]
 fn lowering_instantiates_tuple_domain_variables_from_data_rows()
 -> Result<(), Box<dyn std::error::Error>> {
     let root = temp_test_dir("tuple-domain-from-data")?;

--- a/crates/arco-kdl/tests/semantic_validation.rs
+++ b/crates/arco-kdl/tests/semantic_validation.rs
@@ -230,6 +230,7 @@ data "tech_data" source="data/tech.csv" {
   set "tech"
   set "wind_tech" {
     in "tech"
+    // Spec: §9 — bare RHS is categorical literal, not column lookup.
     filter { tech == wind }
   }
 }
@@ -259,6 +260,113 @@ scenario "S1" {
         .get("wind_tech")
         .ok_or("missing set wind_tech")?;
     assert_eq!(wind_tech.values, vec!["wind".to_string()]);
+
+    fs::remove_dir_all(&root)?;
+    Ok(())
+}
+
+#[test]
+fn semantic_validation_applies_mapped_column_set_filters() -> Result<(), Box<dyn std::error::Error>>
+{
+    let root = temp_root("semantic-set-filter-mapped-column")?;
+    fs::create_dir_all(root.join("data"))?;
+    fs::write(
+        root.join("data").join("tech.csv"),
+        "technology\nwind\nsolar\nwind\n",
+    )?;
+
+    let path = root.join("input.kdl");
+    let text = r#"
+data "tech_data" source="data/tech.csv" {
+  map "tech" from="technology"
+
+  set "tech"
+  set "wind_tech" {
+    in "tech"
+    // Spec: §9 — map applies to lhs, RHS bare token remains literal.
+    filter { tech == wind }
+  }
+}
+
+model "Dispatch" {
+  set "tech"
+
+  control "x" {
+    index "tech"
+  }
+
+  minimize "Obj" {
+    sum(x[tech] for tech in tech)
+  }
+}
+
+scenario "S1" {
+  use "Dispatch"
+}
+"#;
+
+    let parsed = parse_program_text(text, &path)?;
+    let semantic = validate_program(&parsed.program, &path)?;
+
+    let wind_tech = semantic
+        .set_registry
+        .get("wind_tech")
+        .ok_or("missing set wind_tech")?;
+    assert_eq!(wind_tech.values, vec!["wind".to_string()]);
+
+    fs::remove_dir_all(&root)?;
+    Ok(())
+}
+
+#[test]
+fn semantic_validation_applies_set_filter_with_parent_alias_and_bare_rhs()
+-> Result<(), Box<dyn std::error::Error>> {
+    let root = temp_root("semantic-subset-filter-parent-bare-rhs")?;
+    fs::create_dir_all(root.join("data"))?;
+    fs::write(
+        root.join("data").join("assets.csv"),
+        "asset_name,zone_raw\nA,north\nB,south\nC,north\n",
+    )?;
+
+    let path = root.join("input.kdl");
+    let text = r#"
+data "assets_data" source="data/assets.csv" {
+  map "asset_id" from="asset_name"
+  map "zone" from="zone_raw"
+
+  set "asset_id" alias="a"
+  set "south_assets" {
+    in "a"
+    // Spec: §9 — alias resolution and bare RHS semantics together.
+    filter { zone == south }
+  }
+}
+
+model "Dispatch" {
+  set "asset_id" alias="a"
+
+  control "x" {
+    index "a"
+  }
+
+  minimize "Obj" {
+    sum(x[a] for a in asset_id)
+  }
+}
+
+scenario "S1" {
+  use "Dispatch"
+}
+"#;
+
+    let parsed = parse_program_text(text, &path)?;
+    let semantic = validate_program(&parsed.program, &path)?;
+
+    let south_assets = semantic
+        .set_registry
+        .get("south_assets")
+        .ok_or("missing set south_assets")?;
+    assert_eq!(south_assets.values, vec!["B".to_string()]);
 
     fs::remove_dir_all(&root)?;
     Ok(())


### PR DESCRIPTION
## Summary
- Add semantic validation coverage for filter right-hand-side conformance in set filters:
  - mapped-column RHS/lhs usage with bare token RHS
  - parent-alias + bare-RHS subset filter case
- Add compile-suite coverage for mapped-column bare RHS in data param filters.
- Add inline Spec §9 references in conformance tests.

Closes #172.
