### PR TITLE
chore(release): restore dist workflow dispatch

### DIFF
--- a/.github/dist-build-setup.yml
+++ b/.github/dist-build-setup.yml
@@ -1,3 +1,8 @@
+- name: Install uv for solver runtime setup
+  uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+  with:
+    version: "0.9.4"
+
 - name: Setup solver runtime (xpress)
   shell: bash
   env:
@@ -35,6 +40,17 @@
     patch_script="$RUNNER_TEMP/arco-scip-source-patch.cmake"
     toolchain_file="$RUNNER_TEMP/arco-musl-toolchain.cmake"
 
+    if command -v x86_64-unknown-linux-musl-gcc >/dev/null 2>&1; then
+      musl_cc="$(command -v x86_64-unknown-linux-musl-gcc)"
+      musl_cxx="$(command -v x86_64-unknown-linux-musl-g++)"
+    elif command -v x86_64-linux-musl-gcc >/dev/null 2>&1; then
+      musl_cc="$(command -v x86_64-linux-musl-gcc)"
+      musl_cxx="$(command -v x86_64-linux-musl-g++)"
+    else
+      echo "Could not find a musl C/C++ compiler in PATH" >&2
+      exit 1
+    fi
+
     cat > "$patch_script" <<'EOF'
     set(_arco_soplex_cmake "${CMAKE_SOURCE_DIR}/soplex/CMakeLists.txt")
     if(EXISTS "${_arco_soplex_cmake}")
@@ -44,14 +60,59 @@
       file(WRITE "${_arco_soplex_cmake}" "${_arco_soplex_contents}")
       message(STATUS "Arco: disabled Soplex test targets for musl static linking")
     endif()
+
+    set(_arco_soplex_src_cmake "${CMAKE_SOURCE_DIR}/soplex/src/CMakeLists.txt")
+    if(EXISTS "${_arco_soplex_src_cmake}")
+      file(READ "${_arco_soplex_src_cmake}" _arco_soplex_src_contents)
+      set(_arco_soplex_shared_decl [[add_library(libsoplexshared SHARED ${sources})]])
+      set(_arco_soplex_static_decl [[add_library(libsoplexshared STATIC ${sources})]])
+      if(_arco_soplex_src_contents MATCHES "add_library\\(libsoplexshared SHARED")
+        string(REPLACE "${_arco_soplex_shared_decl}" "${_arco_soplex_static_decl}" _arco_soplex_src_contents "${_arco_soplex_src_contents}")
+        if(_arco_soplex_src_contents MATCHES "add_library\\(libsoplexshared SHARED")
+          message(FATAL_ERROR "Arco: failed to replace Soplex shared library declaration")
+        endif()
+        message(STATUS "Arco: forced Soplex shared target to static for musl static linking")
+      elseif(_arco_soplex_src_contents MATCHES "add_library\\(libsoplexshared STATIC")
+        message(STATUS "Arco: Soplex shared target is already static for musl static linking")
+      else()
+        message(FATAL_ERROR "Arco: expected Soplex shared/static library declaration was not found")
+      endif()
+
+      string(REPLACE "install(TARGETS soplex libsoplex" "install(TARGETS libsoplex" _arco_soplex_src_contents "${_arco_soplex_src_contents}")
+      if(_arco_soplex_src_contents MATCHES "install\\(TARGETS soplex")
+        message(FATAL_ERROR "Arco: failed to remove Soplex executable install target")
+      endif()
+      file(WRITE "${_arco_soplex_src_cmake}" "${_arco_soplex_src_contents}")
+      message(STATUS "Arco: removed Soplex executable install target for musl static linking")
+    endif()
+
+    set(_arco_scip_src_cmake "${CMAKE_SOURCE_DIR}/scip/src/CMakeLists.txt")
+    if(EXISTS "${_arco_scip_src_cmake}")
+      file(READ "${_arco_scip_src_cmake}" _arco_scip_src_contents)
+      string(REPLACE "install(TARGETS scip libscip" "install(TARGETS libscip" _arco_scip_src_contents "${_arco_scip_src_contents}")
+      string(REPLACE "export(TARGETS scip libscip" "export(TARGETS libscip" _arco_scip_src_contents "${_arco_scip_src_contents}")
+      if(_arco_scip_src_contents MATCHES "install\\(TARGETS scip")
+        message(FATAL_ERROR "Arco: failed to remove SCIP executable install target")
+      endif()
+      file(WRITE "${_arco_scip_src_cmake}" "${_arco_scip_src_contents}")
+      message(STATUS "Arco: removed SCIP executable install target for musl static linking")
+    endif()
     EOF
 
     cat > "$toolchain_file" <<EOF
+    set(CMAKE_SYSTEM_NAME Linux)
+    set(CMAKE_SYSTEM_PROCESSOR x86_64)
+    set(CMAKE_C_COMPILER "$musl_cc")
+    set(CMAKE_CXX_COMPILER "$musl_cxx")
+    set(CMAKE_ASM_COMPILER "$musl_cc")
     set(CMAKE_PROJECT_TOP_LEVEL_INCLUDES "$patch_script")
     set(CMAKE_PROJECT_INCLUDE "$patch_script")
     EOF
 
     {
+      echo "CC_x86_64_unknown_linux_musl=$musl_cc"
+      echo "CXX_x86_64_unknown_linux_musl=$musl_cxx"
+      echo "CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=$musl_cc"
       echo "CMAKE_TOOLCHAIN_FILE=$toolchain_file"
       echo "CMAKE_TOOLCHAIN_FILE_x86_64_unknown_linux_musl=$toolchain_file"
     } >> "$GITHUB_ENV"

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -46,11 +46,78 @@ jobs:
     name: Build and publish release
     needs: release-please
     if: needs.release-please.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
     permissions:
-      contents: write # Required because the called workflow uploads release artifacts to GitHub Releases.
-    uses: ./.github/workflows/release.yml
-    with:
-      tag: ${{ needs.release-please.outputs.tag_name }}
+      actions: write # Required to dispatch and inspect the cargo-dist workflow run.
+      contents: read
+    steps:
+      - name: Dispatch cargo-dist release
+        id: dispatch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ needs.release-please.outputs.tag_name }}
+        run: |
+          set -euo pipefail
+          started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          gh workflow run release.yml --ref main -f tag="$TAG"
+
+          for _ in {1..60}; do
+            run_id="$(gh run list \
+              --workflow release.yml \
+              --event workflow_dispatch \
+              --branch main \
+              --limit 20 \
+              --json databaseId,createdAt \
+              --jq ".[] | select(.createdAt >= \"$started_at\") | .databaseId" \
+              | head -n 1)"
+            if [[ -n "$run_id" ]]; then
+              echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            sleep 5
+          done
+
+          echo "Timed out waiting for dispatched cargo-dist run" >&2
+          exit 1
+
+      - name: Wait for cargo-dist release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          RUN_ID: ${{ steps.dispatch.outputs.run_id }}
+        run: |
+          set -euo pipefail
+          while true; do
+            status="$(gh run view "$RUN_ID" --json status --jq '.status')"
+            if [[ "$status" == "completed" ]]; then
+              break
+            fi
+            sleep 30
+          done
+
+          conclusion="$(gh run view "$RUN_ID" --json conclusion --jq '.conclusion')"
+          if [[ "$conclusion" != "success" ]]; then
+            gh run view "$RUN_ID"
+            exit 1
+          fi
+
+      - name: Download dist-manifest from cargo-dist run
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          RUN_ID: ${{ steps.dispatch.outputs.run_id }}
+        run: |
+          set -euo pipefail
+          gh run download "$RUN_ID" --name artifacts-dist-manifest --dir cargo-dist-manifest
+
+      - name: Store dist-manifest for follow-up jobs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: artifacts-dist-manifest
+          path: cargo-dist-manifest/dist-manifest.json
+          retention-days: 3
 
   update-release-notes:
     name: Append install instructions
@@ -74,12 +141,12 @@ jobs:
           TAG: ${{ needs.release-please.outputs.tag_name }}
         run: |
           set -euo pipefail
-          install_body=$(jq -r '.announcement_github_body // empty' dist-manifest.json)
+          install_body="$(jq -r '.announcement_github_body // empty' dist-manifest.json)"
           if [[ -z "$install_body" ]]; then
             echo "No install instructions found in dist-manifest.json"
             exit 0
           fi
-          current_body=$(gh release view "$TAG" --json body --jq '.body')
+          current_body="$(gh release view "$TAG" --json body --jq '.body')"
           printf '%s\n\n---\n\n%s' "$current_body" "$install_body" > release-body.md
           gh release edit "$TAG" --notes-file release-body.md
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,12 +40,6 @@ permissions:
 # will be marked as a prerelease.
 on:
   pull_request:
-  workflow_call:
-    inputs:
-      tag:
-        description: Release Tag
-        required: true
-        type: string
   workflow_dispatch:
     inputs:
       tag:
@@ -141,6 +135,10 @@ jobs:
           fi
       - name: Use rustup to set correct Rust version
         run: rustup update "1.85" --no-self-update && rustup default "1.85"
+      - name: "Install uv for solver runtime setup"
+        uses: "astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b"
+        with:
+          "version": "0.9.4"
       - name: "Setup solver runtime (xpress)"
         run: |
           set -euo pipefail
@@ -174,6 +172,17 @@ jobs:
           patch_script="$RUNNER_TEMP/arco-scip-source-patch.cmake"
           toolchain_file="$RUNNER_TEMP/arco-musl-toolchain.cmake"
 
+          if command -v x86_64-unknown-linux-musl-gcc >/dev/null 2>&1; then
+            musl_cc="$(command -v x86_64-unknown-linux-musl-gcc)"
+            musl_cxx="$(command -v x86_64-unknown-linux-musl-g++)"
+          elif command -v x86_64-linux-musl-gcc >/dev/null 2>&1; then
+            musl_cc="$(command -v x86_64-linux-musl-gcc)"
+            musl_cxx="$(command -v x86_64-linux-musl-g++)"
+          else
+            echo "Could not find a musl C/C++ compiler in PATH" >&2
+            exit 1
+          fi
+
           cat > "$patch_script" <<'EOF'
           set(_arco_soplex_cmake "${CMAKE_SOURCE_DIR}/soplex/CMakeLists.txt")
           if(EXISTS "${_arco_soplex_cmake}")
@@ -183,14 +192,59 @@ jobs:
             file(WRITE "${_arco_soplex_cmake}" "${_arco_soplex_contents}")
             message(STATUS "Arco: disabled Soplex test targets for musl static linking")
           endif()
+
+          set(_arco_soplex_src_cmake "${CMAKE_SOURCE_DIR}/soplex/src/CMakeLists.txt")
+          if(EXISTS "${_arco_soplex_src_cmake}")
+            file(READ "${_arco_soplex_src_cmake}" _arco_soplex_src_contents)
+            set(_arco_soplex_shared_decl [[add_library(libsoplexshared SHARED ${sources})]])
+            set(_arco_soplex_static_decl [[add_library(libsoplexshared STATIC ${sources})]])
+            if(_arco_soplex_src_contents MATCHES "add_library\\(libsoplexshared SHARED")
+              string(REPLACE "${_arco_soplex_shared_decl}" "${_arco_soplex_static_decl}" _arco_soplex_src_contents "${_arco_soplex_src_contents}")
+              if(_arco_soplex_src_contents MATCHES "add_library\\(libsoplexshared SHARED")
+                message(FATAL_ERROR "Arco: failed to replace Soplex shared library declaration")
+              endif()
+              message(STATUS "Arco: forced Soplex shared target to static for musl static linking")
+            elseif(_arco_soplex_src_contents MATCHES "add_library\\(libsoplexshared STATIC")
+              message(STATUS "Arco: Soplex shared target is already static for musl static linking")
+            else()
+              message(FATAL_ERROR "Arco: expected Soplex shared/static library declaration was not found")
+            endif()
+
+            string(REPLACE "install(TARGETS soplex libsoplex" "install(TARGETS libsoplex" _arco_soplex_src_contents "${_arco_soplex_src_contents}")
+            if(_arco_soplex_src_contents MATCHES "install\\(TARGETS soplex")
+              message(FATAL_ERROR "Arco: failed to remove Soplex executable install target")
+            endif()
+            file(WRITE "${_arco_soplex_src_cmake}" "${_arco_soplex_src_contents}")
+            message(STATUS "Arco: removed Soplex executable install target for musl static linking")
+          endif()
+
+          set(_arco_scip_src_cmake "${CMAKE_SOURCE_DIR}/scip/src/CMakeLists.txt")
+          if(EXISTS "${_arco_scip_src_cmake}")
+            file(READ "${_arco_scip_src_cmake}" _arco_scip_src_contents)
+            string(REPLACE "install(TARGETS scip libscip" "install(TARGETS libscip" _arco_scip_src_contents "${_arco_scip_src_contents}")
+            string(REPLACE "export(TARGETS scip libscip" "export(TARGETS libscip" _arco_scip_src_contents "${_arco_scip_src_contents}")
+            if(_arco_scip_src_contents MATCHES "install\\(TARGETS scip")
+              message(FATAL_ERROR "Arco: failed to remove SCIP executable install target")
+            endif()
+            file(WRITE "${_arco_scip_src_cmake}" "${_arco_scip_src_contents}")
+            message(STATUS "Arco: removed SCIP executable install target for musl static linking")
+          endif()
           EOF
 
           cat > "$toolchain_file" <<EOF
+          set(CMAKE_SYSTEM_NAME Linux)
+          set(CMAKE_SYSTEM_PROCESSOR x86_64)
+          set(CMAKE_C_COMPILER "$musl_cc")
+          set(CMAKE_CXX_COMPILER "$musl_cxx")
+          set(CMAKE_ASM_COMPILER "$musl_cc")
           set(CMAKE_PROJECT_TOP_LEVEL_INCLUDES "$patch_script")
           set(CMAKE_PROJECT_INCLUDE "$patch_script")
           EOF
 
           {
+            echo "CC_x86_64_unknown_linux_musl=$musl_cc"
+            echo "CXX_x86_64_unknown_linux_musl=$musl_cxx"
+            echo "CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=$musl_cc"
             echo "CMAKE_TOOLCHAIN_FILE=$toolchain_file"
             echo "CMAKE_TOOLCHAIN_FILE_x86_64_unknown_linux_musl=$toolchain_file"
           } >> "$GITHUB_ENV"

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -24,6 +24,9 @@ targets = [
 ]
 # Which actions to run on pull requests
 pr-run-mode = "upload"
+# cargo-dist's MSI template generator currently emits whitespace-only blank lines
+# that repo hooks trim. The checked-in template is functionally identical.
+allow-dirty = ["msi"]
 # Path that installers should place binaries in
 install-path = "CARGO_HOME"
 # Whether CI should trigger releases with dispatches instead of tag pushes


### PR DESCRIPTION
## Summary
- restore cargo-dist generated release.yml by removing the unsupported workflow_call edit
- decouple release-please from the generated dist workflow so dist can run via workflow_dispatch
- allow cargo-dist MSI generated-file drift caused only by whitespace-only lines that repo hooks trim

## Validation
- dist plan --output-format=json
- just workflow-quality
- actionlint on non-generated workflows
