### PR TITLE
fix(kdl): fail fast on duplicate model declarations

### DIFF
--- a/crates/arco-kdl/src/semantic/error.rs
+++ b/crates/arco-kdl/src/semantic/error.rs
@@ -122,6 +122,18 @@ pub enum SemanticError {
         path: PathBuf,
     },
 
+    #[error("duplicate {kind} declaration `{name}` in model `{model}` in {path}")]
+    #[diagnostic(
+        code(arco::semantic::duplicate_model_declaration),
+        help("rename or remove one of the duplicate declarations")
+    )]
+    DuplicateModelDeclaration {
+        kind: &'static str,
+        name: String,
+        model: String,
+        path: PathBuf,
+    },
+
     #[error(
         "unresolved filter identifier `{identifier}` in {declaration_kind} `{declaration}` from data `{data}` in {path}"
     )]

--- a/crates/arco-kdl/src/semantic/validation.rs
+++ b/crates/arco-kdl/src/semantic/validation.rs
@@ -46,6 +46,9 @@ pub fn validate_program(
 
     validate_scenario_data_bindings_match_known_params(scenario, model, program, entrypoint)?;
     validate_model_parameters_resolved(scenario, model, program, entrypoint)?;
+    validate_unique_model_expression_names(model, entrypoint)?;
+    validate_unique_model_constraint_names(model, entrypoint)?;
+    validate_unique_model_control_names(model, entrypoint)?;
 
     let mut seen_data_bindings = BTreeSet::new();
     for binding in &scenario.data {
@@ -506,6 +509,70 @@ fn validate_model_parameters_resolved(
             return Err(SemanticError::MissingDeclaration {
                 kind: "param",
                 name: parameter.name.clone(),
+                path: entrypoint.to_path_buf(),
+            });
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_unique_model_expression_names(
+    model: &ModelDecl,
+    entrypoint: &Path,
+) -> Result<(), SemanticError> {
+    validate_unique_model_names(
+        model,
+        "expression",
+        model
+            .expressions
+            .iter()
+            .map(|expression| expression.name.as_str()),
+        entrypoint,
+    )
+}
+
+fn validate_unique_model_constraint_names(
+    model: &ModelDecl,
+    entrypoint: &Path,
+) -> Result<(), SemanticError> {
+    validate_unique_model_names(
+        model,
+        "constraint",
+        model
+            .constraints
+            .iter()
+            .map(|constraint| constraint.name.as_str()),
+        entrypoint,
+    )
+}
+
+fn validate_unique_model_control_names(
+    model: &ModelDecl,
+    entrypoint: &Path,
+) -> Result<(), SemanticError> {
+    validate_unique_model_names(
+        model,
+        "control",
+        model.controls.iter().map(|control| control.name.as_str()),
+        entrypoint,
+    )
+}
+
+fn validate_unique_model_names<'a>(
+    model: &ModelDecl,
+    kind: &'static str,
+    names: impl Iterator<Item = &'a str>,
+    entrypoint: &Path,
+) -> Result<(), SemanticError> {
+    let mut seen = BTreeSet::new();
+
+    for name in names {
+        if !seen.insert(name) {
+            return Err(SemanticError::DuplicateModelDeclaration {
+                kind,
+                name: name.to_string(),
+                model: model.name.clone(),
                 path: entrypoint.to_path_buf(),
             });
         }

--- a/crates/arco-kdl/src/semantic/validation.rs
+++ b/crates/arco-kdl/src/semantic/validation.rs
@@ -46,9 +46,7 @@ pub fn validate_program(
 
     validate_scenario_data_bindings_match_known_params(scenario, model, program, entrypoint)?;
     validate_model_parameters_resolved(scenario, model, program, entrypoint)?;
-    validate_unique_model_expression_names(model, entrypoint)?;
-    validate_unique_model_constraint_names(model, entrypoint)?;
-    validate_unique_model_control_names(model, entrypoint)?;
+    validate_unique_model_declarations(model, entrypoint)?;
 
     let mut seen_data_bindings = BTreeSet::new();
     for binding in &scenario.data {
@@ -517,7 +515,7 @@ fn validate_model_parameters_resolved(
     Ok(())
 }
 
-fn validate_unique_model_expression_names(
+fn validate_unique_model_declarations(
     model: &ModelDecl,
     entrypoint: &Path,
 ) -> Result<(), SemanticError> {
@@ -529,13 +527,7 @@ fn validate_unique_model_expression_names(
             .iter()
             .map(|expression| expression.name.as_str()),
         entrypoint,
-    )
-}
-
-fn validate_unique_model_constraint_names(
-    model: &ModelDecl,
-    entrypoint: &Path,
-) -> Result<(), SemanticError> {
+    )?;
     validate_unique_model_names(
         model,
         "constraint",
@@ -544,19 +536,14 @@ fn validate_unique_model_constraint_names(
             .iter()
             .map(|constraint| constraint.name.as_str()),
         entrypoint,
-    )
-}
-
-fn validate_unique_model_control_names(
-    model: &ModelDecl,
-    entrypoint: &Path,
-) -> Result<(), SemanticError> {
+    )?;
     validate_unique_model_names(
         model,
         "control",
         model.controls.iter().map(|control| control.name.as_str()),
         entrypoint,
-    )
+    )?;
+    Ok(())
 }
 
 fn validate_unique_model_names<'a>(

--- a/crates/arco-kdl/tests/semantic_validation.rs
+++ b/crates/arco-kdl/tests/semantic_validation.rs
@@ -1420,3 +1420,112 @@ scenario "S1" {
     fs::remove_dir_all(&root)?;
     Ok(())
 }
+
+#[test]
+fn semantic_validation_rejects_duplicate_expression_names_in_model()
+-> Result<(), Box<dyn std::error::Error>> {
+    let root = temp_root("semantic-duplicate-expression-name")?;
+    let path = root.join("input.kdl");
+    let text = r#"
+model "Dispatch" {
+  expression "cost" { 1 }
+  expression "cost" { 2 }
+  minimize "Obj" { cost }
+}
+
+scenario "S1" {
+  use "Dispatch"
+}
+"#;
+
+    let parsed = parse_program_text(text, &path)?;
+    let error = validate_program(&parsed.program, &path)
+        .expect_err("duplicate model expression names should fail semantic validation");
+
+    assert!(error.to_string().contains("duplicate"));
+    assert!(error.to_string().contains("expression"));
+    assert!(error.to_string().contains("cost"));
+
+    fs::remove_dir_all(&root)?;
+    Ok(())
+}
+
+#[test]
+fn semantic_validation_rejects_duplicate_constraint_names_in_model()
+-> Result<(), Box<dyn std::error::Error>> {
+    let root = temp_root("semantic-duplicate-constraint-name")?;
+    let path = root.join("input.kdl");
+    let text = r#"
+set "a" { "n1" }
+
+model "Dispatch" {
+  control "x" {
+    index "i" { in "a" }
+  }
+
+  constraint "bal" {
+    index "i" { in "a" }
+    expression { x[i] <= 1 }
+  }
+
+  constraint "bal" {
+    index "i" { in "a" }
+    expression { x[i] >= 0 }
+  }
+
+  minimize "Obj" { sum(x[i] for i in a) }
+}
+
+scenario "S1" {
+  use "Dispatch"
+}
+"#;
+
+    let parsed = parse_program_text(text, &path)?;
+    let error = validate_program(&parsed.program, &path)
+        .expect_err("duplicate model constraint names should fail semantic validation");
+
+    assert!(error.to_string().contains("duplicate"));
+    assert!(error.to_string().contains("constraint"));
+    assert!(error.to_string().contains("bal"));
+
+    fs::remove_dir_all(&root)?;
+    Ok(())
+}
+
+#[test]
+fn semantic_validation_rejects_duplicate_control_names_in_model()
+-> Result<(), Box<dyn std::error::Error>> {
+    let root = temp_root("semantic-duplicate-control-name")?;
+    let path = root.join("input.kdl");
+    let text = r#"
+set "a" { "n1" }
+
+model "Dispatch" {
+  control "x" {
+    index "i" { in "a" }
+  }
+
+  control "x" {
+    index "i" { in "a" }
+  }
+
+  minimize "Obj" { 0 }
+}
+
+scenario "S1" {
+  use "Dispatch"
+}
+"#;
+
+    let parsed = parse_program_text(text, &path)?;
+    let error = validate_program(&parsed.program, &path)
+        .expect_err("duplicate model control names should fail semantic validation");
+
+    assert!(error.to_string().contains("duplicate"));
+    assert!(error.to_string().contains("control"));
+    assert!(error.to_string().contains('x'));
+
+    fs::remove_dir_all(&root)?;
+    Ok(())
+}

--- a/crates/arco-kdl/tests/semantic_validation.rs
+++ b/crates/arco-kdl/tests/semantic_validation.rs
@@ -1424,9 +1424,9 @@ scenario "S1" {
 #[test]
 fn semantic_validation_rejects_duplicate_expression_names_in_model()
 -> Result<(), Box<dyn std::error::Error>> {
-    let root = temp_root("semantic-duplicate-expression-name")?;
-    let path = root.join("input.kdl");
-    let text = r#"
+    assert_duplicate_model_declaration_fails(
+        "semantic-duplicate-expression-name",
+        r#"
 model "Dispatch" {
   expression "cost" { 1 }
   expression "cost" { 2 }
@@ -1436,26 +1436,18 @@ model "Dispatch" {
 scenario "S1" {
   use "Dispatch"
 }
-"#;
-
-    let parsed = parse_program_text(text, &path)?;
-    let error = validate_program(&parsed.program, &path)
-        .expect_err("duplicate model expression names should fail semantic validation");
-
-    assert!(error.to_string().contains("duplicate"));
-    assert!(error.to_string().contains("expression"));
-    assert!(error.to_string().contains("cost"));
-
-    fs::remove_dir_all(&root)?;
-    Ok(())
+"#,
+        "expression",
+        "cost",
+    )
 }
 
 #[test]
 fn semantic_validation_rejects_duplicate_constraint_names_in_model()
 -> Result<(), Box<dyn std::error::Error>> {
-    let root = temp_root("semantic-duplicate-constraint-name")?;
-    let path = root.join("input.kdl");
-    let text = r#"
+    assert_duplicate_model_declaration_fails(
+        "semantic-duplicate-constraint-name",
+        r#"
 set "a" { "n1" }
 
 model "Dispatch" {
@@ -1479,26 +1471,18 @@ model "Dispatch" {
 scenario "S1" {
   use "Dispatch"
 }
-"#;
-
-    let parsed = parse_program_text(text, &path)?;
-    let error = validate_program(&parsed.program, &path)
-        .expect_err("duplicate model constraint names should fail semantic validation");
-
-    assert!(error.to_string().contains("duplicate"));
-    assert!(error.to_string().contains("constraint"));
-    assert!(error.to_string().contains("bal"));
-
-    fs::remove_dir_all(&root)?;
-    Ok(())
+"#,
+        "constraint",
+        "bal",
+    )
 }
 
 #[test]
 fn semantic_validation_rejects_duplicate_control_names_in_model()
 -> Result<(), Box<dyn std::error::Error>> {
-    let root = temp_root("semantic-duplicate-control-name")?;
-    let path = root.join("input.kdl");
-    let text = r#"
+    assert_duplicate_model_declaration_fails(
+        "semantic-duplicate-control-name",
+        r#"
 set "a" { "n1" }
 
 model "Dispatch" {
@@ -1516,15 +1500,28 @@ model "Dispatch" {
 scenario "S1" {
   use "Dispatch"
 }
-"#;
+"#,
+        "control",
+        "x",
+    )
+}
+
+fn assert_duplicate_model_declaration_fails(
+    test_name: &str,
+    text: &str,
+    kind: &str,
+    name: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let root = temp_root(test_name)?;
+    let path = root.join("input.kdl");
 
     let parsed = parse_program_text(text, &path)?;
     let error = validate_program(&parsed.program, &path)
-        .expect_err("duplicate model control names should fail semantic validation");
+        .expect_err("duplicate model declaration names should fail semantic validation");
 
     assert!(error.to_string().contains("duplicate"));
-    assert!(error.to_string().contains("control"));
-    assert!(error.to_string().contains('x'));
+    assert!(error.to_string().contains(kind));
+    assert!(error.to_string().contains(name));
 
     fs::remove_dir_all(&root)?;
     Ok(())


### PR DESCRIPTION
## Summary
- add semantic fail-fast validation for duplicate model-level declaration names
- reject duplicate `expression`, `constraint`, and `control` names within a model
- add dedicated semantic diagnostic for duplicate model declarations
- add regression tests covering each duplicate kind

## Validation
- just ci

Closes #218
