### PR TITLE
chore(ci): support release maintenance branches

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -14,6 +14,7 @@ on:
   push:
     branches:
       - main
+      - release-*
     paths:
       - "crates/**"
       - "Cargo.toml"
@@ -58,7 +59,8 @@ jobs:
 
       # Cache 1: rmon binary (saves ~20-40s avoiding git install)
       - name: Cache rmon binary
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        if: github.event_name != 'pull_request'
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5 # zizmor: ignore[cache-poisoning]
         id: rmon-cache
         with:
           path: ~/.local/bin/rmon
@@ -77,7 +79,8 @@ jobs:
           rust-cache-shared-key: rust-bench
       # Cache 3: Pre-built arco-cli binary (saves ~2-5min when Cargo.lock unchanged)
       - name: Cache arco-cli binary
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        if: github.event_name != 'pull_request'
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5 # zizmor: ignore[cache-poisoning]
         id: arco-binary-cache
         with:
           path: target/release/arco

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,7 @@ on:
   push:
     branches:
       - main
+      - release-*
     paths:
       - "crates/**"
       - "bindings/python/**"
@@ -66,6 +67,7 @@ jobs:
         env:
           GH_EVENT_NAME: ${{ github.event_name }}
           BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          REF_NAME: ${{ github.base_ref || github.ref_name }}
           HAS_BUILD_RELEASE_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'build:release') }}
           HAS_BUILD_SKIP_RELEASE_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'build:skip-release') }}
         run: |
@@ -76,7 +78,7 @@ jobs:
 
           base_sha="$BASE_SHA"
           if [[ -z "$base_sha" || "$base_sha" =~ ^0+$ ]]; then
-            base_sha="origin/main"
+            base_sha="origin/$REF_NAME"
           fi
 
           while IFS= read -r file; do

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -11,6 +11,7 @@ on:
   push:
     branches:
       - main
+      - release-*
     paths:
       - "docs/**"
       - "scripts/test_docs_doctest.py"

--- a/.github/workflows/kdl-examples-e2e.yaml
+++ b/.github/workflows/kdl-examples-e2e.yaml
@@ -13,6 +13,7 @@ on:
   push:
     branches:
       - main
+      - release-*
     paths:
       - "crates/arco-kdl/**"
       - "crates/arco-cli/**"

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - release-*
   workflow_dispatch:
 
 concurrency:
@@ -41,7 +42,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json
-          target-branch: main
+          target-branch: ${{ github.ref_name }}
 
   prepare-cargo-dist-release:
     name: Prepare cargo-dist release

--- a/.github/workflows/solver-integration.yaml
+++ b/.github/workflows/solver-integration.yaml
@@ -17,6 +17,7 @@ on:
   push:
     branches:
       - main
+      - release-*
     paths:
       - "crates/**"
       - "bindings/python/**"

--- a/.github/workflows/workflow-quality.yaml
+++ b/.github/workflows/workflow-quality.yaml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+      - release-*
     paths:
       - ".github/**"
 
@@ -31,6 +32,7 @@ jobs:
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "0.9.4"
+          enable-cache: false
 
       - name: Run zizmor
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,8 +45,9 @@ The repository ships GitHub Actions for package validation and release:
 
 - `CI` runs install/import smoke tests for built wheels across Python 3.10-3.14,
   validates source-distribution installation, and runs docs doctests.
-- `release-please` runs on `main`, manages release PRs, creates tags and draft
-  GitHub Releases, then dispatches `cargo-dist-release.yml` and publishes to PyPI.
+- `release-please` runs on `main` and `release-*` maintenance branches, manages
+  release PRs, creates tags and draft GitHub Releases, then dispatches
+  `cargo-dist-release.yml` and publishes to PyPI.
 - `cargo-dist-release.yml` builds CLI binaries and installers, uploads them to
   the draft GitHub Release, and publishes it.
 - Releases follow one platform version stream (`arco`) that updates workspace

--- a/RELEASE_POLICY.md
+++ b/RELEASE_POLICY.md
@@ -33,7 +33,7 @@ Every release version is shared across:
 
 | Workflow                 | Trigger                                                                               | Purpose                                                                                                                                   |
 | ------------------------ | ------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `release-please.yaml`    | `push` to `main`                                                                      | Maintains release PRs, creates tag + draft release, dispatches `cargo-dist-release.yml`, then builds and publishes Python package to PyPI |
+| `release-please.yaml`    | `push` to `main` and `release-*` maintenance branches                                 | Maintains release PRs, creates tag + draft release, dispatches `cargo-dist-release.yml`, then builds and publishes Python package to PyPI |
 | `cargo-dist-release.yml` | `workflow_dispatch` from `release-please.yaml` (with tag) or `pull_request` (dry-run) | Builds CLI artifacts via cargo-dist, uploads them to the draft release, and publishes it                                                  |
 
 ### Reusable workflow call
@@ -70,6 +70,20 @@ cargo-dist fails, nothing is published.
 
 `release-please` is the source of truth for release notes and changelog content.
 Changelog sections are configured in `.release-please-config.json`.
+
+## Maintenance Branches
+
+Arco supports maintenance release branches named `release-*` (for example
+`release-0.6`).
+
+- `main` is the next-development release lane.
+- A `release-*` branch is a patch-only maintenance lane for its version line.
+- `release-please.yaml` targets the branch it runs on, so each maintenance branch
+  reads its own branch-local `.release-please-config.json` and
+  `.release-please-manifest.json`.
+- Maintenance branches should usually cherry-pick only bug fixes and use an
+  `always-bump-patch` versioning strategy in their branch-local release-please
+  config.
 
 ## Failure Handling
 
@@ -111,7 +125,9 @@ release workflow before the release is made public.
 
 ## Forcing A Release Version
 
-Use `Release-As` only when an explicit one-off version override is necessary:
+Use `Release-As` only when an explicit one-off version override is necessary.
+It does not exclude already-merged features from the target branch's release
+contents:
 
 ```text
 chore(release): force 0.3.0


### PR DESCRIPTION
Closes: none

## Description

Add maintenance-branch support for release automation and branch-push CI.

- run release-related push workflows on `release-*`
- make `release-please` target the branch it runs on
- make CI diff planning fall back to the active branch instead of always `main`
- document the `release-*` maintenance branch model
- suppress known-safe zizmor cache-poisoning warnings where runtime caches are disabled on PRs

## Testing strategy

- `just workflow-quality`
- `actionlint` across `.github/workflows` (excluding autogenerated `release.yml` per repo convention)

## Related

- https://github.com/NatLabRockies/arco/pull/261
