### PR TITLE
feat(kdl): enable always-on set unpacking

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,60 @@
+# Arco DSL Authoring
+
+This context defines canonical terms for Arco KDL syntax around tuple-domain indexing and constraint generation.
+
+## Language
+
+**Tuple-domain set**:
+A set declared with multiple `index` children representing valid tuples, not Cartesian products.
+_Avoid_: relation set, table set
+
+**Set unpacking index**:
+`index <set_name>` binds canonical component variables from the referenced set into expression scope. For tuple-domain sets, all tuple components are exposed; for non-tuple sets, one component is exposed.
+_Avoid_: treating tuple and non-tuple shorthand as unrelated semantics
+
+**Index binding alias**:
+`index <var> { in <set> }` introduces `<var>` as a local alias for iterating `<set>` within the current declaration scope.
+_Avoid_: reading `<var>` as a new set name
+
+**Canonical component names**:
+When tuple unpacking is used, exposed variables must match the tuple-domain set component names exactly (for example `a,i,g,b`) and cannot be locally renamed at constraint site.
+_Avoid_: local axis renaming, ad-hoc aliases inside constraint
+
+**Tuple-key indexing**:
+For tuple-domain indexed symbols, both expanded indexing (`investment[a,i,g,b]`) and tuple-key indexing (`investment[feasible_links]`) are valid, with tuple-key indexing as the preferred entrypoint. In v1, tuple-key tokens are set-name based (not alias based).
+_Avoid_: forcing only expanded arity access
+
+**Access preference rule**:
+When `index <var> { in <set> }` is used, prefer `<var>` in indexed expressions for non-tuple sets. When shorthand `index <set>` is used, prefer `<set>`.
+_Avoid_: mixing alias and set-name access styles within the same declaration without reason
+
+**Subset-compatible tuple key**:
+A symbol indexed by a parent tuple-domain set may be accessed with a child tuple-domain subset key when the subset is declared `in <parent>` and has the same component signature/order.
+_Avoid_: requiring parent-key-only access for subset-filtered constraints
+
+## Relationships
+
+- A **Set unpacking index** references one declared set.
+- A **Set unpacking index** exposes canonical component variables for that set in expression scope.
+- An **Index binding alias** maps local variable names to declared set domains at declaration scope.
+- **Canonical component names** are sourced from the referenced **Tuple-domain set** declaration.
+- **Tuple-key indexing** and expanded indexing are equivalent access forms over the same tuple-domain row.
+- A **Subset-compatible tuple key** is valid only when subset-parent tuple signatures are structurally compatible.
+
+## Example dialogue
+
+> **Dev:** "If I write `index priority_links`, can I use `a,i,g,b` directly?"
+> **Domain expert:** "Yes — for tuple-domain sets, unpacking exposes each component variable in scope."
+
+## Flagged ambiguities
+
+- `index priority_links` previously read as one scalar index variable. Resolved: `index <set_name>` uses unpacking semantics.
+- Non-tuple disambiguation resolved: unpacking also applies to non-tuple sets (single canonical component).
+- Alias semantics resolved: `index t { in time }` means local alias `t` for set `time`.
+- Tuple unpacking scope resolved: `index <tuple_set>` unpacking applies in generated constraints, `control`, and `param` declarations.
+- Access form resolved: tuple-domain indexed symbols accept both `symbol[tuple_set]` and `symbol[a,i,g,b]`, with tuple-key form preferred.
+- Non-tuple style resolved: `index <var> { in <set> }` prefers `<var>`; shorthand `index <set>` prefers `<set>`.
+- Tuple alias decision: v1 tuple-key form uses set name only (`symbol[feasible_links]`), not binding alias (`symbol[link]`).
+- Subset access resolved: symbols indexed by parent tuple-domain sets accept child subset tuple keys (Option A).
+- Rollout strategy resolved: unpacking semantics are always-on (no compatibility gate); rationale captured in `docs/adr/0001-set-unpacking-always-on.md`.
+- Migration diagnostics resolved: do not emit special legacy scalar-intent warnings for tuple-set shorthand.

--- a/crates/arco-kdl/src/compile/algebra.rs
+++ b/crates/arco-kdl/src/compile/algebra.rs
@@ -324,7 +324,7 @@ fn resolve_tuple_domain_rows<'a>(
     family: &str,
     entrypoint: &Path,
 ) -> Result<Option<&'a [Vec<String>]>, CompileError> {
-    if signature.indices.len() < 2 {
+    if signature.indices.is_empty() {
         return Ok(None);
     }
 
@@ -360,7 +360,12 @@ fn resolve_tuple_domain_rows<'a>(
         return Ok(None);
     };
 
-    if tuple_components != &signature.indices {
+    let uses_tuple_shorthand = signature.indices.len() == 1
+        && signature
+            .index_domains
+            .get(first_index)
+            .is_none_or(|domain| domain == first_index);
+    if !uses_tuple_shorthand && tuple_components != &signature.indices {
         return Err(CompileError::InvalidFormulation {
             message: tuple_domain_index_order_mismatch_message(
                 family,

--- a/crates/arco-kdl/src/compile/data.rs
+++ b/crates/arco-kdl/src/compile/data.rs
@@ -362,8 +362,14 @@ fn resolve_param_key_columns(
     parameter: &ParamDecl,
 ) -> Vec<String> {
     if !parameter.indices.is_empty() {
-        return parameter
-            .indices
+        let indices = if parameter.indices.len() == 1 {
+            expand_tuple_param_index_shorthand(source_program, data_decl, &parameter.indices[0])
+                .unwrap_or_else(|| parameter.indices.clone())
+        } else {
+            parameter.indices.clone()
+        };
+
+        return indices
             .iter()
             .map(|index| canonical_data_set_name(source_program, data_decl, index))
             .map(|index| resolve_data_column(data_decl, index.as_str()))
@@ -385,6 +391,37 @@ fn resolve_param_key_columns(
     }
 
     Vec::new()
+}
+
+fn expand_tuple_param_index_shorthand(
+    source_program: &SourceProgram,
+    data_decl: &DataDecl,
+    symbol: &str,
+) -> Option<Vec<String>> {
+    let canonical = canonical_data_set_name(source_program, data_decl, symbol);
+
+    data_decl
+        .sets
+        .iter()
+        .chain(source_program.sets.iter())
+        .find(|set| set.name == canonical)
+        .and_then(|set| {
+            if set.tuple_indices.is_empty() {
+                None
+            } else {
+                Some(
+                    set.tuple_indices
+                        .iter()
+                        .map(|index| {
+                            index
+                                .domain
+                                .clone()
+                                .unwrap_or_else(|| index.name.clone())
+                        })
+                        .collect::<Vec<_>>(),
+                )
+            }
+        })
 }
 
 fn canonical_data_set_name(

--- a/crates/arco-kdl/src/compile/data.rs
+++ b/crates/arco-kdl/src/compile/data.rs
@@ -405,22 +405,17 @@ fn expand_tuple_param_index_shorthand(
         .iter()
         .chain(source_program.sets.iter())
         .find(|set| set.name == canonical)
-        .and_then(|set| {
-            if set.tuple_indices.is_empty() {
-                None
-            } else {
-                Some(
-                    set.tuple_indices
-                        .iter()
-                        .map(|index| {
-                            index
-                                .domain
-                                .clone()
-                                .unwrap_or_else(|| index.name.clone())
-                        })
-                        .collect::<Vec<_>>(),
-                )
-            }
+        .and_then(|set| (!set.tuple_indices.is_empty()).then_some(&set.tuple_indices))
+        .map(|tuple_indices| {
+            tuple_indices
+                .iter()
+                .map(|index| {
+                    index
+                        .domain
+                        .clone()
+                        .unwrap_or_else(|| index.name.clone())
+                })
+                .collect::<Vec<_>>()
         })
 }
 

--- a/crates/arco-kdl/src/compile/expressions_domains.rs
+++ b/crates/arco-kdl/src/compile/expressions_domains.rs
@@ -370,20 +370,9 @@ fn linearize_indexed_expr(
     instantiated_names: &BTreeSet<String>,
     entrypoint: &Path,
 ) -> Result<AffineExpr, CompileError> {
-    let resolved = if indices.len() == 1 {
-        if let Some(tuple_key_values) = resolve_tuple_key_index(indices, bindings, program) {
-            tuple_key_values
-        } else {
-            indices
-                .iter()
-                .map(|index| resolve_index_expr(index, bindings, named_expressions, entrypoint))
-                .collect::<Result<Vec<_>, _>>()?
-        }
-    } else {
-        indices
-            .iter()
-            .map(|index| resolve_index_expr(index, bindings, named_expressions, entrypoint))
-            .collect::<Result<Vec<_>, _>>()?
+    let resolved = match (indices.len(), resolve_tuple_key_index(indices, bindings, program)) {
+        (1, Some(tuple_key_values)) => tuple_key_values,
+        _ => resolve_index_values(indices, bindings, named_expressions, entrypoint)?,
     };
 
     // Compute the candidate instance name using the same conventions as
@@ -447,6 +436,18 @@ fn linearize_indexed_expr(
     }
 
     parameter_reference_expr(target, &resolved, inputs, entrypoint)
+}
+
+fn resolve_index_values(
+    indices: &[Expr],
+    bindings: &LinearizationBindings,
+    named_expressions: &BTreeMap<String, Expr>,
+    entrypoint: &Path,
+) -> Result<Vec<FilterValue>, CompileError> {
+    indices
+        .iter()
+        .map(|index| resolve_index_expr(index, bindings, named_expressions, entrypoint))
+        .collect::<Result<Vec<_>, _>>()
 }
 
 fn resolve_tuple_key_index(

--- a/crates/arco-kdl/src/compile/expressions_domains.rs
+++ b/crates/arco-kdl/src/compile/expressions_domains.rs
@@ -65,7 +65,11 @@ fn expand_tuple_generation_bindings(
         .iter()
         .map(|binding| binding.variable.clone())
         .collect::<Vec<_>>();
-    if tuple_components != &received_components {
+    let uses_tuple_shorthand = bindings.len() == 1 && {
+        let binding = &bindings[0];
+        binding.variable == binding.domain
+    };
+    if !uses_tuple_shorthand && tuple_components != &received_components {
         return Err(CompileError::InvalidFormulation {
             message: tuple_domain_index_order_mismatch_message(
                 binding_context,
@@ -79,11 +83,11 @@ fn expand_tuple_generation_bindings(
 
     let mut scopes = Vec::with_capacity(tuple_rows.len());
     for row in tuple_rows {
-        if row.len() != bindings.len() {
+        if row.len() != tuple_components.len() {
             return Err(CompileError::InvalidFormulation {
                 message: format!(
                     "tuple row arity mismatch for `{binding_context}`: expected `{}`, received `{}`",
-                    bindings.len(),
+                    tuple_components.len(),
                     row.len()
                 ),
                 path: entrypoint.to_path_buf(),
@@ -91,10 +95,18 @@ fn expand_tuple_generation_bindings(
         }
 
         let mut scope = LinearizationBindings::default();
-        for (binding, value) in bindings.iter().zip(row.iter()) {
-            scope
-                .values
-                .insert(binding.variable.clone(), FilterValue::String(value.clone()));
+        if uses_tuple_shorthand {
+            for (component, value) in tuple_components.iter().zip(row.iter()) {
+                scope
+                    .values
+                    .insert(component.clone(), FilterValue::String(value.clone()));
+            }
+        } else {
+            for (binding, value) in bindings.iter().zip(row.iter()) {
+                scope
+                    .values
+                    .insert(binding.variable.clone(), FilterValue::String(value.clone()));
+            }
         }
         scopes.push(scope);
     }
@@ -358,10 +370,21 @@ fn linearize_indexed_expr(
     instantiated_names: &BTreeSet<String>,
     entrypoint: &Path,
 ) -> Result<AffineExpr, CompileError> {
-    let resolved = indices
-        .iter()
-        .map(|index| resolve_index_expr(index, bindings, named_expressions, entrypoint))
-        .collect::<Result<Vec<_>, _>>()?;
+    let resolved = if indices.len() == 1 {
+        if let Some(tuple_key_values) = resolve_tuple_key_index(indices, bindings, program) {
+            tuple_key_values
+        } else {
+            indices
+                .iter()
+                .map(|index| resolve_index_expr(index, bindings, named_expressions, entrypoint))
+                .collect::<Result<Vec<_>, _>>()?
+        }
+    } else {
+        indices
+            .iter()
+            .map(|index| resolve_index_expr(index, bindings, named_expressions, entrypoint))
+            .collect::<Result<Vec<_>, _>>()?
+    };
 
     // Compute the candidate instance name using the same conventions as
     // instantiate_variable_instances / resolve_custom_index_domains.
@@ -424,4 +447,28 @@ fn linearize_indexed_expr(
     }
 
     parameter_reference_expr(target, &resolved, inputs, entrypoint)
+}
+
+fn resolve_tuple_key_index(
+    indices: &[Expr],
+    bindings: &LinearizationBindings,
+    program: &SemanticProgram,
+) -> Option<Vec<FilterValue>> {
+    let index = indices.first()?;
+    let Expr::Identifier(tuple_domain) = index else {
+        return None;
+    };
+
+    let reverse_aliases = build_reverse_alias_lookup(program);
+    let key = resolve_set_registry_key(tuple_domain, program, &reverse_aliases)?;
+    let set = resolve_set_struct_by_name(key, program, &reverse_aliases)?;
+    let tuple_components = set.tuple_components.as_ref()?;
+
+    let mut resolved = Vec::with_capacity(tuple_components.len());
+    for component in tuple_components {
+        let value = bindings.values.get(component)?;
+        resolved.push(value.clone());
+    }
+
+    Some(resolved)
 }

--- a/crates/arco-kdl/src/semantic/validation.rs
+++ b/crates/arco-kdl/src/semantic/validation.rs
@@ -523,9 +523,10 @@ fn expand_parameter_indices_with_tuple_shorthand(
         return indices.to_vec();
     }
 
-    tuple_components_for_symbol(&indices[0], set_registry, set_aliases)
-        .map(|(_, tuple_components)| tuple_components.to_vec())
-        .unwrap_or_else(|| indices.to_vec())
+    tuple_components_for_symbol(&indices[0], set_registry, set_aliases).map_or_else(
+        || indices.to_vec(),
+        |(_, tuple_components)| tuple_components.to_vec(),
+    )
 }
 
 fn expand_index_decls_with_tuple_shorthand(

--- a/crates/arco-kdl/src/semantic/validation.rs
+++ b/crates/arco-kdl/src/semantic/validation.rs
@@ -60,15 +60,6 @@ pub fn validate_program(
     let mut series_parameters = BTreeSet::new();
     let mut indexed_parameters = BTreeSet::new();
     let mut asset_parameters = BTreeSet::new();
-    for parameter in &model.parameters {
-        classify_parameter_indices(
-            &parameter.name,
-            &parameter.indices,
-            &mut series_parameters,
-            &mut indexed_parameters,
-            &mut asset_parameters,
-        );
-    }
 
     let active_constraints = model
         .constraints
@@ -130,8 +121,31 @@ pub fn validate_program(
         extend_set_registry_from_low_level_declarations(program, entry_dir, &mut set_registry)?;
     }
 
+    let set_aliases = collect_set_aliases(program, Some(model));
+
+    for parameter in &model.parameters {
+        let normalized_indices = expand_parameter_indices_with_tuple_shorthand(
+            &parameter.indices,
+            &set_registry,
+            &set_aliases,
+        );
+        classify_parameter_indices(
+            &parameter.name,
+            &normalized_indices,
+            &mut series_parameters,
+            &mut indexed_parameters,
+            &mut asset_parameters,
+        );
+    }
+
     validate_projection_source_domains(program, &set_registry, entrypoint)?;
-    validate_reduce_projection_expressions(model, program, &set_registry, entrypoint)?;
+    validate_reduce_projection_expressions(
+        model,
+        program,
+        &set_registry,
+        &set_aliases,
+        entrypoint,
+    )?;
     lower_reduce_projection_expressions(
         &mut active_expressions,
         model,
@@ -139,6 +153,19 @@ pub fn validate_program(
         &set_registry,
         entrypoint,
     )?;
+
+    let variable_families = model
+        .controls
+        .iter()
+        .map(|control| {
+            let expanded_indices = expand_index_decls_with_tuple_shorthand(
+                &control.indices,
+                &set_registry,
+                &set_aliases,
+            );
+            FamilySignature::from_index_decls(&control.name, &expanded_indices)
+        })
+        .collect::<Vec<_>>();
 
     let time_steps = set_registry
         .get("time")
@@ -155,18 +182,14 @@ pub fn validate_program(
         active_scenario: scenario.name.clone(),
         sets: resolved_sets,
         set_registry,
-        set_aliases: collect_set_aliases(program, Some(model)),
+        set_aliases: set_aliases.clone(),
         set_params: BTreeMap::new(),
         parameters: ResolvedParameters {
             series: series_parameters.into_iter().collect(),
             indexed: indexed_parameters.into_iter().collect(),
             asset: asset_parameters.into_iter().collect(),
         },
-        variable_families: model
-            .controls
-            .iter()
-            .map(|control| FamilySignature::from_index_decls(&control.name, &control.indices))
-            .collect(),
+        variable_families,
         variable_overrides: collect_control_overrides(
             model
                 .controls
@@ -217,6 +240,7 @@ fn validate_reduce_projection_expressions(
     model: &ModelDecl,
     program: &SourceProgram,
     set_registry: &BTreeMap<String, crate::semantic::ResolvedSet>,
+    set_aliases: &BTreeMap<String, String>,
     entrypoint: &Path,
 ) -> Result<(), SemanticError> {
     let projections = program
@@ -264,8 +288,12 @@ fn validate_reduce_projection_expressions(
                 path: entrypoint.to_path_buf(),
             })?;
 
-        let target_indices = target_family
-            .indices
+        let expanded_target_indices = expand_index_decls_with_tuple_shorthand(
+            &target_family.indices,
+            set_registry,
+            set_aliases,
+        );
+        let target_indices = expanded_target_indices
             .iter()
             .map(|index| index.name.as_str())
             .collect::<Vec<_>>();
@@ -484,6 +512,77 @@ fn validate_model_parameters_resolved(
     }
 
     Ok(())
+}
+
+fn expand_parameter_indices_with_tuple_shorthand(
+    indices: &[String],
+    set_registry: &BTreeMap<String, crate::semantic::ResolvedSet>,
+    set_aliases: &BTreeMap<String, String>,
+) -> Vec<String> {
+    if indices.len() != 1 {
+        return indices.to_vec();
+    }
+
+    let symbol = &indices[0];
+    let Some(set_key) = resolve_set_registry_key(symbol, set_registry, set_aliases) else {
+        return indices.to_vec();
+    };
+    let Some(set) = set_registry.get(set_key) else {
+        return indices.to_vec();
+    };
+    let Some(tuple_components) = set.tuple_components.as_ref() else {
+        return indices.to_vec();
+    };
+
+    tuple_components.clone()
+}
+
+fn expand_index_decls_with_tuple_shorthand(
+    decls: &[crate::source::IndexDecl],
+    set_registry: &BTreeMap<String, crate::semantic::ResolvedSet>,
+    set_aliases: &BTreeMap<String, String>,
+) -> Vec<crate::source::IndexDecl> {
+    let mut expanded = Vec::new();
+
+    for decl in decls {
+        let domain_name = decl.domain.as_deref().unwrap_or(decl.name.as_str());
+        let uses_shorthand = decl.name == domain_name;
+        if uses_shorthand {
+            if let Some(set_key) = resolve_set_registry_key(domain_name, set_registry, set_aliases)
+            {
+                if let Some(tuple_components) = set_registry
+                    .get(set_key)
+                    .and_then(|set| set.tuple_components.as_ref())
+                {
+                    expanded.extend(tuple_components.iter().map(|component| {
+                        crate::source::IndexDecl {
+                            name: component.clone(),
+                            domain: Some(set_key.to_string()),
+                        }
+                    }));
+                    continue;
+                }
+            }
+        }
+
+        expanded.push(decl.clone());
+    }
+
+    expanded
+}
+
+fn resolve_set_registry_key<'a>(
+    name: &str,
+    set_registry: &'a BTreeMap<String, crate::semantic::ResolvedSet>,
+    set_aliases: &BTreeMap<String, String>,
+) -> Option<&'a str> {
+    if let Some((key, _)) = set_registry.get_key_value(name) {
+        return Some(key.as_str());
+    }
+
+    let canonical = set_aliases.get(name)?;
+    let (key, _) = set_registry.get_key_value(canonical)?;
+    Some(key.as_str())
 }
 
 fn classify_parameter_indices(

--- a/crates/arco-kdl/src/semantic/validation.rs
+++ b/crates/arco-kdl/src/semantic/validation.rs
@@ -523,18 +523,9 @@ fn expand_parameter_indices_with_tuple_shorthand(
         return indices.to_vec();
     }
 
-    let symbol = &indices[0];
-    let Some(set_key) = resolve_set_registry_key(symbol, set_registry, set_aliases) else {
-        return indices.to_vec();
-    };
-    let Some(set) = set_registry.get(set_key) else {
-        return indices.to_vec();
-    };
-    let Some(tuple_components) = set.tuple_components.as_ref() else {
-        return indices.to_vec();
-    };
-
-    tuple_components.clone()
+    tuple_components_for_symbol(&indices[0], set_registry, set_aliases)
+        .map(|(_, tuple_components)| tuple_components.to_vec())
+        .unwrap_or_else(|| indices.to_vec())
 }
 
 fn expand_index_decls_with_tuple_shorthand(
@@ -548,20 +539,16 @@ fn expand_index_decls_with_tuple_shorthand(
         let domain_name = decl.domain.as_deref().unwrap_or(decl.name.as_str());
         let uses_shorthand = decl.name == domain_name;
         if uses_shorthand {
-            if let Some(set_key) = resolve_set_registry_key(domain_name, set_registry, set_aliases)
+            if let Some((set_key, tuple_components)) =
+                tuple_components_for_symbol(domain_name, set_registry, set_aliases)
             {
-                if let Some(tuple_components) = set_registry
-                    .get(set_key)
-                    .and_then(|set| set.tuple_components.as_ref())
-                {
-                    expanded.extend(tuple_components.iter().map(|component| {
-                        crate::source::IndexDecl {
-                            name: component.clone(),
-                            domain: Some(set_key.to_string()),
-                        }
-                    }));
-                    continue;
-                }
+                expanded.extend(tuple_components.iter().map(|component| {
+                    crate::source::IndexDecl {
+                        name: component.clone(),
+                        domain: Some(set_key.to_string()),
+                    }
+                }));
+                continue;
             }
         }
 
@@ -569,6 +556,16 @@ fn expand_index_decls_with_tuple_shorthand(
     }
 
     expanded
+}
+
+fn tuple_components_for_symbol<'a>(
+    symbol: &str,
+    set_registry: &'a BTreeMap<String, crate::semantic::ResolvedSet>,
+    set_aliases: &BTreeMap<String, String>,
+) -> Option<(&'a str, &'a [String])> {
+    let set_key = resolve_set_registry_key(symbol, set_registry, set_aliases)?;
+    let tuple_components = set_registry.get(set_key)?.tuple_components.as_deref()?;
+    Some((set_key, tuple_components))
 }
 
 fn resolve_set_registry_key<'a>(

--- a/crates/arco-kdl/tests/compile_suite.rs
+++ b/crates/arco-kdl/tests/compile_suite.rs
@@ -1228,3 +1228,324 @@ scenario "S1" {
     fs::remove_dir_all(&root)?;
     Ok(())
 }
+
+#[test]
+fn lowering_unpacks_tuple_set_shorthand_for_control_and_constraint_bindings()
+-> Result<(), Box<dyn std::error::Error>> {
+    let root = temp_test_dir("tuple-shorthand-unpack")?;
+    fs::create_dir_all(root.join("data"))?;
+    fs::write(
+        root.join("data").join("links.csv"),
+        "area,tech,gen,bus,feasible\n1,wind,g1,b1,1\n2,solar,g2,b3,1\n",
+    )?;
+
+    let path = root.join("input.kdl");
+    fs::write(
+        &path,
+        r#"
+data "links" source="data/links.csv" {
+  alias "generators" column="gen"
+  alias "buses" column="bus"
+
+  set "area"
+  set "tech"
+  set "generators"
+  set "buses"
+
+  set "feasible_links" {
+    index "a" { in "area" }
+    index "i" { in "tech" }
+    index "g" { in "generators" }
+    index "b" { in "buses" }
+    filter { feasible > 0 }
+  }
+}
+
+model "TupleDispatch" {
+  control "x" lower=0 {
+    index "feasible_links"
+  }
+
+  constraint "cap" {
+    index "feasible_links"
+    expression {
+      x[a,i,g,b] <= 1
+    }
+  }
+
+  minimize "Obj" { 0 }
+}
+
+scenario "S1" {
+  use "TupleDispatch"
+}
+"#,
+    )?;
+
+    let parsed = parse_program_file(&path)?;
+    let semantic = validate_program(&parsed.program, &path)?;
+    let compiled = compile_program(&semantic, &parsed.program, &path)?;
+
+    let variable_names = compiled
+        .algebra
+        .variable_instances
+        .iter()
+        .map(|instance| instance.name.clone())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        variable_names,
+        vec![
+            "x[1,wind,g1,b1]".to_string(),
+            "x[2,solar,g2,b3]".to_string()
+        ]
+    );
+
+    let constraint_names = compiled
+        .algebra
+        .constraints
+        .iter()
+        .map(|constraint| constraint.name.clone())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        constraint_names,
+        vec![
+            "cap[1,b1,g1,wind]".to_string(),
+            "cap[2,b3,g2,solar]".to_string()
+        ]
+    );
+
+    fs::remove_dir_all(&root)?;
+    Ok(())
+}
+
+#[test]
+fn lowering_allows_tuple_key_indexing_with_tuple_set_name() -> Result<(), Box<dyn std::error::Error>>
+{
+    let root = temp_test_dir("tuple-key-indexing")?;
+    fs::create_dir_all(root.join("data"))?;
+    fs::write(
+        root.join("data").join("links.csv"),
+        "area,tech,gen,bus,feasible\n1,wind,g1,b1,1\n2,solar,g2,b3,1\n",
+    )?;
+
+    let path = root.join("input.kdl");
+    fs::write(
+        &path,
+        r#"
+data "links" source="data/links.csv" {
+  alias "generators" column="gen"
+  alias "buses" column="bus"
+
+  set "area"
+  set "tech"
+  set "generators"
+  set "buses"
+
+  set "feasible_links" {
+    index "a" { in "area" }
+    index "i" { in "tech" }
+    index "g" { in "generators" }
+    index "b" { in "buses" }
+    filter { feasible > 0 }
+  }
+}
+
+model "TupleDispatch" {
+  control "x" lower=0 {
+    index "feasible_links"
+  }
+
+  constraint "cap" {
+    index "feasible_links"
+    expression {
+      x[feasible_links] <= 1
+    }
+  }
+
+  minimize "Obj" { 0 }
+}
+
+scenario "S1" {
+  use "TupleDispatch"
+}
+"#,
+    )?;
+
+    let parsed = parse_program_file(&path)?;
+    let semantic = validate_program(&parsed.program, &path)?;
+    let compiled = compile_program(&semantic, &parsed.program, &path)?;
+
+    let constraint_names = compiled
+        .algebra
+        .constraints
+        .iter()
+        .map(|constraint| constraint.name.clone())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        constraint_names,
+        vec![
+            "cap[1,b1,g1,wind]".to_string(),
+            "cap[2,b3,g2,solar]".to_string()
+        ]
+    );
+
+    fs::remove_dir_all(&root)?;
+    Ok(())
+}
+
+#[test]
+fn lowering_allows_parent_indexed_symbol_lookup_with_subset_tuple_key()
+-> Result<(), Box<dyn std::error::Error>> {
+    let root = temp_test_dir("tuple-key-subset")?;
+    fs::create_dir_all(root.join("data"))?;
+    fs::write(
+        root.join("data").join("links.csv"),
+        "area,tech,gen,bus,feasible\n1,wind,g1,b1,1\n1,solar,g2,b2,1\n2,solar,g3,b3,1\n",
+    )?;
+
+    let path = root.join("input.kdl");
+    fs::write(
+        &path,
+        r#"
+data "links" source="data/links.csv" {
+  alias "generators" column="gen"
+  alias "buses" column="bus"
+
+  set "area"
+  set "tech"
+  set "generators"
+  set "buses"
+
+  set "feasible_links" {
+    index "a" { in "area" }
+    index "i" { in "tech" }
+    index "g" { in "generators" }
+    index "b" { in "buses" }
+    filter { feasible > 0 }
+  }
+}
+
+set "priority_links" {
+  in "feasible_links"
+  index "a" { in "area" }
+  index "i" { in "tech" }
+  index "g" { in "generators" }
+  index "b" { in "buses" }
+  filter { area == "1" }
+}
+
+model "TupleDispatch" {
+  control "x" lower=0 {
+    index "feasible_links"
+  }
+
+  constraint "cap" {
+    index "priority_links"
+    expression {
+      x[priority_links] <= 1
+    }
+  }
+
+  minimize "Obj" { 0 }
+}
+
+scenario "S1" {
+  use "TupleDispatch"
+}
+"#,
+    )?;
+
+    let parsed = parse_program_file(&path)?;
+    let semantic = validate_program(&parsed.program, &path)?;
+    let compiled = compile_program(&semantic, &parsed.program, &path)?;
+
+    let constraint_names = compiled
+        .algebra
+        .constraints
+        .iter()
+        .map(|constraint| constraint.name.clone())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        constraint_names,
+        vec![
+            "cap[1,b1,g1,wind]".to_string(),
+            "cap[1,b2,g2,solar]".to_string()
+        ]
+    );
+
+    fs::remove_dir_all(&root)?;
+    Ok(())
+}
+
+#[test]
+fn lowering_accepts_data_param_tuple_shorthand_indexing() -> Result<(), Box<dyn std::error::Error>>
+{
+    let root = temp_test_dir("tuple-param-shorthand")?;
+    fs::create_dir_all(root.join("data"))?;
+    fs::write(
+        root.join("data").join("links.csv"),
+        "area,tech,gen,bus,cap,feasible\n1,wind,g1,b1,10,1\n2,solar,g2,b3,20,1\n",
+    )?;
+
+    let path = root.join("input.kdl");
+    fs::write(
+        &path,
+        r#"
+data "links" source="data/links.csv" {
+  alias "generators" column="gen"
+  alias "buses" column="bus"
+
+  set "area"
+  set "tech"
+  set "generators"
+  set "buses"
+
+  set "feasible_links" {
+    index "a" { in "area" }
+    index "i" { in "tech" }
+    index "g" { in "generators" }
+    index "b" { in "buses" }
+    filter { feasible > 0 }
+  }
+
+  param "capacity_mw" from="cap" {
+    index "feasible_links"
+  }
+}
+
+model "TupleDispatch" {
+  control "x" lower=0 {
+    index "feasible_links"
+  }
+
+  constraint "cap" {
+    index "feasible_links"
+    expression {
+      x[feasible_links] <= capacity_mw[feasible_links]
+    }
+  }
+
+  minimize "Obj" { 0 }
+}
+
+scenario "S1" {
+  use "TupleDispatch"
+}
+"#,
+    )?;
+
+    let parsed = parse_program_file(&path)?;
+    let semantic = validate_program(&parsed.program, &path)?;
+    let compiled = compile_program(&semantic, &parsed.program, &path)?;
+
+    let rhs_values = compiled
+        .algebra
+        .constraints
+        .iter()
+        .map(|constraint| constraint.rhs)
+        .collect::<Vec<_>>();
+    assert_eq!(rhs_values, vec![10.0, 20.0]);
+
+    fs::remove_dir_all(&root)?;
+    Ok(())
+}

--- a/docs/adr/0001-set-unpacking-always-on.md
+++ b/docs/adr/0001-set-unpacking-always-on.md
@@ -1,0 +1,3 @@
+# Always-on set unpacking semantics for `index <set>`
+
+Arco will treat `index <set_name>` as set unpacking semantics in all supported locations (`constraint`, `control`, and `param`) without an opt-in compatibility flag. This keeps authoring simple and consistent across tuple and non-tuple sets, and avoids dual-language behavior that would fragment docs and examples. Existing models that relied on scalar-only interpretation for tuple sets must migrate to the explicit alias form (`index <var> { in <set> }`) where needed.

--- a/docs/appendix-a-ergonomic-profile.md
+++ b/docs/appendix-a-ergonomic-profile.md
@@ -97,28 +97,24 @@ data branch_data source="data/branches.csv" {
 >
 > model nodal_allocation {
 >   control dispatch lower=0 {
->     index a { in feasible_links }
->     index i { in feasible_links }
->     index g { in feasible_links }
->     index b { in feasible_links }
+>     index feasible_links
 >   }
 >
 >   constraint priority_floor {
->     index a { in priority_links }
->     index i { in priority_links }
->     index g { in priority_links }
->     index b { in priority_links }
->     expression { dispatch[a,i,g,b] >= 0 }
+>     index priority_links
+>     expression { dispatch[priority_links] >= 0 }
 >   }
 > }
 > ```
 >
-> In V1, tuple-domain variables mean membership in `feasible_links`, not
-> Cartesian expansion over `area × tech × generators × buses`. Projection stays
-> explicit: define a named subset and iterate that subset directly. If the index
-> order is wrong, diagnostics report both the scoped source ID and the canonical
-> tuple domain. Empty-subset diagnostics list every offending key in
-> deterministic tuple order.
+> In V1, `index <tuple_set>` unpacks tuple components from that set and still
+> means membership in tuple rows (not Cartesian expansion over
+> `area × tech × generators × buses`). Projection stays explicit: define a named
+> subset and iterate that subset directly. Tuple-key indexing is allowed with set
+> names (for example `dispatch[priority_links]`), and diagnostics still report
+> scoped source IDs plus canonical tuple domains for index-order mismatches.
+> Empty-subset diagnostics list every offending key in deterministic tuple
+> order.
 
 ## A.4 Ergonomic grammar
 

--- a/docs/arco-spec.md
+++ b/docs/arco-spec.md
@@ -524,6 +524,10 @@ Tuple-domain membership semantics (non-Cartesian):
   bindings like `index a { in tuple_set }`, `index b { in tuple_set }`, ... in
   the same generated family/constraint refer to membership in the same tuple
   rows.
+- `index tuple_set` is shorthand for tuple unpacking in generated
+  constraints/control/param declarations: tuple components are brought into
+  scope from the tuple-domain set declaration, and expansion still follows tuple
+  rows (not Cartesian products).
 - Implementations MUST NOT expand those bindings as a Cartesian product over
   tuple components.
 - Projection to lower-dimensional domains is explicit: define a named subset
@@ -2576,18 +2580,23 @@ constraint bodies. Prefer `<=` or `>=` in all constraint algebra.
 
 ### 12.4 Indexing
 
-| Form       | Description                |
-| ---------- | -------------------------- |
-| `x[a]`     | single-dimension index     |
-| `x[a,t]`   | multi-dimension index      |
-| `x[a,t-1]` | temporal offset (backward) |
-| `x[a,t+1]` | temporal offset (forward)  |
+| Form                | Description                                  |
+| ------------------- | -------------------------------------------- |
+| `x[a]`              | single-dimension index                       |
+| `x[a,t]`            | multi-dimension index                        |
+| `x[feasible_links]` | tuple-key index (set-name key for tuple row) |
+| `x[a,t-1]`          | temporal offset (backward)                   |
+| `x[a,t+1]`          | temporal offset (forward)                    |
 
 Temporal offsets (`t-1`, `t+1`) are valid on ordered sets (typically the `time`
 set). Offsets are restricted to literal integers (e.g., `t-1`, `t+2`); variable
 or parameter-dependent offsets (e.g., `t-lag[g]`) are not supported. Constraints
 using temporal offsets MUST include an `if` guard to exclude boundary steps
 where the offset would be out-of-range (see [§6.5](#65-constraint)).
+
+Tuple-key indexing uses set-name tokens (for example `x[feasible_links]` or
+`x[priority_links]`) and is equivalent to expanded component indexing when the
+referenced tuple set is compatible with the symbol's tuple signature.
 
 ### 12.5 Reductions
 

--- a/examples/nodal-allocation/input.kdl
+++ b/examples/nodal-allocation/input.kdl
@@ -58,10 +58,7 @@ projection "ai" {
 
 model NodalAllocation {
   control investment lower=0 {
-    index a { in feasible_links }
-    index i { in feasible_links }
-    index g { in feasible_links }
-    index b { in feasible_links }
+    index feasible_links
   }
 
   expression investment_by_area_tech {
@@ -71,30 +68,23 @@ model NodalAllocation {
   }
 
   constraint investment_capacity {
-    index a { in feasible_links }
-    index i { in feasible_links }
-    index g { in feasible_links }
-    index b { in feasible_links }
+    index feasible_links
     expression {
-      investment[a,i,g,b] <= capacity_mw[a,i,g,b]
+      investment[feasible_links] <= capacity_mw[feasible_links]
     }
   }
 
   constraint priority_floor {
-    index a { in priority_links }
-    index i { in priority_links }
-    index g { in priority_links }
-    index b { in priority_links }
+    index priority_links
     expression {
-      investment[a,i,g,b] >= priority_floor_mw[a,i,g,b]
+      investment[priority_links] >= priority_floor_mw[priority_links]
     }
   }
 
   constraint enforce_mw_target {
-    index a { in feasible_ai }
-    index i { in feasible_ai }
+    index feasible_ai
     expression {
-      investment_by_area_tech[a,i] >= mw_target[a,i]
+      investment_by_area_tech[feasible_ai] >= mw_target[feasible_ai]
     }
   }
 


### PR DESCRIPTION
## Summary
- implement ADR-0001: treat `index <set>` as always-on unpacking for tuple domains across control/constraint/param flows
- add tuple-key indexing support with set-name tokens (including subset keys)
- expand tuple shorthand in semantic signatures and data param key resolution
- update nodal allocation example and KDL spec/docs to reflect the new syntax

## Tests
- cargo fmt
- cargo test -p arco-kdl
