### PR TITLE
fix(cli): report tuple component sizes in inspect

### DIFF
--- a/crates/arco-cli/src/inspect.rs
+++ b/crates/arco-cli/src/inspect.rs
@@ -358,7 +358,7 @@ fn build_variable_records(
                 kind,
                 lower,
                 upper,
-                set: build_family_set_bindings(family, set_sizes, &program.set_aliases),
+                set: build_family_set_bindings(family, program, set_sizes, &program.set_aliases),
             }
         })
         .collect()
@@ -428,6 +428,7 @@ fn render_bound(bound: &arco_kdl::source::BoundExpr) -> BoundValue {
 
 fn build_family_set_bindings(
     family: &FamilySignature,
+    program: &SemanticProgram,
     set_sizes: &BTreeMap<&str, usize>,
     set_aliases: &BTreeMap<String, String>,
 ) -> Vec<SetBinding> {
@@ -440,7 +441,9 @@ fn build_family_set_bindings(
                 .get(index)
                 .cloned()
                 .unwrap_or_else(|| index.clone());
-            let size = lookup_set_size(set_sizes, set_aliases, set_name.as_str());
+            let size =
+                tuple_component_domain_size(program, set_sizes, set_aliases, &set_name, index)
+                    .unwrap_or_else(|| lookup_set_size(set_sizes, set_aliases, set_name.as_str()));
             let alias = if index == &set_name {
                 None
             } else {
@@ -453,6 +456,27 @@ fn build_family_set_bindings(
             }
         })
         .collect()
+}
+
+fn tuple_component_domain_size(
+    program: &SemanticProgram,
+    set_sizes: &BTreeMap<&str, usize>,
+    set_aliases: &BTreeMap<String, String>,
+    set_name: &str,
+    component: &str,
+) -> Option<usize> {
+    let canonical_set = canonical_set_name(set_name, set_aliases);
+    let tuple_set = program.set_registry.get(canonical_set)?;
+    let tuple_components = tuple_set.tuple_components.as_ref()?;
+    let component_position = tuple_components.iter().position(|name| name == component)?;
+
+    let domain_name = tuple_set
+        .tuple_component_domains
+        .as_ref()
+        .and_then(|domains| domains.get(component_position))
+        .map_or(component, String::as_str);
+
+    lookup_set_size_option(set_sizes, set_aliases, domain_name)
 }
 
 // ─── Parameter builder ───────────────────────────────────────────

--- a/crates/arco-cli/tests/example_cli_commands.rs
+++ b/crates/arco-cli/tests/example_cli_commands.rs
@@ -248,10 +248,19 @@ fn run_compact_nodal_allocation_tracer_bullet_succeeds() {
     );
     for binding in sets {
         assert_eq!(binding["name"], "feasible_links");
+
+        let expected_size = match binding["as"].as_str().expect("tuple binding alias") {
+            "a" => 2,
+            "i" => 3,
+            "g" => 5,
+            "b" => 4,
+            other => panic!("unexpected tuple binding alias: {other}"),
+        };
+
         assert_eq!(
             binding["size"],
-            Value::from(4),
-            "tuple-domain binding should use tuple-row cardinality"
+            Value::from(expected_size),
+            "tuple-domain binding should use tuple-component domain size"
         );
     }
 


### PR DESCRIPTION
## Summary
- fix `arco inspect` variable set bindings for tuple-indexed controls
- report tuple component domain sizes (`area`, `tech`, `generators`, `buses`) instead of tuple-row cardinality for every alias
- add/update regression assertion in nodal allocation CLI test

## Validation
- cargo test -p arco-cli run_compact_nodal_allocation_tracer_bullet_succeeds
- cargo test -p arco-cli
