### PR TITLE
fix(ci): limit PR Python matrix on release-0.6

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -224,7 +224,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ${{ fromJSON(github.event_name == 'pull_request' && '["3.12"]' || '["3.10", "3.11", "3.12", "3.13", "3.14"]') }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:


### PR DESCRIPTION
## Why
- `release-0.6` currently runs the full Python matrix on pull requests.
- We already want PR validation on the maintenance branch to use only Python 3.12.
- Keeping the full matrix on PRs makes maintenance-lane validation slower and more expensive.

## What changed
- Limit `pull_request` Python validation to `3.12` only.
- Keep the full Python matrix for non-PR events.

## Expected result
- PRs into `release-0.6` run a single Python validation job.
- Push/release-oriented validation can still exercise the wider matrix.
- Because this is a `fix(ci)` commit on the maintenance branch, merging it is a good small test that the `release-please` lane reacts on `release-0.6`.