### PR TITLE
feat(examples): add minimal ReEDS KDL benchmark

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -58,7 +58,7 @@ cargo run --release -p arco-cli -- run \
 | DCOPF, PTDF formulation                | `examples/dcopf-ptdf/input.kdl`                                                      | The same OF3bus case written with PTDF flow equations for formulation comparison.                                                                     | Ready  |
 | Unit commitment                        | `examples/unit-commitment/input.kdl`                                                 | Mixed-integer unit commitment with startup, shutdown, ramping, and piecewise costs, adapted from PSOPTLIB UC.                                         | Ready  |
 | Dense LP benchmark                     | `examples/dense-lp/input.kdl`                                                        | Synthetic dense LP used to stress model construction and compare against the bundled Python formulation.                                              | Ready  |
-| ReEDS benchmark                        | `examples/reeds-benchmark/formulation.py`                                            | ReEDS-representative LP benchmark using Arco Python bindings, sparse active domains, ramping, storage, emissions, and transmission.                   | Ready  |
+| ReEDS benchmark                        | `examples/reeds-benchmark/input.kdl`                                                 | ReEDS-representative LP benchmark with exported sparse tuple domains plus a companion Python formulation for parity and benchmark comparison.         | Ready  |
 | SDOM                                   | `examples/sdom/input.kdl`                                                            | Storage deployment optimization with renewables, thermal capacity, storage sizing, and policy-style generation mix constraints.                       | Ready  |
 | Multi-period DC-OPF (24-bus)           | `examples/multi-period-optimal-power-flow/dc-opf-24bus-wind-load-shedding/input.kdl` | 24-hour DC optimal power flow on the IEEE 24-bus system with wind, ramping, load shedding, and curtailment. LP, solves with HiGHS.                    | Ready  |
 | Multi-period AC-OPF (24-bus)           | `examples/multi-period-optimal-power-flow/ac-opf-24bus-wind-load-shedding/input.kdl` | 24-hour AC optimal power flow on the IEEE 24-bus system with wind, ramping, load shedding, and curtailment. NLP, requires IPOPT (`--features ipopt`). | Ready  |
@@ -72,6 +72,8 @@ Some examples ship a Python formulation so you can compare the KDL model with a 
 uv run examples/dense-lp/formulation.py --solve --json
 uv run examples/sdom/formulation.py --solve --json
 uv run examples/reeds-benchmark/formulation.py --size small --json
+REEDS_KDL_INPUT=$(uv run examples/reeds-benchmark/prepare_kdl_contract.py)
+cargo run -p arco-cli -- validate "$REEDS_KDL_INPUT"
 ```
 
 For interactive exploration of dense-lp (inspect model, then solve from a REPL):

--- a/examples/reeds-benchmark/README.md
+++ b/examples/reeds-benchmark/README.md
@@ -1,14 +1,20 @@
 # ReEDS benchmark
 
-Python-only Arco benchmark adapted from the ReEDS framework comparison. It builds a simplified single-vintage capacity-expansion LP with sparse active tech/region/year domains, transmission, ramping, emissions, and storage constraints.
+Small ReEDS-style KDL benchmark for capacity expansion and dispatch.
 
-Run from repo root:
+The KDL files are committed, but CSV inputs are generated into a temporary
+working directory so the repository does not carry generated data files.
+
+Run from the repository root:
+
+```bash
+REEDS_KDL_INPUT=$(uv run examples/reeds-benchmark/prepare_kdl_contract.py)
+cargo run -p arco-cli -- validate "$REEDS_KDL_INPUT"
+cargo run -p arco-cli -- run "$REEDS_KDL_INPUT" --compact
+```
+
+For comparison, the Python benchmark remains available:
 
 ```bash
 uv run examples/reeds-benchmark/formulation.py --size small --json
-uv run examples/reeds-benchmark/formulation.py --size medium --build-only --json
 ```
-
-Sizes: `small`, `medium`, `large`, `xlarge`.
-
-Use this example as the baseline for improving the Arco Python dense-array UX and reducing formulation LOC.

--- a/examples/reeds-benchmark/data.kdl
+++ b/examples/reeds-benchmark/data.kdl
@@ -1,0 +1,71 @@
+data regions source="data/regions.csv" {
+  set region alias="r"
+}
+
+data techs source="data/techs.csv" {
+  set tech alias="i"
+}
+
+data hours source="data/hours.csv" {
+  set hour alias="h"
+}
+
+data years source="data/years.csv" {
+  set year alias="t"
+}
+
+data tech_params source="data/tech_params.csv" {
+  param cost_inv { index tech }
+  param cost_gen { index tech }
+}
+
+data active_capacity source="data/active_capacity.csv" {
+  set active_irt {
+    index i { in tech }
+    index r { in region }
+    index t { in year }
+  }
+}
+
+data capacity_transitions source="data/cap_transition.csv" {
+  map prev_years from="prev_year"
+  set prev_years alias="tp"
+
+  set cap_transition {
+    index i { in tech }
+    index r { in region }
+    index tp { in prev_years }
+    index t { in year }
+  }
+}
+
+data dispatch source="data/dispatch.csv" {
+  set active_irht {
+    index i { in tech }
+    index r { in region }
+    index h { in hour }
+    index t { in year }
+  }
+
+  param cf {
+    index tech
+    index region
+    index hour
+    index year
+  }
+}
+
+data cap_init source="data/cap_init.csv" {
+  param cap_init {
+    index tech
+    index region
+  }
+}
+
+data load source="data/load.csv" {
+  param load {
+    index region
+    index hour
+    index year
+  }
+}

--- a/examples/reeds-benchmark/input.kdl
+++ b/examples/reeds-benchmark/input.kdl
@@ -1,0 +1,7 @@
+include "data.kdl"
+include "model.kdl"
+
+scenario reeds_benchmark_small {
+  use reeds_benchmark
+  report total_cost
+}

--- a/examples/reeds-benchmark/model.kdl
+++ b/examples/reeds-benchmark/model.kdl
@@ -1,0 +1,56 @@
+model reeds_benchmark {
+  control cap lower=0 {
+    index active_irt
+  }
+
+  control inv lower=0 {
+    index active_irt
+  }
+
+  control gen lower=0 {
+    index active_irht
+  }
+
+  expression investment_cost {
+    sum(cost_inv[i] * inv[i,r,t] for i in tech for r in region for t in year)
+  }
+
+  expression generation_cost {
+    sum(cost_gen[i] * gen[i,r,h,t] for i in tech for r in region for h in hour for t in year)
+  }
+
+  constraint initial_capacity {
+    index i { in tech }
+    index r { in region }
+    expression {
+      cap[i,r,2030] = cap_init[i,r] + inv[i,r,2030]
+    }
+  }
+
+  constraint capacity_rollforward {
+    index cap_transition
+    expression {
+      cap[i,r,t] = cap[i,r,tp] + inv[i,r,t]
+    }
+  }
+
+  constraint generation_limit {
+    index active_irht
+    expression {
+      gen[active_irht] <= cf[active_irht] * cap[i,r,t]
+    }
+  }
+
+  constraint supply_demand_balance {
+    index r { in region }
+    index h { in hour }
+    index t { in year }
+    expression {
+      sum(gen[i,r,h,t] for i in tech) >= load[r,h,t]
+    }
+  }
+
+  minimize total_cost {
+    investment_cost + generation_cost
+  }
+}

--- a/examples/reeds-benchmark/prepare_kdl_contract.py
+++ b/examples/reeds-benchmark/prepare_kdl_contract.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Create temporary CSV inputs for the ReEDS KDL benchmark."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import shutil
+import tempfile
+from pathlib import Path
+
+KDL_FILES = ("input.kdl", "data.kdl", "model.kdl")
+REGIONS = ("r1", "r2")
+TECHS = ("gas", "wind")
+HOURS = ("h1", "h2")
+YEARS = (2030, 2035)
+
+
+def write_csv(
+    path: Path, header: tuple[str, ...], rows: list[tuple[object, ...]]
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(header)
+        writer.writerows(rows)
+
+
+def prepare_kdl_contract(output_dir: Path | None = None) -> Path:
+    """Copy KDL files and generate tiny runnable CSV inputs."""
+
+    if output_dir is None:
+        output_dir = Path(tempfile.mkdtemp(prefix="arco-reeds-kdl-"))
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    source_dir = Path(__file__).resolve().parent
+    for name in KDL_FILES:
+        shutil.copy2(source_dir / name, output_dir / name)
+
+    data_dir = output_dir / "data"
+    write_csv(data_dir / "regions.csv", ("region",), [(r,) for r in REGIONS])
+    write_csv(data_dir / "techs.csv", ("tech",), [(i,) for i in TECHS])
+    write_csv(data_dir / "hours.csv", ("hour",), [(h,) for h in HOURS])
+    write_csv(data_dir / "years.csv", ("year",), [(t,) for t in YEARS])
+    write_csv(
+        data_dir / "tech_params.csv",
+        ("tech", "cost_inv", "cost_gen"),
+        [("gas", 400.0, 45.0), ("wind", 900.0, 2.0)],
+    )
+
+    active = [(i, r, t) for i in TECHS for r in REGIONS for t in YEARS]
+    write_csv(data_dir / "active_capacity.csv", ("tech", "region", "year"), active)
+    write_csv(
+        data_dir / "cap_transition.csv",
+        ("tech", "region", "prev_year", "year"),
+        [(i, r, 2030, 2035) for i in TECHS for r in REGIONS],
+    )
+
+    dispatch_rows = []
+    for i in TECHS:
+        for r in REGIONS:
+            for h in HOURS:
+                for t in YEARS:
+                    cf = 1.0 if i == "gas" else (0.45 if h == "h1" else 0.25)
+                    dispatch_rows.append((i, r, h, t, cf))
+    write_csv(
+        data_dir / "dispatch.csv",
+        ("tech", "region", "hour", "year", "cf"),
+        dispatch_rows,
+    )
+
+    write_csv(
+        data_dir / "cap_init.csv",
+        ("tech", "region", "cap_init"),
+        [
+            ("gas", "r1", 80.0),
+            ("gas", "r2", 70.0),
+            ("wind", "r1", 30.0),
+            ("wind", "r2", 20.0),
+        ],
+    )
+    write_csv(
+        data_dir / "load.csv",
+        ("region", "hour", "year", "load"),
+        [
+            (r, h, t, 65.0 if h == "h1" else 75.0)
+            for r in REGIONS
+            for h in HOURS
+            for t in YEARS
+        ],
+    )
+    return output_dir / "input.kdl"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Prepare a temporary ReEDS KDL benchmark input."
+    )
+    parser.add_argument("--output-dir", type=Path)
+    args = parser.parse_args()
+    print(prepare_kdl_contract(args.output_dir))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes N/A

## Description

- Add a minimal ReEDS-style KDL benchmark entrypoint, data contract, and model.
- Add `prepare_kdl_contract.py` to generate tiny CSV inputs in a temporary directory.
- Keep generated CSVs and Python benchmark generator changes out of the PR.

## Testing strategy

- `REEDS_KDL_INPUT=$(uv run examples/reeds-benchmark/prepare_kdl_contract.py) && cargo run -p arco-cli -- validate "$REEDS_KDL_INPUT"`
- `ARCO_CONFIG_DIR=$(mktemp -d) ARCO_PROJECT_CONFIG_DIR=$(mktemp -d) cargo run -p arco-cli -- run "$REEDS_KDL_INPUT" --compact`
- `just ci`

## Related

- Follow-up solver diagnostics PR: https://github.com/NatLabRockies/arco/pull/247
