### PR TITLE
feat(solver): add generic diagnostics

### DIFF
--- a/bindings/python/src/errors.rs
+++ b/bindings/python/src/errors.rs
@@ -320,6 +320,7 @@ pub fn generic_solver_error_to_py(e: arco_ops::solve::SolverError) -> PyErr {
         arco_ops::solve::SolverError::InvalidVariableId(_) => VariableInvalidIdError::new_err(msg),
         arco_ops::solve::SolverError::SolverNotAvailable(_) => SolverInternalError::new_err(msg),
         arco_ops::solve::SolverError::SolverSpecific(_) => SolverInternalError::new_err(msg),
+        arco_ops::solve::SolverError::Diagnostic(_) => SolverInternalError::new_err(msg),
         arco_ops::solve::SolverError::SolveFailure { status } => {
             use arco_ops::solve::SolverStatus;
             match status {

--- a/crates/arco-cli/src/cli_io.rs
+++ b/crates/arco-cli/src/cli_io.rs
@@ -2,6 +2,7 @@ use std::io::{self, Write};
 
 const ANSI_RESET: &str = "\x1b[0m";
 const ANSI_DIM_GRAY: &str = "\x1b[38;5;245m";
+const ANSI_RED: &str = "\x1b[31m";
 const ANSI_BOLD: &str = "\x1b[1m";
 const ANSI_NO_BOLD: &str = "\x1b[22m";
 
@@ -43,6 +44,13 @@ pub fn write_stdout_line(line: &str) -> io::Result<()> {
     write_all_ignoring_broken_pipe(&mut handle, b"\n")
 }
 
+pub fn write_stderr_line(line: &str) -> io::Result<()> {
+    let stderr = io::stderr();
+    let mut handle = stderr.lock();
+    write_all_ignoring_broken_pipe(&mut handle, line.as_bytes())?;
+    write_all_ignoring_broken_pipe(&mut handle, b"\n")
+}
+
 pub fn should_log_solver_to_console(verbose: u8, stdout_is_terminal: bool) -> bool {
     verbose >= 2 && stdout_is_terminal
 }
@@ -69,6 +77,13 @@ pub fn format_timed_status(
         style_bold_in_dim(detail, color_mode)
     );
     style_dimmed(&payload, color_mode)
+}
+
+pub fn style_error_label(content: &str, color_mode: ColorMode) -> String {
+    if color_mode == ColorMode::Disabled {
+        return content.to_string();
+    }
+    format!("{ANSI_RED}{ANSI_BOLD}{content}{ANSI_NO_BOLD}{ANSI_RESET}")
 }
 
 pub fn style_bold_in_dim(content: &str, color_mode: ColorMode) -> String {

--- a/crates/arco-cli/src/driver.rs
+++ b/crates/arco-cli/src/driver.rs
@@ -1,4 +1,4 @@
-use crate::cli_io::{ColorMode, format_timed_status, style_bold_in_dim};
+use crate::cli_io::{ColorMode, format_timed_status, style_bold_in_dim, style_error_label};
 use crate::config::{ConfigError, SolverConfigState, load_solver_config};
 pub use crate::driver_kdl::{KdlCheckOutcome, kdl_check_file_json};
 pub use crate::driver_summary::{
@@ -7,7 +7,7 @@ pub use crate::driver_summary::{
 };
 use crate::driver_summary::{summarize_variables, trim_family_prefix};
 use arco_ops::execution::{ExecutionError, SolveStatus, render_problem_model};
-use arco_ops::solve::{ResolvedSelection, SolverProfile};
+use arco_ops::solve::{ResolvedSelection, SolverDiagnostic, SolverProfile};
 use arco_ops::{ArcoOps, OpsCompileError};
 use miette::Diagnostic;
 use std::fmt::Display;
@@ -44,6 +44,40 @@ pub enum DriverError {
     BackendNotAvailable { message: String },
     #[error("{message}")]
     InspectFormat { message: String },
+}
+
+pub fn render_plain_driver_error(error: &DriverError, color_mode: ColorMode) -> Option<String> {
+    let DriverError::Execution(ExecutionError::Solve { backend, source }) = error else {
+        return None;
+    };
+    let arco_ops::solve::SolverError::Diagnostic(diagnostic) = source else {
+        return None;
+    };
+
+    Some(render_solver_diagnostic(backend, diagnostic, color_mode))
+}
+
+fn render_solver_diagnostic(
+    backend: &str,
+    diagnostic: &SolverDiagnostic,
+    color_mode: ColorMode,
+) -> String {
+    match diagnostic {
+        SolverDiagnostic::ModelSizeLimit {
+            solver,
+            operation,
+            return_code,
+            limit,
+            model,
+        } => format!(
+            "{} {solver} size limit exceeded\n  --> solver backend: {backend}\n   |\n   = model: rows={}, columns={}, nonzeros={}, rows+columns={}, limit={limit}\n   = help: reduce variables/constraints, switch solver (`arco solver set highs`), or use a higher-limit license\n   = note: operation={operation}, rc={return_code}",
+            style_error_label("error[arco::solver::model_size_limit]:", color_mode),
+            model.constraints,
+            model.variables,
+            model.coefficients,
+            model.rows_plus_columns(),
+        ),
+    }
 }
 
 impl Diagnostic for DriverError {
@@ -324,8 +358,11 @@ fn peak_rss_bytes() -> Option<u64> {
 
 #[cfg(test)]
 mod tests {
-    use super::format_validate_success;
+    use super::{format_validate_success, render_plain_driver_error};
+    use crate::driver::DriverError;
     use crate::driver_kdl::span_line_column;
+    use arco_ops::execution::ExecutionError;
+    use arco_ops::solve::{SolverDiagnostic, SolverError, SolverModelStats};
     use miette::SourceSpan;
     use std::fs;
     use std::path::Path;
@@ -345,6 +382,39 @@ mod tests {
 
         assert_eq!(location, (Some(1), Some(10)));
         fs::remove_file(path).expect("remove unicode fixture");
+    }
+
+    #[test]
+    fn renders_plain_solver_diagnostic_without_miette_glyphs() {
+        let error = DriverError::Execution(ExecutionError::Solve {
+            backend: "arco-rust-xpress".to_string(),
+            source: SolverError::Diagnostic(SolverDiagnostic::ModelSizeLimit {
+                solver: "Xpress Community Edition".to_string(),
+                operation: "lpoptimize".to_string(),
+                return_code: 120,
+                limit: 5000,
+                model: SolverModelStats {
+                    variables: 2550,
+                    constraints: 2784,
+                    coefficients: 8160,
+                },
+            }),
+        });
+
+        let rendered = render_plain_driver_error(&error, crate::cli_io::ColorMode::Disabled)
+            .expect("solver diagnostics should render as plain CLI reports");
+
+        assert!(rendered.starts_with(
+            "error[arco::solver::model_size_limit]: Xpress Community Edition size limit exceeded"
+        ));
+        assert!(rendered.contains("  --> solver backend: arco-rust-xpress"));
+        assert!(rendered.contains("   |"));
+        assert!(rendered.contains(
+            "   = model: rows=2784, columns=2550, nonzeros=8160, rows+columns=5334, limit=5000"
+        ));
+        assert!(rendered.contains("   = note: operation=lpoptimize, rc=120"));
+        assert!(!rendered.contains('×'));
+        assert!(!rendered.contains('╰'));
     }
 
     #[test]

--- a/crates/arco-cli/src/main.rs
+++ b/crates/arco-cli/src/main.rs
@@ -1,12 +1,12 @@
 use arco_cli::cli_io::{
-    ColorMode, should_colorize_stdout, should_log_solver_to_console, write_stdout,
-    write_stdout_line,
+    ColorMode, should_colorize_stdout, should_log_solver_to_console, write_stderr_line,
+    write_stdout, write_stdout_line,
 };
 use arco_cli::config::{load_solver_config, save_solver_selection};
 use arco_cli::debug_shell::launch_ipython;
 use arco_cli::driver::{
     RunOptions, inspect_file_report, kdl_check_file_json, print_file_model,
-    run_file_json_with_options_and_config, validate_file_only,
+    render_plain_driver_error, run_file_json_with_options_and_config, validate_file_only,
 };
 use arco_ops::{ArcoOps, OpsExportFormat};
 use clap::{ArgAction, Parser, Subcommand, ValueEnum};
@@ -150,8 +150,20 @@ fn main() -> miette::Result<()> {
                         ),
                 },
                 &solver_config,
-            )?;
-            write_stdout(output.as_bytes()).into_diagnostic()?;
+            );
+            match output {
+                Ok(output) => write_stdout(output.as_bytes()).into_diagnostic()?,
+                Err(error) => {
+                    if let Some(rendered) = render_plain_driver_error(
+                        &error,
+                        ColorMode::from(should_colorize_stdout(std::io::stderr().is_terminal())),
+                    ) {
+                        write_stderr_line(&rendered).into_diagnostic()?;
+                        std::process::exit(1);
+                    }
+                    return Err(error.into());
+                }
+            }
         }
         Command::PrintModel { path } => {
             write_stdout_line(&print_file_model(&path)?).into_diagnostic()?;

--- a/crates/arco-ops/src/execution.rs
+++ b/crates/arco-ops/src/execution.rs
@@ -197,7 +197,7 @@ pub enum ExecutionError {
         #[source]
         source: ArcoSolverError,
     },
-    #[error("adapter backend `{backend}` failed to solve model: {source}")]
+    #[error("solver backend `{backend}` could not solve this model")]
     Solve {
         backend: String,
         #[source]
@@ -910,7 +910,21 @@ mod tests {
         VariableInstance, VariableKind,
     };
     use crate::compile::compile::{CompiledObjective, CompiledProblem, CompiledVariable};
-    use crate::execution::{MockArcoAdapter, execute_problem_with_options};
+    use crate::execution::{ExecutionError, MockArcoAdapter, execute_problem_with_options};
+    use arco_solver::SolverError as ArcoSolverError;
+
+    #[test]
+    fn solve_error_display_keeps_source_out_of_top_level_message() {
+        let error = ExecutionError::Solve {
+            backend: "xpress".to_string(),
+            source: ArcoSolverError::SolverSpecific("detailed solver reason".to_string()),
+        };
+
+        assert_eq!(
+            error.to_string(),
+            "solver backend `xpress` could not solve this model"
+        );
+    }
 
     #[test]
     #[allow(clippy::float_cmp)]

--- a/crates/arco-ops/src/lib.rs
+++ b/crates/arco-ops/src/lib.rs
@@ -78,9 +78,10 @@ pub mod solve {
     pub use arco_solver::{
         ModelViewBackend, ModelViewBackendRegistry, ModelViewSolveResult, ResolvedSelection,
         SelectionError, Solution, SolutionView, Solve, SolveRequest, SolverCapabilityModel,
-        SolverConfig, SolverConfigDocument, SolverError, SolverFamily, SolverProfile,
-        SolverRegistry, SolverRequirements, SolverSelection, SolverStatus, SolverTransport,
-        merged_profiles, preflight_model_view, preflight_selection, resolve_selection,
+        SolverConfig, SolverConfigDocument, SolverDiagnostic, SolverError, SolverFamily,
+        SolverModelStats, SolverProfile, SolverRegistry, SolverRequirements, SolverSelection,
+        SolverStatus, SolverTransport, merged_profiles, preflight_model_view, preflight_selection,
+        resolve_selection,
     };
 }
 

--- a/crates/arco-solver/src/lib.rs
+++ b/crates/arco-solver/src/lib.rs
@@ -25,7 +25,9 @@ pub use registry::{SolverCapabilityModel, SolverFamily, SolverRegistry, SolverTr
 pub use request::SolveRequest;
 pub use selection::{ResolvedSelection, SelectionError, SolverSelection, resolve_selection};
 pub use traits::{SolutionView, Solve};
-pub use types::{Solution, SolverError, SolverStatus, SolverStatusMapping};
+pub use types::{
+    Solution, SolverDiagnostic, SolverError, SolverModelStats, SolverStatus, SolverStatusMapping,
+};
 
 /// Minimal result envelope for direct solves over primitive model views.
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/arco-solver/src/types.rs
+++ b/crates/arco-solver/src/types.rs
@@ -60,6 +60,51 @@ impl std::fmt::Display for SolverStatus {
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct SolverModelStats {
+    pub variables: usize,
+    pub constraints: usize,
+    pub coefficients: usize,
+}
+
+impl SolverModelStats {
+    pub const fn rows_plus_columns(&self) -> usize {
+        self.variables + self.constraints
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub enum SolverDiagnostic {
+    ModelSizeLimit {
+        solver: String,
+        operation: String,
+        return_code: i32,
+        limit: usize,
+        model: SolverModelStats,
+    },
+}
+
+impl std::fmt::Display for SolverDiagnostic {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SolverDiagnostic::ModelSizeLimit {
+                solver,
+                operation,
+                return_code,
+                limit,
+                model,
+            } => write!(
+                f,
+                "{solver} cannot solve this model because it exceeds the configured size limit.\n\nModel size:\n  - rows: {}\n  - columns: {}\n  - nonzeros: {}\n  - rows + columns: {}\n  - limit: {limit}\n\nTry one of:\n  1. reduce the number of variables or constraints in the model\n  2. switch to another solver, for example: `arco solver set highs`\n  3. use a solver license/profile with a higher size limit\n\nDetails: solver={solver}, operation={operation}, rc={return_code}",
+                model.constraints,
+                model.variables,
+                model.coefficients,
+                model.rows_plus_columns(),
+            ),
+        }
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub enum SolverError {
     EmptyModel,
     NoObjective,
@@ -67,6 +112,7 @@ pub enum SolverError {
     InvalidVariableId(u32),
     SolverNotAvailable(String),
     SolveFailure { status: SolverStatus },
+    Diagnostic(SolverDiagnostic),
     SolverSpecific(String),
 }
 
@@ -79,6 +125,7 @@ impl SolverError {
             SolverError::InvalidVariableId(_) => "SOLVER_INVALID_VARIABLE_ID",
             SolverError::SolverNotAvailable(_) => "SOLVER_NOT_AVAILABLE",
             SolverError::SolveFailure { .. } => "SOLVER_SOLVE_FAILURE",
+            SolverError::Diagnostic(_) => "SOLVER_DIAGNOSTIC",
             SolverError::SolverSpecific(_) => "SOLVER_SPECIFIC",
         }
     }
@@ -101,9 +148,8 @@ impl std::fmt::Display for SolverError {
             SolverError::SolveFailure { status } => {
                 write!(f, "[{}] Solve failed with status: {}", self.code(), status)
             }
-            SolverError::SolverSpecific(msg) => {
-                write!(f, "[{}] Solver error: {}", self.code(), msg)
-            }
+            SolverError::Diagnostic(diagnostic) => write!(f, "{}", diagnostic),
+            SolverError::SolverSpecific(msg) => write!(f, "{}", msg),
         }
     }
 }

--- a/crates/arco-solver/tests/error_display.rs
+++ b/crates/arco-solver/tests/error_display.rs
@@ -1,0 +1,33 @@
+use arco_solver::{SolverDiagnostic, SolverError, SolverModelStats};
+
+#[test]
+fn solver_specific_display_uses_message_without_extra_wrapper() {
+    let error = SolverError::SolverSpecific("clean message".to_string());
+
+    assert_eq!(error.to_string(), "clean message");
+}
+
+#[test]
+fn model_size_limit_diagnostic_display_includes_actual_size_and_actions() {
+    let error = SolverError::Diagnostic(SolverDiagnostic::ModelSizeLimit {
+        solver: "Example Solver".to_string(),
+        operation: "optimize".to_string(),
+        return_code: 120,
+        limit: 5000,
+        model: SolverModelStats {
+            variables: 2300,
+            constraints: 2800,
+            coefficients: 12_345,
+        },
+    });
+    let message = error.to_string();
+
+    assert!(message.contains("Example Solver cannot solve this model"));
+    assert!(message.contains("rows: 2800"));
+    assert!(message.contains("columns: 2300"));
+    assert!(message.contains("nonzeros: 12345"));
+    assert!(message.contains("rows + columns: 5100"));
+    assert!(message.contains("limit: 5000"));
+    assert!(message.contains("arco solver set highs"));
+    assert!(message.contains("Details: solver=Example Solver, operation=optimize, rc=120"));
+}

--- a/crates/arco-xpress/src/ffi.rs
+++ b/crates/arco-xpress/src/ffi.rs
@@ -114,6 +114,7 @@ type XPRSsetdblcontrolFn = unsafe extern "C" fn(XPRSprob, c_int, c_double) -> c_
 type XPRSgetdblcontrolFn = unsafe extern "C" fn(XPRSprob, c_int, *mut c_double) -> c_int;
 type XPRSgetintattribFn = unsafe extern "C" fn(XPRSprob, c_int, *mut c_int) -> c_int;
 type XPRSgetdblattribFn = unsafe extern "C" fn(XPRSprob, c_int, *mut c_double) -> c_int;
+type XPRSgetlasterrorFn = unsafe extern "C" fn(XPRSprob, *mut c_char) -> c_int;
 type XPRSlicenseFn = unsafe extern "C" fn(*mut c_int, *const c_char) -> c_int;
 type XPRSgetlicerrmsgFn = unsafe extern "C" fn(*mut c_char, c_int) -> c_int;
 type XPRSgetversionFn = unsafe extern "C" fn(*mut c_char) -> c_int;
@@ -177,6 +178,7 @@ pub struct Api {
     pub xprs_getdblcontrol: XPRSgetdblcontrolFn,
     pub xprs_getintattrib: XPRSgetintattribFn,
     pub xprs_getdblattrib: XPRSgetdblattribFn,
+    pub xprs_getlasterror: XPRSgetlasterrorFn,
     pub xprs_license: XPRSlicenseFn,
     pub xprs_getlicerrmsg: XPRSgetlicerrmsgFn,
     pub xprs_getversion: XPRSgetversionFn,
@@ -311,6 +313,7 @@ fn load_api() -> Result<Api, RuntimeLoadError> {
                     ),
                     xprs_getintattrib: load_symbol!(handle, "XPRSgetintattrib", XPRSgetintattribFn),
                     xprs_getdblattrib: load_symbol!(handle, "XPRSgetdblattrib", XPRSgetdblattribFn),
+                    xprs_getlasterror: load_symbol!(handle, "XPRSgetlasterror", XPRSgetlasterrorFn),
                     xprs_license: load_symbol!(handle, "XPRSlicense", XPRSlicenseFn),
                     xprs_getlicerrmsg: load_symbol!(handle, "XPRSgetlicerrmsg", XPRSgetlicerrmsgFn),
                     xprs_getversion: load_symbol!(handle, "XPRSgetversion", XPRSgetversionFn),

--- a/crates/arco-xpress/src/solver.rs
+++ b/crates/arco-xpress/src/solver.rs
@@ -4,7 +4,10 @@ use crate::ffi;
 use crate::solution::Solution;
 use crate::status;
 use arco_model::{ConstraintId, ModelFingerprint, ModelView, Sense, VariableId};
-use arco_solver::{ModelViewBackend, ModelViewSolveResult, Solve, SolverConfig, SolverError};
+use arco_solver::{
+    ModelViewBackend, ModelViewSolveResult, Solve, SolverConfig, SolverDiagnostic, SolverError,
+    SolverModelStats,
+};
 use std::collections::BTreeMap;
 use std::ffi::{CStr, CString, c_char, c_int, c_void};
 use std::io::{self, Write};
@@ -46,6 +49,7 @@ impl Drop for ProbGuard {
 }
 
 const ERRMSG_BUF_LEN: c_int = 512;
+const LAST_ERROR_BUF_LEN: c_int = 4096;
 
 /// Return the most likely local Xpress installation directory.
 pub fn detect_xpress_dir() -> Option<PathBuf> {
@@ -203,6 +207,86 @@ fn restore_env(key: &str, original: Option<&str>) {
         Some(value) => unsafe { std::env::set_var(key, value) },
         None => unsafe { std::env::remove_var(key) },
     }
+}
+
+#[allow(unsafe_code)]
+fn xprs_last_error(api: &'static ffi::Api, prob: ffi::XPRSprob) -> Option<String> {
+    let mut buffer = [0 as c_char; LAST_ERROR_BUF_LEN as usize];
+    let rc = unsafe { (api.xprs_getlasterror)(prob, buffer.as_mut_ptr()) };
+    if rc != 0 {
+        return None;
+    }
+
+    let message = unsafe { CStr::from_ptr(buffer.as_ptr()) }
+        .to_string_lossy()
+        .trim()
+        .to_string();
+    if message.is_empty() {
+        None
+    } else {
+        Some(message)
+    }
+}
+
+fn xpress_model_stats(model: &(impl ModelView + ?Sized)) -> SolverModelStats {
+    SolverModelStats {
+        variables: model.num_variables(),
+        constraints: model.num_constraints(),
+        coefficients: model.num_coefficients(),
+    }
+}
+
+fn normalize_xpress_last_error(last_error: &str) -> String {
+    let trimmed = last_error.trim();
+    let without_prefix = trimmed.strip_prefix('?').unwrap_or(trimmed).trim_start();
+    let without_code = without_prefix
+        .split_once(" Error:")
+        .map_or(without_prefix, |(_, message)| message.trim());
+
+    if without_code.contains("Problem has too many rows and columns. The maximum is 5000") {
+        return "Xpress Community Edition size limit exceeded: this model is larger than the 5000 row/column maximum. Try a smaller instance or use HiGHS/full Xpress."
+            .to_string();
+    }
+
+    without_code.to_string()
+}
+
+fn format_xpress_failure_message(action: &str, rc: c_int, last_error: Option<&str>) -> String {
+    match last_error {
+        Some(message) => {
+            let normalized = normalize_xpress_last_error(message);
+            format!("Xpress solve failed ({action}, rc={rc}): {normalized}")
+        }
+        None => format!("Xpress solve failed ({action}, rc={rc})"),
+    }
+}
+
+fn xpress_failure_error(
+    api: &'static ffi::Api,
+    prob: ffi::XPRSprob,
+    action: &str,
+    rc: c_int,
+    model: &(impl ModelView + ?Sized),
+) -> SolverError {
+    let last_error = xprs_last_error(api, prob);
+    if last_error
+        .as_deref()
+        .is_some_and(|message| normalize_xpress_last_error(message).contains("size limit exceeded"))
+    {
+        return SolverError::Diagnostic(SolverDiagnostic::ModelSizeLimit {
+            solver: "Xpress Community Edition".to_string(),
+            operation: action.trim_start_matches("XPRS").to_ascii_lowercase(),
+            return_code: rc,
+            limit: 5000,
+            model: xpress_model_stats(model),
+        });
+    }
+
+    SolverError::SolverSpecific(format_xpress_failure_message(
+        action,
+        rc,
+        last_error.as_deref(),
+    ))
 }
 
 #[allow(unsafe_code)]
@@ -533,7 +617,7 @@ fn solve_problem(
                 std::ptr::null(),
             )
         })
-        .map_err(|rc| SolverError::SolverSpecific(format!("XPRSloadmip failed: {rc}")))?;
+        .map_err(|rc| xpress_failure_error(api, prob, "XPRSloadmip", rc, model))?;
     } else {
         ffi::check_xprs(unsafe {
             (api.xprs_loadlp)(
@@ -553,7 +637,7 @@ fn solve_problem(
                 upper_bounds.as_ptr(),
             )
         })
-        .map_err(|rc| SolverError::SolverSpecific(format!("XPRSloadlp failed: {rc}")))?;
+        .map_err(|rc| xpress_failure_error(api, prob, "XPRSloadlp", rc, model))?;
     }
 
     ffi::check_xprs(unsafe {
@@ -570,10 +654,10 @@ fn solve_problem(
     let run_start = Instant::now();
     if has_integer {
         ffi::check_xprs(unsafe { (api.xprs_mipoptimize)(prob, std::ptr::null()) })
-            .map_err(|rc| SolverError::SolverSpecific(format!("XPRSmipoptimize failed: {rc}")))?;
+            .map_err(|rc| xpress_failure_error(api, prob, "XPRSmipoptimize", rc, model))?;
     } else {
         ffi::check_xprs(unsafe { (api.xprs_lpoptimize)(prob, std::ptr::null()) })
-            .map_err(|rc| SolverError::SolverSpecific(format!("XPRSlpoptimize failed: {rc}")))?;
+            .map_err(|rc| xpress_failure_error(api, prob, "XPRSlpoptimize", rc, model))?;
     }
     let run_seconds = run_start.elapsed().as_secs_f64();
     let solve_time_seconds = solve_started.elapsed().as_secs_f64();
@@ -901,6 +985,36 @@ mod tests {
             .expect_err("zero threads should be rejected");
         assert!(
             matches!(error, SolverError::SolverSpecific(message) if message.contains("threads"))
+        );
+    }
+
+    #[test]
+    fn formats_xpress_failure_message_with_last_error() {
+        let message =
+            format_xpress_failure_message("XPRSlpoptimize", 120, Some("invalid identifier 'gen'"));
+
+        assert_eq!(
+            message,
+            "Xpress solve failed (XPRSlpoptimize, rc=120): invalid identifier 'gen'"
+        );
+    }
+
+    #[test]
+    fn formats_xpress_failure_message_without_last_error() {
+        let message = format_xpress_failure_message("XPRSloadlp", 1157, None);
+
+        assert_eq!(message, "Xpress solve failed (XPRSloadlp, rc=1157)");
+    }
+
+    #[test]
+    fn normalizes_xpress_community_size_limit_message() {
+        let message = normalize_xpress_last_error(
+            "?120 Error: Problem has too many rows and columns. The maximum is 5000",
+        );
+
+        assert_eq!(
+            message,
+            "Xpress Community Edition size limit exceeded: this model is larger than the 5000 row/column maximum. Try a smaller instance or use HiGHS/full Xpress."
         );
     }
 }


### PR DESCRIPTION
Closes N/A

## Description

- Add generic solver diagnostic types for model-size limit failures.
- Map Xpress Community Edition size-limit failures into typed diagnostics with actual model size.
- Render curated solver diagnostics in clippy/ruff-style CLI output.
- Keep Python solver-error conversion exhaustive for the new diagnostic variant.

## Testing strategy

- `just ci`
- Xpress ReEDS repro was validated locally before split; expected result is a typed size-limit diagnostic under Community Edition.

## Related

- Split from https://github.com/NatLabRockies/arco/pull/246
