### PR TITLE
chore(cli): add kdl fmt command

### DIFF
--- a/crates/arco-cli/Cargo.toml
+++ b/crates/arco-cli/Cargo.toml
@@ -32,6 +32,7 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
+arco-kdl = { workspace = true }
 arco-ops = { workspace = true }
 clap = { version = "4", features = ["derive"] }
 miette = { version = "7", features = ["fancy"] }
@@ -40,6 +41,7 @@ serde_json = { workspace = true }
 toml = { workspace = true }
 toml_edit = "0.22"
 sysinfo = { workspace = true }
+similar = "2"
 thiserror = "2.0"
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }

--- a/crates/arco-cli/src/main.rs
+++ b/crates/arco-cli/src/main.rs
@@ -9,12 +9,14 @@ use arco_cli::driver::{
     render_plain_driver_error, run_file_json_with_options_and_config, validate_file_only,
 };
 use arco_cli::self_update;
+use arco_kdl::source::format_program_text;
 use arco_ops::{ArcoOps, OpsExportFormat};
-use clap::{ArgAction, Parser, Subcommand, ValueEnum};
+use clap::{ArgAction, Args, Parser, Subcommand, ValueEnum};
 use miette::IntoDiagnostic;
+use similar::TextDiff;
 use std::fs;
-use std::io::IsTerminal;
-use std::path::PathBuf;
+use std::io::{IsTerminal, Read};
+use std::path::{Path, PathBuf};
 
 #[derive(Parser)]
 #[command(
@@ -108,6 +110,26 @@ enum KdlAction {
         #[arg(long, default_value = "text")]
         format: CheckFormat,
     },
+    /// Format KDL files (similar to `ruff format`)
+    Fmt(KdlFmtArgs),
+}
+
+#[derive(Args, Debug)]
+struct KdlFmtArgs {
+    /// Files or directories to format (defaults to current directory)
+    paths: Vec<PathBuf>,
+    /// Check if files are formatted; do not write changes
+    #[arg(long)]
+    check: bool,
+    /// Show a unified diff for required changes
+    #[arg(long)]
+    diff: bool,
+    /// Read KDL from stdin
+    #[arg(long)]
+    stdin: bool,
+    /// Optional display name for stdin source (used in diff headers)
+    #[arg(long)]
+    stdin_filename: Option<String>,
 }
 
 #[derive(Subcommand)]
@@ -232,6 +254,7 @@ fn handle_kdl_action(action: KdlAction) -> miette::Result<()> {
                 }
             }
         },
+        KdlAction::Fmt(args) => run_kdl_fmt(args)?,
     }
 
     Ok(())
@@ -285,6 +308,128 @@ fn handle_solver_action(action: SolverAction) -> miette::Result<()> {
             write_stdout_line(&format!("selection: {}", selection)).into_diagnostic()?;
             write_stdout_line(&format!("path: {}", path.display())).into_diagnostic()?;
         }
+    }
+
+    Ok(())
+}
+
+fn format_kdl_text(input: &str, path: Option<&Path>) -> miette::Result<String> {
+    format_program_text(input).map_err(|error| {
+        if let Some(path) = path {
+            miette::miette!(
+                "Failed to parse KDL document: {} ({})",
+                path.display(),
+                error
+            )
+        } else {
+            miette::miette!("Failed to parse KDL document")
+        }
+    })
+}
+
+fn collect_kdl_files(path: &Path, files: &mut Vec<PathBuf>) -> miette::Result<()> {
+    let metadata = fs::symlink_metadata(path).into_diagnostic()?;
+    if metadata.file_type().is_symlink() {
+        return Ok(());
+    }
+
+    if metadata.is_file() {
+        if path.extension().is_some_and(|ext| ext == "kdl") {
+            files.push(path.to_path_buf());
+        }
+        return Ok(());
+    }
+
+    if metadata.is_dir() {
+        if let Some(name) = path.file_name().and_then(|value| value.to_str()) {
+            if matches!(name, ".git" | "target" | "node_modules" | ".uv-cache") {
+                return Ok(());
+            }
+        }
+
+        for entry in fs::read_dir(path).into_diagnostic()? {
+            let entry = entry.into_diagnostic()?;
+            collect_kdl_files(&entry.path(), files)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn print_unified_diff(label: &str, before: &str, after: &str) -> miette::Result<()> {
+    let diff = TextDiff::from_lines(before, after);
+    write_stdout_line(&format!("--- {label}")).into_diagnostic()?;
+    write_stdout_line(&format!("+++ {label}")).into_diagnostic()?;
+    for change in diff.unified_diff().header("", "").iter_hunks() {
+        write_stdout(change.to_string().as_bytes()).into_diagnostic()?;
+    }
+    Ok(())
+}
+
+fn run_kdl_fmt(args: KdlFmtArgs) -> miette::Result<()> {
+    if args.stdin || args.paths.iter().any(|path| path == Path::new("-")) {
+        let mut input = String::new();
+        std::io::stdin()
+            .read_to_string(&mut input)
+            .into_diagnostic()?;
+        let formatted = format_kdl_text(&input, None)?;
+
+        if args.check || args.diff {
+            if input != formatted {
+                if args.diff {
+                    let label = args.stdin_filename.as_deref().unwrap_or("stdin.kdl");
+                    print_unified_diff(label, &input, &formatted)?;
+                }
+                std::process::exit(1);
+            }
+            return Ok(());
+        }
+
+        write_stdout(formatted.as_bytes()).into_diagnostic()?;
+        return Ok(());
+    }
+
+    let roots = if args.paths.is_empty() {
+        vec![PathBuf::from(".")]
+    } else {
+        args.paths
+    };
+
+    let mut files = Vec::new();
+    for root in roots {
+        collect_kdl_files(&root, &mut files)?;
+    }
+
+    let mut changed_files = 0usize;
+
+    for file in files {
+        let input = fs::read_to_string(&file).into_diagnostic()?;
+        let formatted = format_kdl_text(&input, Some(&file))?;
+        if input == formatted {
+            continue;
+        }
+
+        changed_files += 1;
+
+        if args.diff {
+            let label = file.to_string_lossy().to_string();
+            print_unified_diff(&label, &input, &formatted)?;
+        }
+
+        if !args.check && !args.diff {
+            fs::write(&file, formatted).into_diagnostic()?;
+        }
+    }
+
+    if args.check || args.diff {
+        if changed_files > 0 {
+            write_stderr_line(&format!("{} file(s) would be reformatted", changed_files))
+                .into_diagnostic()?;
+            std::process::exit(1);
+        }
+        write_stderr_line("All files already formatted").into_diagnostic()?;
+    } else {
+        write_stderr_line(&format!("{} file(s) reformatted", changed_files)).into_diagnostic()?;
     }
 
     Ok(())

--- a/crates/arco-cli/tests/example_cli_commands.rs
+++ b/crates/arco-cli/tests/example_cli_commands.rs
@@ -232,6 +232,87 @@ fn kdl_check_json_reports_included_file_path() {
 }
 
 #[test]
+fn kdl_fmt_rewrites_unformatted_file() {
+    let root = unique_temp_dir("kdl-fmt-rewrite");
+    fs::create_dir_all(&root).expect("create temp dir");
+    let file_path = root.join("input.kdl");
+    fs::write(&file_path, "node\tkey=1\n").expect("write unformatted kdl");
+
+    let file = file_path.to_str().expect("path to str");
+    let output = run_cli(&["kdl", "fmt", file]);
+    assert!(
+        output.status.success(),
+        "format should succeed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let rewritten = fs::read_to_string(&file_path).expect("read formatted file");
+    assert!(rewritten.contains("node"));
+    assert!(rewritten.contains("key=1"));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn kdl_fmt_check_fails_when_file_needs_changes() {
+    let root = unique_temp_dir("kdl-fmt-check");
+    fs::create_dir_all(&root).expect("create temp dir");
+    let file_path = root.join("input.kdl");
+    fs::write(&file_path, "node\tkey=1\n").expect("write unformatted kdl");
+
+    let file = file_path.to_str().expect("path to str");
+    let output = run_cli(&["kdl", "fmt", "--check", file]);
+    assert!(
+        !output.status.success(),
+        "check should fail\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(String::from_utf8_lossy(&output.stderr).contains("would be reformatted"));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn kdl_fmt_diff_prints_unified_diff() {
+    let root = unique_temp_dir("kdl-fmt-diff");
+    fs::create_dir_all(&root).expect("create temp dir");
+    let file_path = root.join("input.kdl");
+    fs::write(&file_path, "node\tkey=1\n").expect("write unformatted kdl");
+
+    let file = file_path.to_str().expect("path to str");
+    let output = run_cli(&["kdl", "fmt", "--diff", file]);
+    assert!(
+        !output.status.success(),
+        "diff should fail with changes\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("---"));
+    assert!(stdout.contains("+++"));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn kdl_fmt_handles_arco_surface_syntax_file() {
+    let model_path = example_path("examples/dense-lp/input.kdl");
+    let model = model_path
+        .to_str()
+        .expect("example path contains invalid unicode");
+
+    let output = run_cli(&["kdl", "fmt", "--check", model]);
+    assert!(
+        !String::from_utf8_lossy(&output.stderr).contains("Failed to parse KDL document"),
+        "kdl fmt should parse arco surface syntax\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
 fn inspect_produces_valid_toml() {
     let model_path = example_path("examples/capacity-expansion/input.kdl");
     let model = model_path

--- a/crates/arco-cli/tests/example_cli_commands.rs
+++ b/crates/arco-cli/tests/example_cli_commands.rs
@@ -232,6 +232,28 @@ fn kdl_check_json_reports_included_file_path() {
 }
 
 #[test]
+fn print_model_succeeds_for_time_aliased_example() {
+    let model_path = example_path("examples/capacity-expansion/input.kdl");
+    let model = model_path
+        .to_str()
+        .expect("example path contains invalid unicode");
+
+    let output = run_cli(&["print-model", model]);
+    assert!(
+        output.status.success(),
+        "print-model should succeed for a model using `set time alias=\"t\"`\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("Min expansion_cost:"),
+        "expected algebraic model output\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
 fn kdl_fmt_rewrites_unformatted_file() {
     let root = unique_temp_dir("kdl-fmt-rewrite");
     fs::create_dir_all(&root).expect("create temp dir");

--- a/crates/arco-kdl/src/source/mod.rs
+++ b/crates/arco-kdl/src/source/mod.rs
@@ -7,4 +7,4 @@ mod surface;
 
 pub use ast::*;
 pub use error::*;
-pub use parser::{parse_program_file, parse_program_text};
+pub use parser::{format_program_text, parse_program_file, parse_program_text};

--- a/crates/arco-kdl/src/source/parser.rs
+++ b/crates/arco-kdl/src/source/parser.rs
@@ -14,7 +14,7 @@ use crate::source::parser_helpers::{
     property_string, unsupported_declaration_error,
 };
 use crate::source::surface::normalize_surface_syntax;
-use kdl::{KdlDocument, KdlNode, KdlValue};
+use kdl::{KdlDocument, KdlError, KdlNode, KdlValue};
 use miette::NamedSource;
 use std::fs;
 use std::path::Path;
@@ -88,6 +88,13 @@ pub fn parse_program_file(path: &Path) -> Result<ParsedSource, SourceError> {
     info!(path = %path.display(), status = "ok", "parsing source file");
     let base_dir = path.parent().unwrap_or_else(|| Path::new("."));
     parse_program_file_with_base(path, base_dir, true)
+}
+
+pub fn format_program_text(text: &str) -> Result<String, KdlError> {
+    let normalized = normalize_surface_syntax(text);
+    let mut document: KdlDocument = normalized.parse()?;
+    document.autoformat();
+    Ok(document.to_string())
 }
 
 pub fn parse_program_text(text: &str, path: &Path) -> Result<ParsedSource, SourceError> {

--- a/crates/arco-ops/src/compile/compile/expressions_domains.rs
+++ b/crates/arco-ops/src/compile/compile/expressions_domains.rs
@@ -141,28 +141,18 @@ fn reduction_domain_values(
         domain if program.is_time_set_name(domain) => Ok((1..=program.time_steps())
             .map(|time| FilterValue::Number(time as f64))
             .collect()),
-        _ => {
-            if let Some(set) = program.set_registry.get(domain) {
-                return Ok(set
-                    .values
+        _ => program
+            .resolve_set(domain)
+            .map(|set| {
+                set.values
                     .iter()
-                    .map(|v| FilterValue::String(v.clone()))
-                    .collect());
-            }
-            if let Some(canonical) = program.set_aliases.get(domain) {
-                if let Some(set) = program.set_registry.get(canonical.as_str()) {
-                    return Ok(set
-                        .values
-                        .iter()
-                        .map(|v| FilterValue::String(v.clone()))
-                        .collect());
-                }
-            }
-            Err(CompileError::InvalidFormulation {
+                    .map(|value| FilterValue::String(value.clone()))
+                    .collect()
+            })
+            .ok_or_else(|| CompileError::InvalidFormulation {
                 message: format!("unsupported reduction domain `{domain}`"),
                 path: entrypoint.to_path_buf(),
-            })
-        }
+            }),
     }
 }
 

--- a/crates/arco-ops/src/compile/semantic/types.rs
+++ b/crates/arco-ops/src/compile/semantic/types.rs
@@ -88,16 +88,29 @@ impl SemanticProgram {
             .is_some_and(|(candidate, time_set)| std::ptr::eq(candidate, time_set))
     }
 
-    fn time_set(&self) -> Option<&ResolvedSet> {
-        self.resolve_set("time").or_else(|| self.resolve_set("t"))
+    pub fn resolve_set(&self, name: &str) -> Option<&ResolvedSet> {
+        if let Some(set) = self.set_registry.get(name) {
+            return Some(set);
+        }
+        if let Some(set) = self
+            .set_aliases
+            .get(name)
+            .and_then(|canonical| self.set_registry.get(canonical.as_str()))
+        {
+            return Some(set);
+        }
+        for (alias, canonical) in &self.set_aliases {
+            if canonical == name {
+                if let Some(set) = self.set_registry.get(alias.as_str()) {
+                    return Some(set);
+                }
+            }
+        }
+        None
     }
 
-    fn resolve_set(&self, name: &str) -> Option<&ResolvedSet> {
-        self.set_registry.get(name).or_else(|| {
-            self.set_aliases
-                .get(name)
-                .and_then(|canonical| self.set_registry.get(canonical))
-        })
+    fn time_set(&self) -> Option<&ResolvedSet> {
+        self.resolve_set("time").or_else(|| self.resolve_set("t"))
     }
 }
 


### PR DESCRIPTION
## Summary
- add `arco kdl fmt` command inspired by Ruff formatter UX
- support `--check`, `--diff`, `--stdin`, and `--stdin-filename`
- format via Arco KDL surface normalization before KDL autoformat
- avoid scanning symlinked/heavy directories when formatting default paths
- add CLI regression tests for rewrite/check/diff and dense-lp surface syntax parse

## Validation
- cargo test -p arco-cli kdl_fmt_
