### PR TITLE
chore(python): fix license files in source distributions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -570,6 +570,7 @@ package.json
 # End of https://www.toptal.com/developers/gitignore/api/c,vim,data,rust,venv,julia,linux,macos,python,windows,database,virtualenv,visualstudiocode,node
 
 # Generated during packaging from root licenses/
+bindings/python/BSD-3-Clause.txt
 bindings/python/licenses/
 
 # Local git worktrees

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -9,7 +9,7 @@ description = "Python bindings for Arco optimization library"
 readme = "README.md"
 requires-python = ">=3.9"
 license = { file = "licenses/BSD-3-Clause.txt" }
-license-files = ["licenses/HiGHS-MIT.txt"]
+license-files = ["licenses/*.txt"]
 authors = [{ name = "Arco maintainers" }]
 maintainers = [{ name = "pesap", email = "pesap@users.noreply.github.com" }]
 keywords = ["optimization", "linear-programming", "mixed-integer-programming"]
@@ -39,7 +39,7 @@ Changelog = "https://github.com/NatLabRockies/arco/releases"
 
 [tool.maturin]
 features = ["pyo3/extension-module"]
-include = ["arco/py.typed", "arco/arco.pyi", "arco/blocks.pyi"]
+include = ["arco/py.typed", "arco/arco.pyi", "arco/blocks.pyi", "BSD-3-Clause.txt"]
 python-source = "."
 
 [dependency-groups]

--- a/scripts/sync_python_licenses.py
+++ b/scripts/sync_python_licenses.py
@@ -15,8 +15,9 @@ def _repo_root() -> Path:
 
 def _sync_python_licenses(*, repo_root: Path) -> list[Path]:
     source_dir = repo_root / "licenses"
-    destination_dir = repo_root / "bindings" / "python" / "licenses"
-    destination_dir.mkdir(parents=True, exist_ok=True)
+    python_root = repo_root / "bindings" / "python"
+    license_dir = python_root / "licenses"
+    license_dir.mkdir(parents=True, exist_ok=True)
 
     copied: list[Path] = []
     for filename in LICENSE_FILENAMES:
@@ -25,9 +26,14 @@ def _sync_python_licenses(*, repo_root: Path) -> list[Path]:
             raise FileNotFoundError(
                 f"Required license file is missing: {source.as_posix()}"
             )
-        destination = destination_dir / filename
+        destination = license_dir / filename
         shutil.copy2(source, destination)
         copied.append(destination)
+
+        if filename == "BSD-3-Clause.txt":
+            root_destination = python_root / filename
+            shutil.copy2(source, root_destination)
+            copied.append(root_destination)
     return copied
 
 


### PR DESCRIPTION
## Summary
- extend the Python license sync script to copy the workspace BSD license into the Python package root before builds
- keep the existing workspace/package license metadata unchanged
- include the generated package-root BSD license in maturin sdists and ignore the generated copy locally

## Validation
- `uv run python scripts/sync_python_licenses.py`
- `uv run --project bindings/python --with maturin maturin sdist --manifest-path bindings/python/Cargo.toml --out <tmp>`
- inspected generated `arco-0.6.1.tar.gz` and confirmed all declared `License-File` entries exist in the archive

## CI failure reviewed
Run https://github.com/NatLabRockies/arco/actions/runs/25952163904 failed in `Publish to PyPI` because PyPI rejected `arco-0.6.1.tar.gz`: `License-File BSD-3-Clause.txt does not exist in distribution file`.
