### PR TITLE
feat(cli): add self-update command

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ arco <command> [options]
 | `arco validate <file>`      | Validate a `.kdl` file without solving                |
 | `arco kdl check <file>`     | Validate a `.kdl` file with optional JSON diagnostics |
 | `arco --version`            | Print the installed Arco CLI version                  |
+| `arco self update`          | Update a standalone installer build                   |
 | `arco inspect <file>`       | Inspect semantic model (sets, variables, parameters)  |
 | `arco print-model <file>`   | Print the algebraic model sent to the solver          |
 | `arco export <file>`        | Export as LP or MPS format                            |

--- a/crates/arco-cli/Cargo.toml
+++ b/crates/arco-cli/Cargo.toml
@@ -43,6 +43,10 @@ sysinfo = { workspace = true }
 thiserror = "2.0"
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
+axoupdater = { version = "0.9", default-features = false, features = ["github_releases"] }
+http = "1"
+owo-colors = "4"
+tokio = { version = "1", features = ["rt-multi-thread"] }
 
 [dev-dependencies]
 csv = "1.4"

--- a/crates/arco-cli/src/lib.rs
+++ b/crates/arco-cli/src/lib.rs
@@ -4,3 +4,4 @@ pub mod debug_shell;
 pub mod driver;
 mod driver_kdl;
 mod driver_summary;
+pub mod self_update;

--- a/crates/arco-cli/src/main.rs
+++ b/crates/arco-cli/src/main.rs
@@ -8,6 +8,7 @@ use arco_cli::driver::{
     RunOptions, inspect_file_report, kdl_check_file_json, print_file_model,
     render_plain_driver_error, run_file_json_with_options_and_config, validate_file_only,
 };
+use arco_cli::self_update;
 use arco_ops::{ArcoOps, OpsExportFormat};
 use clap::{ArgAction, Parser, Subcommand, ValueEnum};
 use miette::IntoDiagnostic;
@@ -79,6 +80,12 @@ enum Command {
         #[command(subcommand)]
         action: SolverAction,
     },
+    /// Manage the arco executable
+    #[command(name = "self")]
+    This {
+        #[command(subcommand)]
+        action: SelfAction,
+    },
 }
 
 #[derive(Clone, Copy, Debug, ValueEnum)]
@@ -109,6 +116,19 @@ enum SolverAction {
     Show,
     /// Set the default solver selection token (family or profile)
     Set { selection: String },
+}
+
+#[derive(Subcommand)]
+enum SelfAction {
+    /// Update this arco executable when installed by the standalone installer
+    Update {
+        /// Update to a specific release tag instead of the latest release
+        #[arg(long)]
+        version: Option<String>,
+        /// GitHub token for higher API rate limits
+        #[arg(long)]
+        token: Option<String>,
+    },
 }
 
 fn main() -> miette::Result<()> {
@@ -188,6 +208,7 @@ fn main() -> miette::Result<()> {
             output,
         } => export_model(path, format, output)?,
         Command::Solver { action } => handle_solver_action(action)?,
+        Command::This { action } => handle_self_action(action, cli.verbose)?,
     }
 
     Ok(())
@@ -233,6 +254,19 @@ fn export_model(
         fs::write(output_path, buffer).into_diagnostic()?;
     } else {
         write_stdout(&buffer).into_diagnostic()?;
+    }
+
+    Ok(())
+}
+
+fn handle_self_action(action: SelfAction, verbose: u8) -> miette::Result<()> {
+    match action {
+        SelfAction::Update { version, token } => {
+            let code = self_update::update(version, token, verbose)?;
+            if code != 0 {
+                std::process::exit(code);
+            }
+        }
     }
 
     Ok(())

--- a/crates/arco-cli/src/self_update.rs
+++ b/crates/arco-cli/src/self_update.rs
@@ -1,0 +1,124 @@
+use std::io::IsTerminal;
+
+use axoupdater::{AxoUpdater, AxoupdateError, UpdateRequest};
+use miette::{IntoDiagnostic, Result};
+use owo_colors::OwoColorize;
+
+use crate::cli_io::{should_colorize_stdout, write_stderr_line};
+
+const APP_NAME: &str = "arco";
+const RELEASE_URL_PREFIX: &str = "https://github.com/NatLabRockies/arco/releases/tag/";
+
+pub fn update(version: Option<String>, token: Option<String>, verbose: u8) -> Result<i32> {
+    tokio::runtime::Runtime::new()
+        .into_diagnostic()?
+        .block_on(update_async(version, token, verbose))
+}
+
+async fn update_async(version: Option<String>, token: Option<String>, verbose: u8) -> Result<i32> {
+    let color = should_colorize_stdout(std::io::stderr().is_terminal());
+    let mut updater = AxoUpdater::new_for(APP_NAME);
+
+    if verbose > 0 {
+        updater.enable_installer_output();
+    } else {
+        updater.disable_installer_output();
+    }
+
+    if let Some(ref token) = token {
+        updater.set_github_token(token);
+    }
+
+    let Ok(updater) = updater.load_receipt() else {
+        write_stderr_line(&labelled(
+            "error",
+            "Self-update is only available for arco binaries installed via the standalone installation scripts.",
+            color,
+        ))
+        .into_diagnostic()?;
+        write_stderr_line(&labelled(
+            "hint",
+            "If you installed arco with a package manager, update arco with that package manager instead.",
+            color,
+        ))
+        .into_diagnostic()?;
+        return Ok(1);
+    };
+
+    if !updater
+        .check_receipt_is_for_this_executable()
+        .into_diagnostic()?
+    {
+        write_stderr_line(&labelled(
+            "error",
+            "Self-update is only available for arco binaries installed via the standalone installation scripts.",
+            color,
+        ))
+        .into_diagnostic()?;
+        write_stderr_line(&labelled(
+            "hint",
+            "A cargo-dist receipt exists, but it does not belong to this executable.",
+            color,
+        ))
+        .into_diagnostic()?;
+        return Ok(1);
+    }
+
+    write_stderr_line(&labelled("info", "Checking for updates...", color)).into_diagnostic()?;
+
+    let update_request = version.map_or(UpdateRequest::Latest, UpdateRequest::SpecificTag);
+    updater.configure_version_specifier(update_request);
+
+    match updater.run().await {
+        Ok(Some(result)) => {
+            let version_information = result.old_version.map_or_else(
+                || format!("to v{}", result.new_version),
+                |old_version| format!("from v{old_version} to v{}", result.new_version),
+            );
+            write_stderr_line(&labelled(
+                "success",
+                &format!(
+                    "Upgraded arco {version_information}! {RELEASE_URL_PREFIX}{}",
+                    result.new_version_tag
+                ),
+                color,
+            ))
+            .into_diagnostic()?;
+        }
+        Ok(None) => {
+            write_stderr_line(&labelled(
+                "success",
+                &format!(
+                    "You're on the latest version of arco (v{})",
+                    env!("CARGO_PKG_VERSION")
+                ),
+                color,
+            ))
+            .into_diagnostic()?;
+        }
+        Err(error) => {
+            if let AxoupdateError::Reqwest(error) = &error {
+                if error.status() == Some(http::StatusCode::FORBIDDEN) && token.is_none() {
+                    write_stderr_line(&labelled(
+                        "error",
+                        "GitHub API rate limit exceeded. Please provide a GitHub token via --token.",
+                        color,
+                    ))
+                    .into_diagnostic()?;
+                    return Ok(1);
+                }
+            }
+            return Err(error).into_diagnostic();
+        }
+    }
+
+    Ok(0)
+}
+
+fn labelled(label: &str, message: &str, color: bool) -> String {
+    if color {
+        format!("{}{} {message}", label.bold().cyan(), ":".bold())
+    } else {
+        format!("{label}: {message}")
+    }
+}

--- a/crates/arco-cli/tests/example_cli_commands.rs
+++ b/crates/arco-cli/tests/example_cli_commands.rs
@@ -125,6 +125,22 @@ fn version_flag_prints_arco_version() {
 }
 
 #[test]
+fn self_update_without_dist_receipt_reports_standalone_requirement() {
+    let output = run_cli(&["self", "update"]);
+    assert!(
+        !output.status.success(),
+        "self update should fail without a cargo-dist receipt\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("Self-update is only available for arco binaries installed via the standalone installation scripts")
+    );
+}
+
+#[test]
 fn kdl_check_json_succeeds_for_valid_model() {
     let model_path = example_path("examples/capacity-expansion/input.kdl");
     let model = model_path

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -30,8 +30,8 @@ install-path = "CARGO_HOME"
 dispatch-releases = true
 # Build only the required packages, and individually
 precise-builds = true
-# Whether to install an updater program
-install-updater = true
+# Self-update is handled by `arco self update`.
+install-updater = false
 # Extra setup steps injected into dist build-local-artifacts jobs
 github-build-setup = "../dist-build-setup.yml"
 


### PR DESCRIPTION
## Description

Adds an `arco self update` command for standalone installer builds.

- Uses `axoupdater` with the `arco` app receipt.
- Reports a clear error when the binary was not installed by cargo-dist standalone installers.
- Disables cargo-dist's separate updater artifact because the CLI now owns self-update UX.

## Testing strategy

- `cargo fmt`
- `cargo test -p arco-cli self_update_without_dist_receipt_reports_standalone_requirement`
- `just clippy-all`
- `just test`
- `just ci`
