### PR TITLE
refactor: address code quality audit findings

### DIFF
--- a/crates/arco-cli/src/debug_shell.rs
+++ b/crates/arco-cli/src/debug_shell.rs
@@ -191,21 +191,24 @@ fn build_ipython_script(path: &Path, model: &PythonModelData) -> String {
         path = format_python_string(&path.display().to_string()),
         num_constraints = model.constraint_names.len(),
         num_variables = model.variable_names.len(),
-        col_ptrs = format_python_usize_list(&model.col_ptrs),
-        row_indices = format_python_usize_list(&model.row_indices),
-        values = format_python_f64_list(&model.values),
-        var_lower = format_python_f64_list(&model.var_lower),
-        var_upper = format_python_f64_list(&model.var_upper),
-        con_lower = format_python_f64_list(&model.con_lower),
-        con_upper = format_python_f64_list(&model.con_upper),
-        is_integer = format_python_bool_list(&model.is_integer),
-        variable_names = format_python_string_list(&model.variable_names),
-        constraint_names = format_python_string_list(&model.constraint_names),
+        col_ptrs = format_python_list(&model.col_ptrs, |v| v.to_string()),
+        row_indices = format_python_list(&model.row_indices, |v| v.to_string()),
+        values = format_python_list(&model.values, |v| format_python_f64(*v)),
+        var_lower = format_python_list(&model.var_lower, |v| format_python_f64(*v)),
+        var_upper = format_python_list(&model.var_upper, |v| format_python_f64(*v)),
+        con_lower = format_python_list(&model.con_lower, |v| format_python_f64(*v)),
+        con_upper = format_python_list(&model.con_upper, |v| format_python_f64(*v)),
+        is_integer = format_python_list(&model.is_integer, |v| (if *v { "True" } else { "False" })
+            .to_string()),
+        variable_names = format_python_list(&model.variable_names, |v| format_python_string(v)),
+        constraint_names = format_python_list(&model.constraint_names, |v| format_python_string(v)),
         objective_sense = match model.objective_sense {
             ObjectiveSense::Minimize => "MINIMIZE",
             ObjectiveSense::Maximize => "MAXIMIZE",
         },
-        objective_terms = format_python_tuple_list(&model.objective_terms),
+        objective_terms = format_python_list(&model.objective_terms, |(index, coefficient)| {
+            format!("({}, {})", index, format_python_f64(*coefficient))
+        }),
         objective_name = format_python_string(&model.objective_name),
         objective_constant = format_python_f64(model.objective_constant),
     )
@@ -227,30 +230,6 @@ fn format_python_string(value: &str) -> String {
     }
     encoded.push('"');
     encoded
-}
-
-fn format_python_string_list(values: &[String]) -> String {
-    format_python_list(values, |value| format_python_string(value))
-}
-
-fn format_python_usize_list(values: &[usize]) -> String {
-    format_python_list(values, |value| value.to_string())
-}
-
-fn format_python_f64_list(values: &[f64]) -> String {
-    format_python_list(values, |value| format_python_f64(*value))
-}
-
-fn format_python_bool_list(values: &[bool]) -> String {
-    format_python_list(values, |value| {
-        (if *value { "True" } else { "False" }).to_string()
-    })
-}
-
-fn format_python_tuple_list(values: &[(usize, f64)]) -> String {
-    format_python_list(values, |(index, coefficient)| {
-        format!("({}, {})", index, format_python_f64(*coefficient))
-    })
 }
 
 fn format_python_list<T>(values: &[T], format_item: impl Fn(&T) -> String) -> String {

--- a/crates/arco-cli/src/driver.rs
+++ b/crates/arco-cli/src/driver.rs
@@ -1,5 +1,5 @@
 use crate::cli_io::{ColorMode, format_timed_status, style_bold_in_dim, style_error_label};
-use crate::config::{ConfigError, SolverConfigState, load_solver_config};
+use crate::config::{ConfigError, SolverConfigState};
 pub use crate::driver_kdl::{KdlCheckMode, KdlCheckOutcome, kdl_check_file_json};
 pub use crate::driver_summary::{
     DualReportSummary, DualReportValueSummary, ObjectiveSummary, ProblemCounts, ReportSummary,
@@ -130,65 +130,16 @@ impl Diagnostic for DriverError {
     }
 }
 
-fn load_resolved_selection() -> Result<ResolvedSelection, DriverError> {
-    Ok(load_solver_config()?.resolved)
-}
-
-fn selected_profile<'a>(
-    state: &'a SolverConfigState,
-    selection: &ResolvedSelection,
-) -> Option<&'a SolverProfile> {
-    selection
-        .profile
-        .as_ref()
-        .and_then(|name| state.merged_profiles.get(name))
-}
-
-pub fn run_file(path: &Path) -> Result<RunSummary, DriverError> {
-    run_file_with_options_and_selection(path, &RunOptions::default(), &load_resolved_selection()?)
-}
-
-pub fn run_file_with_options(path: &Path, options: &RunOptions) -> Result<RunSummary, DriverError> {
-    run_file_with_options_and_selection(path, options, &load_resolved_selection()?)
-}
-
-pub fn run_file_with_options_and_selection(
-    path: &Path,
-    options: &RunOptions,
-    selection: &ResolvedSelection,
-) -> Result<RunSummary, DriverError> {
-    run_file_with_options_and_profile(path, options, selection, None)
-}
-
-pub fn run_file_json(path: &Path) -> Result<String, DriverError> {
-    run_file_json_with_options_and_selection(
-        path,
-        &RunOptions::default(),
-        &load_resolved_selection()?,
-    )
-}
-
-pub fn run_file_json_with_options(
-    path: &Path,
-    options: &RunOptions,
-) -> Result<String, DriverError> {
-    run_file_json_with_options_and_selection(path, options, &load_resolved_selection()?)
-}
-
-pub fn run_file_json_with_options_and_selection(
-    path: &Path,
-    options: &RunOptions,
-    selection: &ResolvedSelection,
-) -> Result<String, DriverError> {
-    run_file_json_with_options_and_profile(path, options, selection, None)
-}
-
 pub fn run_file_json_with_options_and_config(
     path: &Path,
     options: &RunOptions,
     state: &SolverConfigState,
 ) -> Result<String, DriverError> {
-    let profile = selected_profile(state, &state.resolved);
+    let profile = state
+        .resolved
+        .profile
+        .as_ref()
+        .and_then(|name| state.merged_profiles.get(name));
     run_file_json_with_options_and_profile(path, options, &state.resolved, profile)
 }
 

--- a/crates/arco-cli/src/main.rs
+++ b/crates/arco-cli/src/main.rs
@@ -160,6 +160,8 @@ fn main() -> miette::Result<()> {
     let _ = miette::set_hook(Box::new(|_| {
         Box::new(miette::MietteHandlerOpts::new().build())
     }));
+    let stdout_is_terminal = std::io::stdout().is_terminal();
+    let color_mode = ColorMode::from(should_colorize_stdout(stdout_is_terminal));
     let validate_command = matches!(
         &cli.command,
         Command::Validate { .. }
@@ -188,10 +190,7 @@ fn main() -> miette::Result<()> {
                     filter_variable,
                     filter_asset,
                     solver_log: solver_log
-                        || should_log_solver_to_console(
-                            cli.verbose,
-                            std::io::stdout().is_terminal(),
-                        ),
+                        || should_log_solver_to_console(cli.verbose, stdout_is_terminal),
                 },
                 &solver_config,
             );
@@ -213,16 +212,12 @@ fn main() -> miette::Result<()> {
             write_stdout_line(&print_file_model(&path)?).into_diagnostic()?;
         }
         Command::Validate { path } => {
-            write_stdout_line(&validate_file_only(
-                &path,
-                ColorMode::from(should_colorize_stdout(std::io::stdout().is_terminal())),
-            )?)
-            .into_diagnostic()?;
+            write_stdout_line(&validate_file_only(&path, color_mode)?).into_diagnostic()?;
         }
         Command::Inspect { path, json } => {
             write_stdout_line(&inspect_file_report(&path, json)?).into_diagnostic()?;
         }
-        Command::Kdl { action } => handle_kdl_action(action)?,
+        Command::Kdl { action } => handle_kdl_action_with_color(action, color_mode)?,
         Command::Debug { path } => {
             launch_ipython(&path)?;
         }
@@ -238,7 +233,7 @@ fn main() -> miette::Result<()> {
     Ok(())
 }
 
-fn handle_kdl_action(action: KdlAction) -> miette::Result<()> {
+fn handle_kdl_action_with_color(action: KdlAction, color_mode: ColorMode) -> miette::Result<()> {
     match action {
         KdlAction::Check {
             path,
@@ -247,12 +242,8 @@ fn handle_kdl_action(action: KdlAction) -> miette::Result<()> {
         } => match format {
             CheckFormat::Text => {
                 let mode = kdl_check_mode(materialize_data);
-                write_stdout_line(&arco_cli::driver::validate_file(
-                    &path,
-                    ColorMode::from(should_colorize_stdout(std::io::stdout().is_terminal())),
-                    mode,
-                )?)
-                .into_diagnostic()?;
+                write_stdout_line(&arco_cli::driver::validate_file(&path, color_mode, mode)?)
+                    .into_diagnostic()?;
             }
             CheckFormat::Json => {
                 let outcome = kdl_check_file_json(&path, kdl_check_mode(materialize_data))?;

--- a/crates/arco-model/src/model/builder.rs
+++ b/crates/arco-model/src/model/builder.rs
@@ -89,24 +89,22 @@ impl Model {
     ///
     /// Returns an error if the model already has an objective.
     pub fn minimize(&mut self, expr: Expr) -> Result<(), ModelError> {
-        if self.objective.sense.is_some() {
-            return Err(ModelError::MultipleObjectives);
-        }
-        self.set_objective(Objective {
-            sense: Some(Sense::Minimize),
-            terms: expr.into_linear_terms(),
-        })
+        self.set_sense(expr, Sense::Minimize)
     }
 
     /// Maximize a linear expression.
     ///
     /// Returns an error if the model already has an objective.
     pub fn maximize(&mut self, expr: Expr) -> Result<(), ModelError> {
+        self.set_sense(expr, Sense::Maximize)
+    }
+
+    fn set_sense(&mut self, expr: Expr, sense: Sense) -> Result<(), ModelError> {
         if self.objective.sense.is_some() {
             return Err(ModelError::MultipleObjectives);
         }
         self.set_objective(Objective {
-            sense: Some(Sense::Maximize),
+            sense: Some(sense),
             terms: expr.into_linear_terms(),
         })
     }

--- a/crates/arco-ops/src/execution.rs
+++ b/crates/arco-ops/src/execution.rs
@@ -1899,6 +1899,32 @@ impl ConstrainedProblem for NonlinearIpoptProblem {
     }
 }
 
+/// Build Hessian sparsity lower-triangular pairs for a single tape, appending
+/// to the global `rows`/`cols` vectors and recording local index pairs in `pairs`.
+#[cfg(feature = "ipopt")]
+fn build_hessian_sparsity_pairs(
+    tape: &Tape,
+    rows: &mut Vec<Index>,
+    cols: &mut Vec<Index>,
+    pairs: &mut Vec<(u32, u32, u32)>,
+) {
+    if !tape.is_nonlinear {
+        return;
+    }
+    let local_n = tape.local_to_global.len();
+    for lj in 0..local_n {
+        for lk in lj..local_n {
+            let g_j = tape.local_to_global[lj];
+            let g_k = tape.local_to_global[lk];
+            let (row, col) = if g_j >= g_k { (g_j, g_k) } else { (g_k, g_j) };
+            let pos = rows.len() as u32;
+            rows.push(row as Index);
+            cols.push(col as Index);
+            pairs.push((lj as u32, lk as u32, pos));
+        }
+    }
+}
+
 #[cfg(feature = "ipopt")]
 #[allow(clippy::too_many_arguments)]
 fn solve_with_nonlinear_ipopt(
@@ -1984,38 +2010,17 @@ fn solve_with_nonlinear_ipopt(
     let mut hess_rows: Vec<Index> = Vec::new();
     let mut hess_cols: Vec<Index> = Vec::new();
     let mut obj_hess_pairs: Vec<(u32, u32, u32)> = Vec::new();
-    if objective_tape.is_nonlinear {
-        let local_n = objective_tape.local_to_global.len();
-        for lj in 0..local_n {
-            for lk in lj..local_n {
-                let g_j = objective_tape.local_to_global[lj];
-                let g_k = objective_tape.local_to_global[lk];
-                let (row, col) = if g_j >= g_k { (g_j, g_k) } else { (g_k, g_j) };
-                let pos = hess_rows.len() as u32;
-                hess_rows.push(row as Index);
-                hess_cols.push(col as Index);
-                obj_hess_pairs.push((lj as u32, lk as u32, pos));
-            }
-        }
-    }
+    build_hessian_sparsity_pairs(
+        &objective_tape,
+        &mut hess_rows,
+        &mut hess_cols,
+        &mut obj_hess_pairs,
+    );
     let mut constraint_hess_pairs: Vec<Vec<(u32, u32, u32)>> =
         Vec::with_capacity(constraint_tapes.len());
     for tape in &constraint_tapes {
         let mut pairs: Vec<(u32, u32, u32)> = Vec::new();
-        if tape.is_nonlinear {
-            let local_n = tape.local_to_global.len();
-            for lj in 0..local_n {
-                for lk in lj..local_n {
-                    let g_j = tape.local_to_global[lj];
-                    let g_k = tape.local_to_global[lk];
-                    let (row, col) = if g_j >= g_k { (g_j, g_k) } else { (g_k, g_j) };
-                    let pos = hess_rows.len() as u32;
-                    hess_rows.push(row as Index);
-                    hess_cols.push(col as Index);
-                    pairs.push((lj as u32, lk as u32, pos));
-                }
-            }
-        }
+        build_hessian_sparsity_pairs(tape, &mut hess_rows, &mut hess_cols, &mut pairs);
         constraint_hess_pairs.push(pairs);
     }
 


### PR DESCRIPTION
## Summary

Five cleanups across the codebase from a systematic audit:

- **schema.rs**: Production `.unwrap()` on `Option` → proper error (file later deleted upstream, handled in rebase)
- **builder.rs**: Deduplicated `minimize`/`maximize` → shared `set_sense()`
- **debug_shell.rs**: Removed 5 thin format-list wrappers, inlined calls
- **driver.rs**: Collapsed 5-deep `run_file*` wrapper chain, removed dead helpers
- **main.rs**: Cached `stdout_is_terminal`/`color_mode` once, eliminated redundant ioctl calls
- **execution.rs**: Extracted `build_hessian_sparsity_pairs()`, deduped Hessian building

## Validation

- `cargo fmt --all -- --check` ✅
- `cargo clippy --workspace --exclude xpress/ipopt/python -- -D warnings` ✅
- `cargo test --workspace` ✅ (all 260+ tests pass)
- `uv run python scripts/check_architecture.py` ✅

## Stats

67 lines added, 143 lines removed across 5 files.