### PR TITLE
fix(cli): pin homedir on release-0.6

### DIFF
--- a/crates/arco-cli/Cargo.toml
+++ b/crates/arco-cli/Cargo.toml
@@ -44,6 +44,7 @@ thiserror = "2.0"
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 axoupdater = { version = "0.9", default-features = false, features = ["github_releases"] }
+homedir = "=0.3.4"
 http = "1"
 owo-colors = "4"
 tokio = { version = "1", features = ["rt-multi-thread"] }


### PR DESCRIPTION
## Summary
- port the homedir pin that already exists on main onto release-0.6
- prevent fresh Windows release builds from resolving homedir 0.3.5 on Rust 1.85

## Root cause
- the Windows release job resolved `homedir 0.3.5`
- that version uses unstable let-chains and fails on Rust 1.85
- main already pins `homedir = "=0.3.4"`; maintenance branch was missing that pin

## Validation
- cargo tree -i homedir -p arco-cli
- just pre-commit-stage pre-push