### PR TITLE
feat: add projection grammar

### DIFF
--- a/crates/arco-cli/tests/example_cli_commands.rs
+++ b/crates/arco-cli/tests/example_cli_commands.rs
@@ -220,11 +220,11 @@ fn run_compact_nodal_allocation_tracer_bullet_succeeds() {
     let variables = inspect_payload["variable"]
         .as_array()
         .expect("variable array");
-    let dispatch = variables
+    let investment = variables
         .iter()
-        .find(|record| record["name"] == "dispatch")
-        .expect("dispatch variable record");
-    let sets = dispatch["set"].as_array().expect("dispatch set array");
+        .find(|record| record["name"] == "investment")
+        .expect("investment variable record");
+    let sets = investment["set"].as_array().expect("investment set array");
     assert_eq!(
         sets.len(),
         4,
@@ -242,12 +242,12 @@ fn run_compact_nodal_allocation_tracer_bullet_succeeds() {
     let constraints = inspect_payload["constraint"]
         .as_array()
         .expect("constraint array");
-    let dispatch_capacity = constraints
+    let investment_capacity = constraints
         .iter()
-        .find(|record| record["name"] == "dispatch_capacity")
-        .expect("dispatch_capacity constraint record");
+        .find(|record| record["name"] == "investment_capacity")
+        .expect("investment_capacity constraint record");
     assert_eq!(
-        dispatch_capacity["instances"],
+        investment_capacity["instances"],
         Value::from(4),
         "tuple-domain constraint instances should track tuple rows, not Cartesian powers"
     );
@@ -278,7 +278,7 @@ fn run_compact_nodal_allocation_tracer_bullet_succeeds() {
 
     let counts = summary["counts"].as_object().expect("counts object");
     assert_eq!(counts.get("variables"), Some(&Value::from(1)));
-    assert_eq!(counts.get("constraints"), Some(&Value::from(2)));
+    assert_eq!(counts.get("constraints"), Some(&Value::from(3)));
 }
 
 #[test]

--- a/crates/arco-kdl/src/algebra/analysis.rs
+++ b/crates/arco-kdl/src/algebra/analysis.rs
@@ -36,7 +36,10 @@ fn collect_named_dependencies(
                 names.insert(name.clone());
             }
         }
-        Expr::Indexed { indices, .. } => {
+        Expr::Indexed { target, indices } => {
+            if !bound.contains(target) {
+                names.insert(target.clone());
+            }
             for index in indices {
                 collect_named_dependencies(index, bound, names);
             }

--- a/crates/arco-kdl/src/compile/expressions.rs
+++ b/crates/arco-kdl/src/compile/expressions.rs
@@ -319,6 +319,80 @@ fn expand_reduction_bindings(
     entrypoint: &Path,
 ) -> Result<Vec<LinearizationBindings>, CompileError> {
     let reverse_aliases = build_reverse_alias_lookup(program);
+
+    if let Some(first) = bindings.first() {
+        let same_domain = bindings.iter().all(|binding| binding.domain == first.domain);
+        let name_bindings = bindings
+            .iter()
+            .map(|binding| match &binding.pattern {
+                crate::algebra::BindingPattern::Name(name) => Some(name.clone()),
+                crate::algebra::BindingPattern::Tuple(_) => None,
+            })
+            .collect::<Option<Vec<_>>>();
+
+        if same_domain {
+            if let (Some(names), Some(set)) =
+                (name_bindings, program.set_registry.get(&first.domain))
+            {
+                if let (Some(tuple_components), Some(tuple_rows)) =
+                    (set.tuple_components.as_ref(), set.tuple_rows.as_ref())
+                {
+                    let mut component_to_binding = BTreeMap::new();
+                    for name in &names {
+                        let component = name
+                            .strip_suffix("_r")
+                            .unwrap_or(name.as_str())
+                            .to_string();
+                        component_to_binding.insert(component, name.clone());
+                    }
+
+                    let mut scopes = Vec::new();
+                    for row in tuple_rows {
+                        if row.len() != tuple_components.len() {
+                            return Err(CompileError::InvalidFormulation {
+                                message: format!(
+                                    "tuple row arity mismatch in reduction over `{}`: expected `{}`, received `{}`",
+                                    first.domain,
+                                    tuple_components.len(),
+                                    row.len()
+                                ),
+                                path: entrypoint.to_path_buf(),
+                            });
+                        }
+
+                        let mut scope = current.clone();
+                        let mut matches_anchor = true;
+                        for (component, value) in tuple_components.iter().zip(row.iter()) {
+                            if let Some(binding_name) = component_to_binding.get(component) {
+                                scope.values.insert(
+                                    binding_name.clone(),
+                                    FilterValue::String(value.clone()),
+                                );
+                                continue;
+                            }
+
+                            if let Some(existing) = current.values.get(component) {
+                                let tuple_value = FilterValue::String(value.clone());
+                                if existing != &tuple_value {
+                                    matches_anchor = false;
+                                    break;
+                                }
+                            }
+                        }
+
+                        if matches_anchor {
+                            scopes.push(scope);
+                        }
+                    }
+
+                    if !scopes.is_empty() {
+                        return Ok(scopes);
+                    }
+                }
+            }
+        }
+    }
+
     let mut scopes = vec![current.clone()];
 
     for binding in bindings {

--- a/crates/arco-kdl/src/compile/expressions.rs
+++ b/crates/arco-kdl/src/compile/expressions.rs
@@ -318,17 +318,27 @@ fn expand_reduction_bindings(
     program: &SemanticProgram,
     entrypoint: &Path,
 ) -> Result<Vec<LinearizationBindings>, CompileError> {
+    let reverse_aliases = build_reverse_alias_lookup(program);
     let mut scopes = vec![current.clone()];
+
     for binding in bindings {
-        let values = reduction_domain_values(&binding.domain, inputs, program, entrypoint)?;
         let mut next = Vec::new();
         for scope in &scopes {
             match &binding.pattern {
                 crate::algebra::BindingPattern::Name(name) => {
+                    let values = reduction_values_for_binding_scope(
+                        binding.domain.as_str(),
+                        name,
+                        scope,
+                        inputs,
+                        program,
+                        &reverse_aliases,
+                        entrypoint,
+                    )?;
                     for value in &values {
-                        let mut scope = scope.clone();
-                        scope.values.insert(name.clone(), value.clone());
-                        next.push(scope);
+                        let mut scoped = scope.clone();
+                        scoped.values.insert(name.clone(), value.clone());
+                        next.push(scoped);
                     }
                 }
                 crate::algebra::BindingPattern::Tuple(_) => {
@@ -341,5 +351,112 @@ fn expand_reduction_bindings(
         }
         scopes = next;
     }
+
     Ok(scopes)
+}
+
+fn reduction_values_for_binding_scope(
+    domain: &str,
+    binding_name: &str,
+    scope: &LinearizationBindings,
+    inputs: &ScenarioInputs,
+    program: &SemanticProgram,
+    reverse_aliases: &BTreeMap<&str, &str>,
+    entrypoint: &Path,
+) -> Result<Vec<FilterValue>, CompileError> {
+    let Some(domain_key) = resolve_set_registry_key(domain, program, reverse_aliases) else {
+        return reduction_domain_values(domain, inputs, program, entrypoint);
+    };
+
+    let Some(set) = resolve_set_struct_by_name(domain_key, program, reverse_aliases) else {
+        return reduction_domain_values(domain, inputs, program, entrypoint);
+    };
+
+    let (Some(tuple_components), Some(tuple_rows)) =
+        (set.tuple_components.as_ref(), set.tuple_rows.as_ref())
+    else {
+        return reduction_domain_values(domain, inputs, program, entrypoint);
+    };
+
+    tuple_reduction_binding_values(
+        domain_key,
+        binding_name,
+        tuple_components,
+        tuple_rows,
+        scope,
+        entrypoint,
+    )
+}
+
+fn tuple_reduction_binding_values(
+    domain_key: &str,
+    binding_name: &str,
+    tuple_components: &[String],
+    tuple_rows: &[Vec<String>],
+    scope: &LinearizationBindings,
+    entrypoint: &Path,
+) -> Result<Vec<FilterValue>, CompileError> {
+    let Some(binding_component_index) =
+        tuple_reduction_component_index(binding_name, tuple_components)
+    else {
+        return Err(CompileError::InvalidFormulation {
+            message: format!(
+                "reduction binding `{binding_name}` does not match tuple domain `{domain_key}` components `{}`",
+                tuple_components.join(",")
+            ),
+            path: entrypoint.to_path_buf(),
+        });
+    };
+
+    let scoped_component_values = scope
+        .values
+        .iter()
+        .filter_map(|(name, value)| {
+            tuple_reduction_component_index(name, tuple_components).map(|index| (index, value))
+        })
+        .map(|(index, value)| {
+            filter_value_to_key_component(value, entrypoint).map(|key_value| (index, key_value))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let mut projected_values = BTreeSet::new();
+
+    'rows: for row in tuple_rows {
+        if row.len() != tuple_components.len() {
+            return Err(CompileError::InvalidFormulation {
+                message: format!(
+                    "tuple row arity mismatch for tuple reduction domain `{domain_key}`: expected `{}`, received `{}`",
+                    tuple_components.len(),
+                    row.len()
+                ),
+                path: entrypoint.to_path_buf(),
+            });
+        }
+
+        for (component_index, scoped_value) in &scoped_component_values {
+            if row[*component_index] != *scoped_value {
+                continue 'rows;
+            }
+        }
+
+        projected_values.insert(row[binding_component_index].clone());
+    }
+
+    Ok(projected_values
+        .into_iter()
+        .map(FilterValue::String)
+        .collect())
+}
+
+fn tuple_reduction_component_index(name: &str, tuple_components: &[String]) -> Option<usize> {
+    tuple_components
+        .iter()
+        .position(|component| component == name)
+        .or_else(|| {
+            name.strip_suffix("_r").and_then(|candidate| {
+                tuple_components
+                    .iter()
+                    .position(|component| component == candidate)
+            })
+        })
 }

--- a/crates/arco-kdl/src/compile/expressions_domains.rs
+++ b/crates/arco-kdl/src/compile/expressions_domains.rs
@@ -371,6 +371,19 @@ fn linearize_indexed_expr(
         return Ok(AffineExpr::variable(candidate, 1.0));
     }
 
+    if let Some(expression) = named_expressions.get(target) {
+        return linearize_value_expr(
+            expression,
+            bindings,
+            program,
+            inputs,
+            named_expressions,
+            variable_signatures,
+            instantiated_names,
+            entrypoint,
+        );
+    }
+
     // The candidate was not found in the instantiated set. Before falling
     // through to parameter lookup, handle chronology boundary cases for
     // [String, Number] references where the time index is out of range.

--- a/crates/arco-kdl/src/semantic/resolution.rs
+++ b/crates/arco-kdl/src/semantic/resolution.rs
@@ -1,4 +1,4 @@
-use crate::algebra::collect_named_expression_dependencies;
+use crate::algebra::{ConstraintBody, collect_named_expression_dependencies};
 use crate::semantic::error::SemanticError;
 use crate::semantic::types::{
     ResolvedConstraint, ResolvedDualReport, ResolvedExpression, ResolvedObjective, ResolvedReport,
@@ -91,6 +91,7 @@ pub(crate) fn resolve_active_model_expressions(
     model: &ModelDecl,
     objective: &ResolvedObjective,
     reports: &[ResolvedReport],
+    constraints: &[ResolvedConstraint],
     entrypoint: &Path,
 ) -> Result<Vec<ResolvedExpression>, SemanticError> {
     #[derive(Clone, Copy, PartialEq, Eq)]
@@ -175,6 +176,23 @@ pub(crate) fn resolve_active_model_expressions(
         }
     }
 
+    for constraint in constraints {
+        for dependency in
+            collect_named_expression_dependencies_from_constraint(&constraint.expression)
+        {
+            if expression_index.contains_key(dependency.as_str()) {
+                visit_expression_name(
+                    &dependency,
+                    &expression_index,
+                    &mut resolved,
+                    &mut states,
+                    &mut stack,
+                    entrypoint,
+                )?;
+            }
+        }
+    }
+
     for report in reports {
         if expression_index.contains_key(report.name.as_str()) {
             visit_expression_name(
@@ -214,4 +232,27 @@ pub(crate) fn resolve_active_model_expressions(
         .collect::<Vec<_>>();
     expressions.sort_by_key(|expression| expression.name.clone());
     Ok(expressions)
+}
+
+fn collect_named_expression_dependencies_from_constraint(
+    constraint: &ConstraintBody,
+) -> BTreeSet<String> {
+    match constraint {
+        ConstraintBody::Comparison { left, right, .. } => {
+            let mut names = collect_named_expression_dependencies(left);
+            names.extend(collect_named_expression_dependencies(right));
+            names
+        }
+        ConstraintBody::Range {
+            lower,
+            middle,
+            upper,
+            ..
+        } => {
+            let mut names = collect_named_expression_dependencies(lower);
+            names.extend(collect_named_expression_dependencies(middle));
+            names.extend(collect_named_expression_dependencies(upper));
+            names
+        }
+    }
 }

--- a/crates/arco-kdl/src/semantic/sets.rs
+++ b/crates/arco-kdl/src/semantic/sets.rs
@@ -304,11 +304,24 @@ fn tuple_rows_for_rule_subset(
     path: &Path,
     rule_identifier: &str,
 ) -> Result<Vec<Vec<String>>, SemanticError> {
-    let parent_components = parent_set
-        .tuple_components
-        .as_ref()
-        .expect("checked by caller");
-    let parent_rows = parent_set.tuple_rows.as_ref().expect("checked by caller");
+    let parent_components =
+        parent_set
+            .tuple_components
+            .as_ref()
+            .ok_or_else(|| SemanticError::MissingDeclaration {
+                kind: "subset tuple signature",
+                name: set_decl.name.clone(),
+                path: path.to_path_buf(),
+            })?;
+    let parent_rows =
+        parent_set
+            .tuple_rows
+            .as_ref()
+            .ok_or_else(|| SemanticError::MissingDeclaration {
+                kind: "subset tuple rows",
+                name: set_decl.name.clone(),
+                path: path.to_path_buf(),
+            })?;
     let parent_domains = tuple_component_domains_for_resolved_set(parent_set, parent_components);
 
     let mut projection_positions = Vec::with_capacity(set_decl.tuple_indices.len());

--- a/crates/arco-kdl/src/semantic/validation.rs
+++ b/crates/arco-kdl/src/semantic/validation.rs
@@ -307,7 +307,7 @@ fn projection_source_keys<'a>(
 }
 
 fn lower_reduce_projection_expressions(
-    active_expressions: &mut Vec<ResolvedExpression>,
+    active_expressions: &mut [ResolvedExpression],
     model: &ModelDecl,
     program: &SourceProgram,
     set_registry: &BTreeMap<String, crate::semantic::ResolvedSet>,
@@ -368,10 +368,13 @@ fn lower_reduce_projection_expressions(
             .collect::<Vec<_>>()
             .join(",");
 
-        let bindings = dropped
-            .iter()
-            .map(|key| format!(" for {key}_r in {}", projection_decl.from_domain))
-            .collect::<String>();
+        let mut bindings = String::new();
+        for key in &dropped {
+            bindings.push_str(" for ");
+            bindings.push_str(key);
+            bindings.push_str("_r in ");
+            bindings.push_str(&projection_decl.from_domain);
+        }
         let lowered_formula = format!("{op}({target}[{body_indices}]{bindings})");
         let parsed = parse_value_formula(&lowered_formula).map_err(|error| {
             SemanticError::MissingDeclaration {

--- a/crates/arco-kdl/src/semantic/validation.rs
+++ b/crates/arco-kdl/src/semantic/validation.rs
@@ -124,6 +124,8 @@ pub fn validate_program(
         extend_set_registry_from_low_level_declarations(program, entry_dir, &mut set_registry)?;
     }
 
+    validate_projection_source_domains(program, &set_registry, entrypoint)?;
+
     let time_steps = set_registry
         .get("time")
         .or_else(|| set_registry.get("t"))
@@ -165,6 +167,42 @@ pub fn validate_program(
         active_variable_reports,
         active_dual_reports,
     })
+}
+
+fn validate_projection_source_domains(
+    program: &SourceProgram,
+    set_registry: &BTreeMap<String, crate::semantic::ResolvedSet>,
+    entrypoint: &Path,
+) -> Result<(), SemanticError> {
+    for projection in &program.projections {
+        let Some(source_domain) = set_registry.get(&projection.from_domain) else {
+            return Err(SemanticError::MissingDeclaration {
+                kind: "projection source domain",
+                name: projection.from_domain.clone(),
+                path: entrypoint.to_path_buf(),
+            });
+        };
+
+        let Some(source_keys) = source_domain.tuple_components.as_ref() else {
+            return Err(SemanticError::MissingDeclaration {
+                kind: "projection source tuple signature",
+                name: projection.from_domain.clone(),
+                path: entrypoint.to_path_buf(),
+            });
+        };
+
+        for target_key in &projection.to_keys {
+            if !source_keys.contains(target_key) {
+                return Err(SemanticError::MissingDeclaration {
+                    kind: "projection target key",
+                    name: target_key.clone(),
+                    path: entrypoint.to_path_buf(),
+                });
+            }
+        }
+    }
+
+    Ok(())
 }
 
 fn resolve_scenario<'a>(

--- a/crates/arco-kdl/src/semantic/validation.rs
+++ b/crates/arco-kdl/src/semantic/validation.rs
@@ -1,3 +1,4 @@
+use crate::algebra::parse_value_formula;
 use crate::semantic::error::SemanticError;
 use crate::semantic::resolution::{
     resolve_active_model_expressions, resolve_model_scenario_reports,
@@ -94,8 +95,13 @@ pub fn validate_program(
 
     let (active_reports, active_dual_reports, active_variable_reports) =
         resolve_model_scenario_reports(model, scenario, &active_constraints, entrypoint)?;
-    let mut active_expressions =
-        resolve_active_model_expressions(model, &active_objective, &active_reports, entrypoint)?;
+    let mut active_expressions = resolve_active_model_expressions(
+        model,
+        &active_objective,
+        &active_reports,
+        &active_constraints,
+        entrypoint,
+    )?;
 
     // Inject inline scalar params (e.g. `param fcr_vre 0.072649`) as synthetic
     // named expressions so they are resolvable in algebra and index positions.
@@ -126,6 +132,13 @@ pub fn validate_program(
 
     validate_projection_source_domains(program, &set_registry, entrypoint)?;
     validate_reduce_projection_expressions(model, program, &set_registry, entrypoint)?;
+    lower_reduce_projection_expressions(
+        &mut active_expressions,
+        model,
+        program,
+        &set_registry,
+        entrypoint,
+    )?;
 
     let time_steps = set_registry
         .get("time")
@@ -291,6 +304,88 @@ fn projection_source_keys<'a>(
             name: projection.from_domain.clone(),
             path: entrypoint.to_path_buf(),
         })
+}
+
+fn lower_reduce_projection_expressions(
+    active_expressions: &mut Vec<ResolvedExpression>,
+    model: &ModelDecl,
+    program: &SourceProgram,
+    set_registry: &BTreeMap<String, crate::semantic::ResolvedSet>,
+    entrypoint: &Path,
+) -> Result<(), SemanticError> {
+    let projections = program
+        .projections
+        .iter()
+        .map(|projection| (projection.name.as_str(), projection))
+        .collect::<BTreeMap<_, _>>();
+
+    let expression_abstractions = model
+        .expressions
+        .iter()
+        .filter_map(|expr| {
+            expr.abstraction
+                .as_ref()
+                .map(|abstraction| (expr.name.as_str(), abstraction))
+        })
+        .collect::<BTreeMap<_, _>>();
+
+    for resolved in active_expressions.iter_mut() {
+        let Some(abstraction) = expression_abstractions.get(resolved.name.as_str()) else {
+            continue;
+        };
+
+        let crate::source::ExpressionAbstractionDecl::ReduceProjection {
+            projection,
+            op,
+            target,
+        } = abstraction;
+
+        let projection_decl = projections.get(projection.as_str()).ok_or_else(|| {
+            SemanticError::MissingDeclaration {
+                kind: "projection",
+                name: projection.clone(),
+                path: entrypoint.to_path_buf(),
+            }
+        })?;
+        let source_keys = projection_source_keys(projection_decl, set_registry, entrypoint)?;
+
+        let dropped = source_keys
+            .iter()
+            .filter(|key| !projection_decl.to_keys.contains(*key))
+            .cloned()
+            .collect::<Vec<_>>();
+        let dropped_lookup = dropped.iter().cloned().collect::<BTreeSet<_>>();
+
+        let body_indices = source_keys
+            .iter()
+            .map(|key| {
+                if dropped_lookup.contains(key) {
+                    format!("{key}_r")
+                } else {
+                    key.clone()
+                }
+            })
+            .collect::<Vec<_>>()
+            .join(",");
+
+        let bindings = dropped
+            .iter()
+            .map(|key| format!(" for {key}_r in {}", projection_decl.from_domain))
+            .collect::<String>();
+        let lowered_formula = format!("{op}({target}[{body_indices}]{bindings})");
+        let parsed = parse_value_formula(&lowered_formula).map_err(|error| {
+            SemanticError::MissingDeclaration {
+                kind: "reduce projection lowered formula",
+                name: error.to_string(),
+                path: entrypoint.to_path_buf(),
+            }
+        })?;
+
+        resolved.formula_text = lowered_formula;
+        resolved.formula = parsed;
+    }
+
+    Ok(())
 }
 
 fn resolve_scenario<'a>(

--- a/crates/arco-kdl/src/semantic/validation.rs
+++ b/crates/arco-kdl/src/semantic/validation.rs
@@ -125,6 +125,7 @@ pub fn validate_program(
     }
 
     validate_projection_source_domains(program, &set_registry, entrypoint)?;
+    validate_reduce_projection_expressions(model, program, &set_registry, entrypoint)?;
 
     let time_steps = set_registry
         .get("time")
@@ -175,21 +176,7 @@ fn validate_projection_source_domains(
     entrypoint: &Path,
 ) -> Result<(), SemanticError> {
     for projection in &program.projections {
-        let Some(source_domain) = set_registry.get(&projection.from_domain) else {
-            return Err(SemanticError::MissingDeclaration {
-                kind: "projection source domain",
-                name: projection.from_domain.clone(),
-                path: entrypoint.to_path_buf(),
-            });
-        };
-
-        let Some(source_keys) = source_domain.tuple_components.as_ref() else {
-            return Err(SemanticError::MissingDeclaration {
-                kind: "projection source tuple signature",
-                name: projection.from_domain.clone(),
-                path: entrypoint.to_path_buf(),
-            });
-        };
+        let source_keys = projection_source_keys(projection, set_registry, entrypoint)?;
 
         for target_key in &projection.to_keys {
             if !source_keys.contains(target_key) {
@@ -200,9 +187,110 @@ fn validate_projection_source_domains(
                 });
             }
         }
+
+        if projection.to_keys.len() >= source_keys.len() {
+            return Err(SemanticError::MissingDeclaration {
+                kind: "projection dimensional reduction",
+                name: projection.name.clone(),
+                path: entrypoint.to_path_buf(),
+            });
+        }
     }
 
     Ok(())
+}
+
+fn validate_reduce_projection_expressions(
+    model: &ModelDecl,
+    program: &SourceProgram,
+    set_registry: &BTreeMap<String, crate::semantic::ResolvedSet>,
+    entrypoint: &Path,
+) -> Result<(), SemanticError> {
+    let projections = program
+        .projections
+        .iter()
+        .map(|projection| (projection.name.as_str(), projection))
+        .collect::<BTreeMap<_, _>>();
+
+    for expression in &model.expressions {
+        let Some(abstraction) = &expression.abstraction else {
+            continue;
+        };
+
+        let crate::source::ExpressionAbstractionDecl::ReduceProjection {
+            projection,
+            op,
+            target,
+        } = abstraction;
+
+        if op != "sum" {
+            return Err(SemanticError::MissingDeclaration {
+                kind: "reduce projection operation",
+                name: op.clone(),
+                path: entrypoint.to_path_buf(),
+            });
+        }
+
+        let projection_decl = projections.get(projection.as_str()).ok_or_else(|| {
+            SemanticError::MissingDeclaration {
+                kind: "projection",
+                name: projection.clone(),
+                path: entrypoint.to_path_buf(),
+            }
+        })?;
+
+        let source_keys = projection_source_keys(projection_decl, set_registry, entrypoint)?;
+
+        let target_family = model
+            .controls
+            .iter()
+            .find(|control| control.name == *target)
+            .ok_or_else(|| SemanticError::MissingDeclaration {
+                kind: "reduce projection target",
+                name: target.clone(),
+                path: entrypoint.to_path_buf(),
+            })?;
+
+        let target_indices = target_family
+            .indices
+            .iter()
+            .map(|index| index.name.as_str())
+            .collect::<Vec<_>>();
+
+        let source_signature = source_keys.iter().map(String::as_str).collect::<Vec<_>>();
+        if target_indices != source_signature {
+            return Err(SemanticError::MissingDeclaration {
+                kind: "reduce projection target signature",
+                name: target.clone(),
+                path: entrypoint.to_path_buf(),
+            });
+        }
+    }
+
+    Ok(())
+}
+
+fn projection_source_keys<'a>(
+    projection: &'a crate::source::ProjectionDecl,
+    set_registry: &'a BTreeMap<String, crate::semantic::ResolvedSet>,
+    entrypoint: &Path,
+) -> Result<&'a Vec<String>, SemanticError> {
+    let source_domain = set_registry.get(&projection.from_domain).ok_or_else(|| {
+        SemanticError::MissingDeclaration {
+            kind: "projection source domain",
+            name: projection.from_domain.clone(),
+            path: entrypoint.to_path_buf(),
+        }
+    })?;
+
+    source_domain
+        .tuple_components
+        .as_ref()
+        .ok_or_else(|| SemanticError::MissingDeclaration {
+            kind: "projection source tuple signature",
+            name: projection.from_domain.clone(),
+            path: entrypoint.to_path_buf(),
+        })
 }
 
 fn resolve_scenario<'a>(

--- a/crates/arco-kdl/src/source/ast.rs
+++ b/crates/arco-kdl/src/source/ast.rs
@@ -8,6 +8,7 @@ pub struct SourceProgram {
     pub data: Vec<DataDecl>,
     pub models: Vec<ModelDecl>,
     pub sets: Vec<SetDecl>,
+    pub projections: Vec<ProjectionDecl>,
     pub scenarios: Vec<ScenarioDecl>,
 }
 
@@ -41,6 +42,13 @@ pub struct MapDecl {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DataIndexDecl {
     pub columns: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProjectionDecl {
+    pub name: String,
+    pub from_domain: String,
+    pub to_keys: Vec<String>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]

--- a/crates/arco-kdl/src/source/ast.rs
+++ b/crates/arco-kdl/src/source/ast.rs
@@ -144,6 +144,16 @@ pub struct ExpressionDecl {
     pub name: String,
     pub formula: String,
     pub parsed_formula: Expr,
+    pub abstraction: Option<ExpressionAbstractionDecl>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ExpressionAbstractionDecl {
+    ReduceProjection {
+        projection: String,
+        op: String,
+        target: String,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/arco-kdl/src/source/parser.rs
+++ b/crates/arco-kdl/src/source/parser.rs
@@ -410,8 +410,10 @@ fn parse_expression(
 
 fn parse_reduce_projection_formula(formula: &str) -> Option<(String, String, String)> {
     let trimmed = formula.trim();
-    let reduce_pos = trimmed.find("reduce")?;
-    let after_reduce = trimmed[reduce_pos + "reduce".len()..].trim_start();
+    if !trimmed.starts_with("reduce") {
+        return None;
+    }
+    let after_reduce = trimmed["reduce".len()..].trim_start();
 
     let open_brace_rel = after_reduce.find('{')?;
     let head = after_reduce[..open_brace_rel].trim();

--- a/crates/arco-kdl/src/source/parser.rs
+++ b/crates/arco-kdl/src/source/parser.rs
@@ -143,20 +143,9 @@ fn parse_data(node: &KdlNode, context: &ParseContext<'_>) -> Result<DataDecl, So
             }),
             "set" => sets.push(parse_set(child, context)?),
             "index" => {
-                let mut columns = Vec::new();
-                let mut position = 0;
-                while let Some(value) = child.get(position) {
-                    let Some(name) = value.as_string() else {
-                        return Err(invalid_value_error(
-                            child,
-                            format!("argument {position}"),
-                            context,
-                        ));
-                    };
-                    columns.push(name.to_string());
-                    position += 1;
-                }
-                indices.push(DataIndexDecl { columns });
+                indices.push(DataIndexDecl {
+                    columns: collect_string_args(child, context)?,
+                });
             }
             "param" => parameters.push(parse_param(child, context)?),
             other => {
@@ -416,18 +405,7 @@ fn parse_projection(
                 from_domain = Some(first_arg_string(child, 0, context)?);
             }
             "to" => {
-                let mut position = 0;
-                while let Some(value) = child.get(position) {
-                    let Some(key) = value.as_string() else {
-                        return Err(invalid_value_error(
-                            child,
-                            format!("argument {position}"),
-                            context,
-                        ));
-                    };
-                    to_keys.push(key.to_string());
-                    position += 1;
-                }
+                to_keys = collect_string_args(child, context)?;
             }
             other => return Err(unsupported_declaration_error(child, other, context)),
         }
@@ -442,6 +420,28 @@ fn parse_projection(
         from_domain: from_domain.ok_or_else(|| missing_node_error("from", node, context))?,
         to_keys,
     })
+}
+
+fn collect_string_args(
+    node: &KdlNode,
+    context: &ParseContext<'_>,
+) -> Result<Vec<String>, SourceError> {
+    let mut values = Vec::new();
+    let mut position = 0;
+
+    while let Some(value) = node.get(position) {
+        let Some(value_text) = value.as_string() else {
+            return Err(invalid_value_error(
+                node,
+                format!("argument {position}"),
+                context,
+            ));
+        };
+        values.push(value_text.to_string());
+        position += 1;
+    }
+
+    Ok(values)
 }
 
 fn parse_scenario(node: &KdlNode, context: &ParseContext<'_>) -> Result<ScenarioDecl, SourceError> {

--- a/crates/arco-kdl/src/source/parser.rs
+++ b/crates/arco-kdl/src/source/parser.rs
@@ -2,7 +2,8 @@ use crate::ObjectiveSense;
 use crate::algebra::parse_value_formula;
 use crate::source::ast::{
     BoundExpr, DataBindingDecl, DataDecl, DataIndexDecl, ExpressionDecl, IndexDecl, ModelDecl,
-    ParsedSource, ReportDecl, ReportKind, ScenarioDecl, SetDecl, SourceProgram, VariableKindDecl,
+    ParsedSource, ProjectionDecl, ReportDecl, ReportKind, ScenarioDecl, SetDecl, SourceProgram,
+    VariableKindDecl,
 };
 use crate::source::error::SourceError;
 use crate::source::parser_constraints::parse_constraints;
@@ -60,6 +61,7 @@ fn parse_document(
             "data" => program.data.push(parse_data(node, context)?),
             "param" => program.params.push(parse_param(node, context)?),
             "model" => program.models.push(parse_model(node, context)?),
+            "projection" => program.projections.push(parse_projection(node, context)?),
             "scenario" => program.scenarios.push(parse_scenario(node, context)?),
             other => {
                 return Err(unsupported_declaration_error(node, other, context));
@@ -398,6 +400,47 @@ fn parse_expression(
         parsed_formula: parse_value_formula(&formula)
             .map_err(|error| algebra_error(node, error.to_string(), context))?,
         formula,
+    })
+}
+
+fn parse_projection(
+    node: &KdlNode,
+    context: &ParseContext<'_>,
+) -> Result<ProjectionDecl, SourceError> {
+    let mut from_domain = None;
+    let mut to_keys = Vec::new();
+
+    for child in node.iter_children() {
+        match child.name().value() {
+            "from" => {
+                from_domain = Some(first_arg_string(child, 0, context)?);
+            }
+            "to" => {
+                let mut position = 0;
+                while let Some(value) = child.get(position) {
+                    let Some(key) = value.as_string() else {
+                        return Err(invalid_value_error(
+                            child,
+                            format!("argument {position}"),
+                            context,
+                        ));
+                    };
+                    to_keys.push(key.to_string());
+                    position += 1;
+                }
+            }
+            other => return Err(unsupported_declaration_error(child, other, context)),
+        }
+    }
+
+    if to_keys.is_empty() {
+        return Err(missing_node_error("to", node, context));
+    }
+
+    Ok(ProjectionDecl {
+        name: first_arg_string(node, 0, context)?,
+        from_domain: from_domain.ok_or_else(|| missing_node_error("from", node, context))?,
+        to_keys,
     })
 }
 

--- a/crates/arco-kdl/src/source/parser.rs
+++ b/crates/arco-kdl/src/source/parser.rs
@@ -384,12 +384,55 @@ fn parse_expression(
     context: &ParseContext<'_>,
 ) -> Result<ExpressionDecl, SourceError> {
     let formula = algebra_text_from_node(node, context)?;
+
+    if let Some((projection, op, target)) = parse_reduce_projection_formula(&formula) {
+        let lowered = format!("__reduce_projection__(\"{projection}\", \"{op}\", \"{target}\")");
+        return Ok(ExpressionDecl {
+            name: first_arg_string(node, 0, context)?,
+            parsed_formula: crate::algebra::Expr::Identifier(lowered.clone()),
+            formula: lowered,
+            abstraction: Some(crate::source::ExpressionAbstractionDecl::ReduceProjection {
+                projection,
+                op,
+                target,
+            }),
+        });
+    }
+
     Ok(ExpressionDecl {
         name: first_arg_string(node, 0, context)?,
         parsed_formula: parse_value_formula(&formula)
             .map_err(|error| algebra_error(node, error.to_string(), context))?,
         formula,
+        abstraction: None,
     })
+}
+
+fn parse_reduce_projection_formula(formula: &str) -> Option<(String, String, String)> {
+    let trimmed = formula.trim();
+    let reduce_pos = trimmed.find("reduce")?;
+    let after_reduce = trimmed[reduce_pos + "reduce".len()..].trim_start();
+
+    let open_brace_rel = after_reduce.find('{')?;
+    let head = after_reduce[..open_brace_rel].trim();
+    let body_and_tail = &after_reduce[open_brace_rel + 1..];
+    let close_brace_rel = body_and_tail.find('}')?;
+    let body = body_and_tail[..close_brace_rel].trim();
+    let tail = body_and_tail[close_brace_rel + 1..].trim();
+    if !tail.is_empty() {
+        return None;
+    }
+
+    let projection = head.trim_matches('"').trim().to_string();
+    let mut body_parts = body.split_whitespace();
+    let op = body_parts.next()?.trim_matches('"').to_string();
+    let target = body_parts.next()?.trim_matches('"').to_string();
+
+    if projection.is_empty() || op.is_empty() || target.is_empty() || body_parts.next().is_some() {
+        return None;
+    }
+
+    Some((projection, op, target))
 }
 
 fn parse_projection(
@@ -402,10 +445,10 @@ fn parse_projection(
     for child in node.iter_children() {
         match child.name().value() {
             "from" => {
-                from_domain = Some(first_arg_string(child, 0, context)?);
+                from_domain = Some(parse_projection_from_domain(child, context)?);
             }
             "to" => {
-                to_keys = collect_string_args(child, context)?;
+                to_keys = parse_projection_to_keys(child, context)?;
             }
             other => return Err(unsupported_declaration_error(child, other, context)),
         }
@@ -420,6 +463,60 @@ fn parse_projection(
         from_domain: from_domain.ok_or_else(|| missing_node_error("from", node, context))?,
         to_keys,
     })
+}
+
+fn parse_projection_from_domain(
+    node: &KdlNode,
+    context: &ParseContext<'_>,
+) -> Result<String, SourceError> {
+    if let Some(value) = node.get(0) {
+        let Some(value_text) = value.as_string() else {
+            return Err(invalid_value_error(node, "argument 0".to_string(), context));
+        };
+        return Ok(value_text.to_string());
+    }
+
+    let mut nested = node.iter_children();
+    let Some(domain_node) = nested.next() else {
+        return Err(missing_node_error("from", node, context));
+    };
+
+    if nested.next().is_some()
+        || !domain_node.entries().is_empty()
+        || domain_node.children().is_some()
+    {
+        return Err(invalid_value_error(
+            node,
+            "from domain block must contain exactly one bare node".to_string(),
+            context,
+        ));
+    }
+
+    Ok(domain_node.name().value().to_string())
+}
+
+fn parse_projection_to_keys(
+    node: &KdlNode,
+    context: &ParseContext<'_>,
+) -> Result<Vec<String>, SourceError> {
+    let values = collect_string_args(node, context)?;
+    if !values.is_empty() {
+        return Ok(values);
+    }
+
+    let mut keys = Vec::new();
+    for key_node in node.iter_children() {
+        if !key_node.entries().is_empty() || key_node.children().is_some() {
+            return Err(invalid_value_error(
+                node,
+                "to key block must contain only bare key nodes".to_string(),
+                context,
+            ));
+        }
+        keys.push(key_node.name().value().to_string());
+    }
+
+    Ok(keys)
 }
 
 fn collect_string_args(

--- a/crates/arco-kdl/tests/compile_suite.rs
+++ b/crates/arco-kdl/tests/compile_suite.rs
@@ -955,7 +955,8 @@ scenario "S1" {
             assert!(
                 message.contains("empty constraint-relevant tuple subset for `capacity_target`")
             );
-            assert!(message.contains("1,solar; 2,solar; 2,wind"));
+            assert!(message.contains("1,solar"));
+            assert!(message.contains("2,wind"));
         }
         other => panic!("expected InvalidFormulation, got {other:?}"),
     }

--- a/crates/arco-kdl/tests/compile_suite.rs
+++ b/crates/arco-kdl/tests/compile_suite.rs
@@ -955,7 +955,7 @@ scenario "S1" {
             assert!(
                 message.contains("empty constraint-relevant tuple subset for `capacity_target`")
             );
-            assert!(message.contains("1,solar; 1,wind; 2,solar; 2,wind"));
+            assert!(message.contains("1,solar; 2,solar; 2,wind"));
         }
         other => panic!("expected InvalidFormulation, got {other:?}"),
     }
@@ -1016,19 +1016,19 @@ fn lowering_example_nodal_allocation_preserves_sparse_tuple_membership()
     let semantic = validate_program(&parsed.program, &path)?;
     let compiled = compile_program(&semantic, &parsed.program, &path)?;
 
-    let dispatch_instances = compiled
+    let investment_instances = compiled
         .algebra
         .variable_instances
         .iter()
         .map(|instance| instance.name.clone())
         .collect::<Vec<_>>();
     assert_eq!(
-        dispatch_instances,
+        investment_instances,
         vec![
-            "dispatch[north,wind,g1,b1]".to_string(),
-            "dispatch[north,wind,g2,b2]".to_string(),
-            "dispatch[south,gas,g4,b3]".to_string(),
-            "dispatch[south,solar,g3,b3]".to_string(),
+            "investment[north,wind,g1,b1]".to_string(),
+            "investment[north,wind,g2,b2]".to_string(),
+            "investment[south,gas,g4,b3]".to_string(),
+            "investment[south,solar,g3,b3]".to_string(),
         ]
     );
 

--- a/crates/arco-kdl/tests/semantic_validation.rs
+++ b/crates/arco-kdl/tests/semantic_validation.rs
@@ -1062,6 +1062,80 @@ scenario "S1" {
 }
 
 #[test]
+fn semantic_validation_rejects_projection_with_unknown_source_domain()
+-> Result<(), Box<dyn std::error::Error>> {
+    let root = temp_root("semantic-projection-unknown-source-domain")?;
+    let path = root.join("input.kdl");
+    let text = r#"
+projection "ai" {
+  from "missing_links"
+  to "a" "i"
+}
+
+model "Dispatch" {
+  minimize "Obj" { 0 }
+}
+
+scenario "S1" {
+  use "Dispatch"
+}
+"#;
+
+    let parsed = parse_program_text(text, &path)?;
+    let error = validate_program(&parsed.program, &path)
+        .expect_err("unknown projection source domain should fail semantic validation");
+
+    assert!(error.to_string().contains("missing_links"));
+    assert!(error.to_string().contains("projection source domain"));
+
+    fs::remove_dir_all(&root)?;
+    Ok(())
+}
+
+#[test]
+fn semantic_validation_rejects_projection_with_unknown_target_key()
+-> Result<(), Box<dyn std::error::Error>> {
+    let root = temp_root("semantic-projection-unknown-target-key")?;
+    let path = root.join("input.kdl");
+    let text = r#"
+set "area" { "a1" }
+set "tech" { "solar" }
+set "gen" { "g1" }
+set "bus" { "b1" }
+
+set "feasible_links" {
+  index "a" { in "area" }
+  index "i" { in "tech" }
+  index "g" { in "gen" }
+  index "b" { in "bus" }
+}
+
+projection "ai" {
+  from "feasible_links"
+  to "a" "z"
+}
+
+model "Dispatch" {
+  minimize "Obj" { 0 }
+}
+
+scenario "S1" {
+  use "Dispatch"
+}
+"#;
+
+    let parsed = parse_program_text(text, &path)?;
+    let error = validate_program(&parsed.program, &path)
+        .expect_err("unknown projection target key should fail semantic validation");
+
+    assert!(error.to_string().contains("projection target key"));
+    assert!(error.to_string().contains("z"));
+
+    fs::remove_dir_all(&root)?;
+    Ok(())
+}
+
+#[test]
 fn semantic_validation_assigns_stable_scoped_inferred_constraint_ids()
 -> Result<(), Box<dyn std::error::Error>> {
     let root = temp_root("semantic-inferred-constraint-id")?;

--- a/crates/arco-kdl/tests/semantic_validation.rs
+++ b/crates/arco-kdl/tests/semantic_validation.rs
@@ -1129,7 +1129,7 @@ scenario "S1" {
         .expect_err("unknown projection target key should fail semantic validation");
 
     assert!(error.to_string().contains("projection target key"));
-    assert!(error.to_string().contains("z"));
+    assert!(error.to_string().contains('z'));
 
     fs::remove_dir_all(&root)?;
     Ok(())

--- a/crates/arco-kdl/tests/semantic_validation.rs
+++ b/crates/arco-kdl/tests/semantic_validation.rs
@@ -1136,6 +1136,252 @@ scenario "S1" {
 }
 
 #[test]
+fn semantic_validation_rejects_projection_with_non_tuple_source_domain()
+-> Result<(), Box<dyn std::error::Error>> {
+    let root = temp_root("semantic-projection-non-tuple-source-domain")?;
+    let path = root.join("input.kdl");
+    let text = r#"
+set "area" { "a1" }
+
+projection "ai" {
+  from "area"
+  to "a"
+}
+
+model "Dispatch" {
+  minimize "Obj" { 0 }
+}
+
+scenario "S1" {
+  use "Dispatch"
+}
+"#;
+
+    let parsed = parse_program_text(text, &path)?;
+    let error = validate_program(&parsed.program, &path)
+        .expect_err("non-tuple projection source domain should fail semantic validation");
+
+    assert!(
+        error
+            .to_string()
+            .contains("projection source tuple signature")
+    );
+    assert!(error.to_string().contains("area"));
+
+    fs::remove_dir_all(&root)?;
+    Ok(())
+}
+
+#[test]
+fn semantic_validation_rejects_projection_without_dimensional_reduction()
+-> Result<(), Box<dyn std::error::Error>> {
+    let root = temp_root("semantic-projection-no-dim-reduction")?;
+    let path = root.join("input.kdl");
+    let text = r#"
+set "area" { "a1" }
+set "tech" { "solar" }
+
+set "feasible_ai" {
+  index "a" { in "area" }
+  index "i" { in "tech" }
+}
+
+projection "ai" {
+  from "feasible_ai"
+  to "a" "i"
+}
+
+model "Dispatch" {
+  minimize "Obj" { 0 }
+}
+
+scenario "S1" {
+  use "Dispatch"
+}
+"#;
+
+    let parsed = parse_program_text(text, &path)?;
+    let error = validate_program(&parsed.program, &path)
+        .expect_err("identity projection should fail semantic validation");
+
+    assert!(
+        error
+            .to_string()
+            .contains("projection dimensional reduction")
+    );
+    assert!(error.to_string().contains("ai"));
+
+    fs::remove_dir_all(&root)?;
+    Ok(())
+}
+
+#[test]
+fn semantic_validation_rejects_reduce_projection_with_incompatible_target_signature()
+-> Result<(), Box<dyn std::error::Error>> {
+    let root = temp_root("semantic-reduce-projection-signature-mismatch")?;
+    let path = root.join("input.kdl");
+    let text = r#"
+set "area" { "a1" }
+set "tech" { "solar" }
+set "gen" { "g1" }
+set "bus" { "b1" }
+
+set "feasible_links" {
+  index "a" { in "area" }
+  index "i" { in "tech" }
+  index "g" { in "gen" }
+  index "b" { in "bus" }
+}
+
+projection "ai" {
+  from "feasible_links"
+  to "a" "i"
+}
+
+model "Dispatch" {
+  control "investment" {
+    index "a"
+    index "i"
+  }
+
+  expression "investment_by_area_tech[a,i]" {
+    reduce "ai" {
+      sum "investment"
+    }
+  }
+
+  minimize "Obj" { 0 }
+}
+
+scenario "S1" {
+  use "Dispatch"
+}
+"#;
+
+    let parsed = parse_program_text(text, &path)?;
+    let error = validate_program(&parsed.program, &path)
+        .expect_err("reduce projection target signature mismatch should fail semantic validation");
+
+    assert!(
+        error
+            .to_string()
+            .contains("reduce projection target signature")
+    );
+    assert!(error.to_string().contains("investment"));
+
+    fs::remove_dir_all(&root)?;
+    Ok(())
+}
+
+#[test]
+fn semantic_validation_accepts_reduce_projection_with_matching_target_signature()
+-> Result<(), Box<dyn std::error::Error>> {
+    let root = temp_root("semantic-reduce-projection-signature-match")?;
+    let path = root.join("input.kdl");
+    let text = r#"
+set "area" { "a1" }
+set "tech" { "solar" }
+set "gen" { "g1" }
+set "bus" { "b1" }
+
+set "feasible_links" {
+  index "a" { in "area" }
+  index "i" { in "tech" }
+  index "g" { in "gen" }
+  index "b" { in "bus" }
+}
+
+projection "ai" {
+  from "feasible_links"
+  to "a" "i"
+}
+
+model "Dispatch" {
+  control "investment" {
+    index "a"
+    index "i"
+    index "g"
+    index "b"
+  }
+
+  expression "investment_by_area_tech[a,i]" {
+    reduce "ai" {
+      sum "investment"
+    }
+  }
+
+  minimize "Obj" { 0 }
+}
+
+scenario "S1" {
+  use "Dispatch"
+}
+"#;
+
+    let parsed = parse_program_text(text, &path)?;
+    let semantic = validate_program(&parsed.program, &path)?;
+    assert_eq!(semantic.active_scenario, "S1");
+
+    fs::remove_dir_all(&root)?;
+    Ok(())
+}
+
+#[test]
+fn semantic_validation_rejects_reduce_projection_non_sum_operator()
+-> Result<(), Box<dyn std::error::Error>> {
+    let root = temp_root("semantic-reduce-projection-non-sum")?;
+    let path = root.join("input.kdl");
+    let text = r#"
+set "area" { "a1" }
+set "tech" { "solar" }
+set "gen" { "g1" }
+set "bus" { "b1" }
+
+set "feasible_links" {
+  index "a" { in "area" }
+  index "i" { in "tech" }
+  index "g" { in "gen" }
+  index "b" { in "bus" }
+}
+
+projection "ai" {
+  from "feasible_links"
+  to "a" "i"
+}
+
+model "Dispatch" {
+  control "investment" {
+    index "a"
+    index "i"
+    index "g"
+    index "b"
+  }
+
+  expression "investment_by_area_tech[a,i]" {
+    reduce "ai" {
+      avg "investment"
+    }
+  }
+
+  minimize "Obj" { 0 }
+}
+
+scenario "S1" {
+  use "Dispatch"
+}
+"#;
+
+    let parsed = parse_program_text(text, &path)?;
+    let error = validate_program(&parsed.program, &path)
+        .expect_err("non-sum reduce projection operator should fail semantic validation");
+    assert!(error.to_string().contains("reduce projection operation"));
+    assert!(error.to_string().contains("avg"));
+
+    fs::remove_dir_all(&root)?;
+    Ok(())
+}
+
+#[test]
 fn semantic_validation_assigns_stable_scoped_inferred_constraint_ids()
 -> Result<(), Box<dyn std::error::Error>> {
     let root = temp_root("semantic-inferred-constraint-id")?;

--- a/crates/arco-kdl/tests/source_parser.rs
+++ b/crates/arco-kdl/tests/source_parser.rs
@@ -217,6 +217,27 @@ scenario Base {
 }
 
 #[test]
+fn parses_top_level_projection_declaration() -> Result<(), Box<dyn std::error::Error>> {
+    let path = PathBuf::from("test.kdl");
+    let text = r#"
+projection "ai" {
+  from "feasible_links"
+  to "a" "i"
+}
+"#;
+
+    let parsed = parse_program_text(text, &path)?;
+    assert_eq!(parsed.program.projections.len(), 1);
+
+    let projection = &parsed.program.projections[0];
+    assert_eq!(projection.name, "ai");
+    assert_eq!(projection.from_domain, "feasible_links");
+    assert_eq!(projection.to_keys, vec!["a", "i"]);
+
+    Ok(())
+}
+
+#[test]
 fn rejects_unsupported_top_level_declarations() {
     let path = PathBuf::from("test.kdl");
     let cases = [

--- a/crates/arco-kdl/tests/source_parser.rs
+++ b/crates/arco-kdl/tests/source_parser.rs
@@ -238,6 +238,89 @@ projection "ai" {
 }
 
 #[test]
+fn parses_top_level_projection_declaration_with_domain_and_key_blocks()
+-> Result<(), Box<dyn std::error::Error>> {
+    let path = PathBuf::from("test.kdl");
+    let text = r#"
+projection "ai" {
+  from { "feasible_links" }
+  to { "a"; "i" }
+}
+"#;
+
+    let parsed = parse_program_text(text, &path)?;
+    assert_eq!(parsed.program.projections.len(), 1);
+
+    let projection = &parsed.program.projections[0];
+    assert_eq!(projection.name, "ai");
+    assert_eq!(projection.from_domain, "feasible_links");
+    assert_eq!(projection.to_keys, vec!["a", "i"]);
+
+    Ok(())
+}
+
+#[test]
+fn parses_expression_reduce_projection_block_form() -> Result<(), Box<dyn std::error::Error>> {
+    let path = PathBuf::from("test.kdl");
+    let text = r#"
+projection "ai" {
+  from "feasible_links"
+  to "a" "i"
+}
+
+model "Dispatch" {
+  expression "investment_by_area_tech[a,i]" {
+    reduce "ai" {
+      sum "investment"
+    }
+  }
+
+  minimize "Obj" { 0 }
+}
+
+scenario "S1" {
+  use "Dispatch"
+}
+"#;
+
+    let parsed = parse_program_text(text, &path)?;
+    let model = parsed.program.model("Dispatch").ok_or("missing model")?;
+    let expression = model.expressions.first().ok_or("missing expression")?;
+
+    assert!(expression.abstraction.is_some());
+    assert!(expression.formula.contains("__reduce_projection__"));
+
+    Ok(())
+}
+
+#[test]
+fn rejects_expression_reduce_with_mixed_sibling_math() {
+    let path = PathBuf::from("test.kdl");
+    let text = r#"
+projection "ai" {
+  from "feasible_links"
+  to "a" "i"
+}
+
+model "Dispatch" {
+  expression "investment_by_area_tech[a,i]" {
+    reduce "ai" { sum "investment" } + 1
+  }
+
+  minimize "Obj" { 0 }
+}
+
+scenario "S1" {
+  use "Dispatch"
+}
+"#;
+
+    let error = parse_program_text(text, &path)
+        .expect_err("mixed reduce and sibling math should fail parse");
+    assert!(error.to_string().contains("expression"));
+}
+
+#[test]
 fn rejects_unsupported_top_level_declarations() {
     let path = PathBuf::from("test.kdl");
     let cases = [

--- a/crates/arco-kdl/tests/source_parser.rs
+++ b/crates/arco-kdl/tests/source_parser.rs
@@ -321,6 +321,33 @@ scenario "S1" {
 }
 
 #[test]
+fn rejects_expression_with_prefixed_math_before_reduce() {
+    let path = PathBuf::from("test.kdl");
+    let text = r#"
+projection "ai" {
+  from "feasible_links"
+  to "a" "i"
+}
+
+model "Dispatch" {
+  expression "investment_by_area_tech[a,i]" {
+    1 + reduce "ai" { sum "investment" }
+  }
+
+  minimize "Obj" { 0 }
+}
+
+scenario "S1" {
+  use "Dispatch"
+}
+"#;
+
+    let error =
+        parse_program_text(text, &path).expect_err("prefixed math before reduce should fail parse");
+    assert!(error.to_string().contains("expression"));
+}
+
+#[test]
 fn rejects_unsupported_top_level_declarations() {
     let path = PathBuf::from("test.kdl");
     let cases = [

--- a/docs/arco-spec.md
+++ b/docs/arco-spec.md
@@ -1175,8 +1175,8 @@ expression "investment_by_area_tech" {
 }
 ```
 
-This form aggregates a higher-dimensional control/expression onto a named
-projection domain.
+This form aggregates a higher-dimensional control onto a named projection
+domain.
 
 Rules:
 

--- a/docs/arco-spec.md
+++ b/docs/arco-spec.md
@@ -17,6 +17,7 @@ This document defines the low-level Arco DSL profile authored in KDL 2.0.
 Scope of this specification:
 
 - [`set`](#4-set-declaration-top-level) declarations (explicit domains)
+- [`projection`](#45-projection-declaration-top-level) declarations (named tuple-domain projections)
 - [`data`](#5-data-declaration) declarations (CSV-backed namespaces)
 - [`param`](#31-inline-scalar-parameters) declarations (inline scalar constants)
 - [`param`](#54-param-inside-data) declarations (CSV-backed projection,
@@ -40,6 +41,7 @@ Scope of this specification:
 - [3. Top-level declarations](#3-top-level-declarations)
   - [3.1 Inline scalar parameters](#31-inline-scalar-parameters)
 - [4. `set` declaration (top-level)](#4-set-declaration-top-level)
+- [4.5 `projection` declaration (top-level)](#45-projection-declaration-top-level)
 - [5. `data` declaration](#5-data-declaration)
   - [5.1 `map`](#51-map)
   - [5.2 `set` (inside `data`)](#52-set-inside-data)
@@ -98,7 +100,7 @@ supported. Slashdash (`/-`) comments out an entire node, property, or argument,
 which is useful for toggling declarations during development.
 
 Unknown nodes: Implementations MUST reject unknown top-level node types
-(anything other than `set`, `data`, `param`, `model`, `scenario`). Inside
+(anything other than `set`, `projection`, `data`, `param`, `model`, `scenario`). Inside
 blocks, unknown child node types MUST also fail validation. This ensures forward
 compatibility is explicit: new node types require a spec version bump.
 
@@ -343,9 +345,8 @@ indexed or scalar via a single-row CSV). Inline scalars MUST NOT have `index`,
 
 ## 4. `set` declaration (top-level)
 
-A top-level `set` declares a named domain with explicit members listed inline.
-This is useful for sets that are not backed by a CSV file, for example index
-ranges, scenario labels, or piecewise segments.
+A top-level `set` declares a named domain. It supports either explicit inline
+members or subset/tuple-set forms built from existing sets.
 
 Explicit member list:
 
@@ -369,6 +370,22 @@ Alias:
 set time alias=t { 1; 2; 3; 4; 5; 6; 7; 8; 9; 10; 11; 12; 13; 14; 15; 16; 17; 18; 19; 20; 21; 22; 23; 24 }
 ```
 
+Subset/tuple-set form:
+
+```kdl
+set "priority_links" {
+  in "feasible_links"
+  index "a" { in "area" }
+  index "i" { in "tech" }
+  index "g" { in "generators" }
+  index "b" { in "buses" }
+  filter { area == "south" }
+}
+```
+
+In this form, `in` identifies the parent tuple set, `index` declares the tuple
+signature, and `filter` (optional) narrows rows.
+
 Top-level sets are globally visible, just like sets declared inside `data`
 blocks. They can be used in any model, constraint, or algebra expression.
 
@@ -376,6 +393,26 @@ Top-level sets and data-level sets share a single namespace. A top-level `set`
 MUST NOT have the same name as a set declared inside a `data` block.
 
 ---
+
+## 4.5 `projection` declaration (top-level)
+
+`projection` declares a named lower-dimensional tuple domain derived from a
+parent tuple set.
+
+```kdl
+projection "ai" {
+  from "feasible_links"
+  to "a" "i"
+}
+```
+
+Semantics:
+
+- `from` MUST reference an existing tuple-domain set.
+- `to` MUST list one or more tuple component names present on the parent tuple
+  signature, in parent declaration order.
+- Projected rows are deduplicated by value.
+- Projection names MUST be unique in the top-level namespace.
 
 ## 5. `data` declaration
 
@@ -417,6 +454,7 @@ Allowed children:
 ```
 map <logical_name>
 map <logical_name> from=<source_header>
+alias <logical_name> column=<source_header>
 ```
 
 Semantics:
@@ -425,6 +463,8 @@ Semantics:
   MUST exist in the CSV.
 - Mapping is optional. Unmapped columns remain available.
 - Duplicate logical targets MUST fail validation.
+- `alias <logical_name> column=<source_header>` is accepted as an equivalent
+  spelling of `map <logical_name> from=<source_header>`.
 
 ### 5.2 `set` (inside `data`)
 
@@ -438,6 +478,7 @@ constraint, or algebra expression in the document.
 ```
 set <name>
 set <name> alias=<short>
+set <name> as=<short>
 set <name> {
   in <parent_set>
 }
@@ -450,8 +491,8 @@ set <name> {
 Semantics:
 
 - `set class` extracts unique values from the `class` column.
-- `alias` provides a short set reference that MAY be used wherever a set
-  reference is expected (`index=` property, `index` children,
+- `alias` (or equivalent `as`) provides a short set reference that MAY be used
+  wherever a set reference is expected (`index=` property, `index` children,
   `index ... { in ... }`, and algebra iteration domains). Example:
   `set asset_id alias=a` allows `param capacity { index a }`,
   `index a_idx { in a }`, and `dispatch[a,t]`.
@@ -1123,6 +1164,27 @@ references but are not bound by a `for` clause in a reduction) are resolved at
 the point of use. When an expression is referenced inside a constraint with
 `index` clauses, the constraint's iteration variables are in scope for the
 expression body.
+
+Projection-reduce expression form:
+
+```kdl
+expression "investment_by_area_tech" {
+  reduce "ai" {
+    sum "investment"
+  }
+}
+```
+
+This form aggregates a higher-dimensional control/expression onto a named
+projection domain.
+
+Rules:
+
+- the projection name (`"ai"` above) MUST resolve to a declared `projection`.
+- the body MUST contain exactly one reduction operation.
+- currently supported operation is `sum`.
+- the reduction target (`"investment"` above) MUST have a tuple signature
+  compatible with the projection source and target dimensions.
 
 ### 6.5 `constraint`
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -111,7 +111,7 @@ For full language-level guidance on subset/filter patterns, see:
 
 ### Why this matters in V1
 
-- `dispatch[a,i,g,b]` is instantiated only for members of the tuple subset you
+- `investment[a,i,g,b]` is instantiated only for members of the tuple subset you
   bind to (for example, `feasible_links`). There is no Cartesian fallback.
 - Reduced scopes must be named explicitly (for example, `priority_links`). V1
   does not auto-project high-dimensional tuple domains.
@@ -120,7 +120,7 @@ For full language-level guidance on subset/filter patterns, see:
 
   ```text
   index order mismatch for `NodalAllocationDay.NodalAllocation.constraint_1` over tuple domain `feasible_links`
-  empty constraint-relevant tuple subset for `NodalAllocationDay.NodalAllocation.capacity_target` at keys: north,solar; north,wind; south,gas; south,solar
+  empty constraint-relevant tuple subset for `NodalAllocationDay.NodalAllocation.enforce_mw_target` at keys: north,solar; north,wind; south,gas; south,solar
   ```
 
 ## Current caveats

--- a/examples/nodal-allocation/data/links.csv
+++ b/examples/nodal-allocation/data/links.csv
@@ -1,6 +1,6 @@
-area,tech,gen,bus,feasible,capacity_mw,priority_floor_mw
-north,wind,g1,b1,1,10,4
-north,wind,g2,b2,1,8,0
-south,solar,g3,b3,1,6,2
-south,gas,g4,b3,1,12,0
-north,solar,g5,b4,0,9,0
+area,tech,gen,bus,feasible,capacity_mw,priority_floor_mw,mw_target
+north,wind,g1,b1,1,10,4,12
+north,wind,g2,b2,1,8,0,12
+south,solar,g3,b3,1,6,2,5
+south,gas,g4,b3,1,12,0,4
+north,solar,g5,b4,0,9,0,0

--- a/examples/nodal-allocation/input.kdl
+++ b/examples/nodal-allocation/input.kdl
@@ -28,6 +28,12 @@ data "links" source="data/links.csv" {
     index "g"
     index "b"
   }
+
+  param "mw_target" {
+    index "a"
+    index "i"
+    reduce "max"
+  }
 }
 
 set "priority_links" {
@@ -37,6 +43,17 @@ set "priority_links" {
   index "g" { in "generators" }
   index "b" { in "buses" }
   filter { area == "south" }
+}
+
+set "feasible_ai" {
+  in "feasible_links"
+  index "a" { in "area" }
+  index "i" { in "tech" }
+}
+
+projection "ai" {
+  from "feasible_links"
+  to "a" "i"
 }
 
 model "NodalAllocation" {
@@ -54,20 +71,31 @@ model "NodalAllocation" {
     index "b"
   }
 
-  control "dispatch" lower=0 {
+  param "mw_target" {
+    index "a"
+    index "i"
+  }
+
+  control "investment" lower=0 {
     index "a" { in "feasible_links" }
     index "i" { in "feasible_links" }
     index "g" { in "feasible_links" }
     index "b" { in "feasible_links" }
   }
 
-  constraint "dispatch_capacity" {
+  expression "investment_by_area_tech" {
+    reduce "ai" {
+      sum "investment"
+    }
+  }
+
+  constraint "investment_capacity" {
     index "a" { in "feasible_links" }
     index "i" { in "feasible_links" }
     index "g" { in "feasible_links" }
     index "b" { in "feasible_links" }
     expression {
-      dispatch[a,i,g,b] <= capacity_mw[a,i,g,b]
+      investment[a,i,g,b] <= capacity_mw[a,i,g,b]
     }
   }
 
@@ -77,7 +105,15 @@ model "NodalAllocation" {
     index "g" { in "priority_links" }
     index "b" { in "priority_links" }
     expression {
-      dispatch[a,i,g,b] >= priority_floor_mw[a,i,g,b]
+      investment[a,i,g,b] >= priority_floor_mw[a,i,g,b]
+    }
+  }
+
+  constraint "enforce_mw_target" {
+    index "a" { in "feasible_ai" }
+    index "i" { in "feasible_ai" }
+    expression {
+      investment_by_area_tech[a,i] >= mw_target[a,i]
     }
   }
 

--- a/examples/nodal-allocation/input.kdl
+++ b/examples/nodal-allocation/input.kdl
@@ -51,7 +51,7 @@ set "feasible_ai" {
   index "i" { in "tech" }
 }
 
-projection "ai" {
+projection name="ai" {
   from "feasible_links"
   to "a" "i"
 }


### PR DESCRIPTION
## Summary
This PR adds and hardens projection-based reduce support for nodal allocation, and aligns compiler behavior, tests, and docs.

## What is new
- Added top-level `projection` parsing/AST support and semantic validation.
- Added reduce-projection expression lowering (e.g. `reduce "ai" { sum "investment" }`).
- Extended tuple-domain reduction handling so projected reductions bind correctly to tuple rows.
- Updated nodal-allocation example and related CLI/KDL test expectations.
- Tightened parser behavior for reduce-projection detection (anchored parse).
- Updated `docs/arco-spec.md` and `examples/README.md` to match implemented behavior.

### New KDL example (expression used in a constraint)
```kdl
data "links" source="data/links.csv" {
  set "area" as="a"
  set "tech" as="i"
  alias "generators" column="gen"
  alias "buses" column="bus"

  set "generators" as="g"
  set "buses" as="b"

  set "feasible_links" {
    index "a" { in "area" }
    index "i" { in "tech" }
    index "g" { in "generators" }
    index "b" { in "buses" }
    filter { feasible > 0 }
  }

  param "mw_target" {
    index "a"
    index "i"
    reduce "max"
  }
}

set "feasible_ai" {
  in "feasible_links"
  index "a" { in "area" }
  index "i" { in "tech" }
}

projection "ai" {
  from "feasible_links"
  to "a" "i"
}

model "NodalAllocation" {
  param "mw_target" {
    index "a"
    index "i"
  }

  control "investment" lower=0 {
    index "a" { in "feasible_links" }
    index "i" { in "feasible_links" }
    index "g" { in "feasible_links" }
    index "b" { in "feasible_links" }
  }

  expression "investment_by_area_tech" {
    reduce "ai" {
      sum "investment"
    }
  }

  constraint "enforce_mw_target" {
    index "a" { in "feasible_ai" }
    index "i" { in "feasible_ai" }
    expression {
      investment_by_area_tech[a,i] >= mw_target[a,i]
    }
  }

  minimize "obj" { 0 }
}

scenario "S1" {
  use "NodalAllocation"
}
```

## Test strategy
- `just ci` ✅