### PR TITLE
fix(xpress): ship Xpress in default Python builds

### DIFF
--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -25,7 +25,7 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
 
 [features]
-default = []
+default = ["xpress"]
 ipopt = ["arco-ops/ipopt"]
 xpress = ["arco-ops/xpress"]
 

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -12,6 +12,10 @@ uv sync --group dev
 uv run --with maturin maturin develop
 ```
 
+Default Python builds include the runtime-loaded Xpress backend. Solving with
+`arco.Xpress(...)` still requires the FICO Xpress runtime and a valid license on
+the target machine.
+
 To enable the IPOPT nonlinear backend, build with the `ipopt` feature (requires
 a system IPOPT install):
 
@@ -20,14 +24,15 @@ cd bindings/python
 uv run --with maturin maturin develop --features ipopt
 ```
 
-To enable the Xpress backend in Python bindings, build with `xpress`:
+To disable Xpress for a source build, turn off default Cargo features:
 
 ```bash
 cd bindings/python
-uv run --with maturin maturin develop --features xpress
+uv run --with maturin maturin develop --no-default-features --features pyo3/extension-module
 ```
 
-Without this feature, `arco.Xpress(...)` is importable but solve will fail fast with a rebuild hint.
+Without this feature, `arco.Xpress(...)` is importable but solve will fail fast
+with a rebuild hint.
 
 Run linting:
 

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -38,7 +38,7 @@ Issues = "https://github.com/NatLabRockies/arco/issues"
 Changelog = "https://github.com/NatLabRockies/arco/releases"
 
 [tool.maturin]
-features = ["pyo3/extension-module"]
+features = ["pyo3/extension-module", "xpress"]
 include = ["arco/py.typed", "arco/arco.pyi", "arco/blocks.pyi", "BSD-3-Clause.txt"]
 python-source = "."
 

--- a/bindings/python/tests/test_rust_boundaries.py
+++ b/bindings/python/tests/test_rust_boundaries.py
@@ -31,6 +31,14 @@ def test_python_cargo_depends_on_shared_public_contracts_only_among_arco_crates(
         assert forbidden not in cargo_toml
 
 
+def test_python_package_builds_with_xpress_support_by_default() -> None:
+    cargo_manifest = tomllib.loads((PYTHON_CRATE / "Cargo.toml").read_text())
+    pyproject = tomllib.loads((PYTHON_CRATE / "pyproject.toml").read_text())
+
+    assert "xpress" in cargo_manifest["features"]["default"]
+    assert "xpress" in pyproject["tool"]["maturin"]["features"]
+
+
 def test_cli_cargo_depends_on_arco_ops_only_among_arco_modeling_crates() -> None:
     cargo_toml = (ROOT / "crates" / "arco-cli" / "Cargo.toml").read_text()
 

--- a/docs/how-to/configure-solver.md
+++ b/docs/how-to/configure-solver.md
@@ -138,8 +138,10 @@ backend uses its own default.
 
 ## Xpress (LP / MIP solver)
 
-The Xpress backend is available when Arco is built with the `xpress` feature
-flag. Xpress supports LP, MIP, and QP problems.
+The Xpress backend is included in prebuilt Arco binaries and default Python
+package builds. Rust source builds that opt out of release/default packaging can
+still enable it with the `xpress` feature flag. Xpress supports LP, MIP, and QP
+problems.
 
 > [!IMPORTANT]
 > Xpress requires the FICO Xpress Optimizer SDK installed locally.
@@ -147,8 +149,9 @@ flag. Xpress supports LP, MIP, and QP problems.
 ### Setup at a glance
 
 1. Install Xpress Community Edition from [fico.com](https://www.fico.com/en/products/fico-xpress-optimization).
-2. If you installed Arco from a prebuilt binary, skip build steps and only configure environment variables.
-3. If you build Arco yourself, build with `--features xpress`.
+2. If you installed Arco from a prebuilt binary or the default Python package,
+   skip build steps and only configure environment variables.
+3. If you build the Rust CLI yourself, build with `--features xpress`.
 4. Run `arco solver set xpress` and verify with `arco solver show`.
 
 ### Platform setup
@@ -168,7 +171,7 @@ Build:
 # Optional when not in an auto-detected location
 export XPRESSDIR="$HOME/opt/xpressmp"
 cargo build --features xpress
-uv run --project bindings/python --with maturin maturin develop --features xpress
+uv run --project bindings/python --with maturin maturin develop
 ```
 
 </details>
@@ -184,7 +187,7 @@ Build:
 # Optional when not in an auto-detected location
 export XPRESSDIR="/opt/xpressmp"
 cargo build --features xpress
-uv run --project bindings/python --with maturin maturin develop --features xpress
+uv run --project bindings/python --with maturin maturin develop
 ```
 
 </details>
@@ -204,7 +207,7 @@ Build:
 ```powershell
 $env:XPRESSDIR = "C:\xpressmp"
 cargo build --features xpress
-uv run --project bindings/python --with maturin maturin develop --features xpress
+uv run --project bindings/python --with maturin maturin develop
 ```
 
 </details>
@@ -299,9 +302,12 @@ arco solver show
 
 </details>
 
-### Build with Xpress support (source builds only)
+### Build with Xpress support (Rust CLI source builds only)
 
-Use the OS-specific toggle blocks in [Platform setup](#platform-setup).
+Use the OS-specific toggle blocks in [Platform setup](#platform-setup) when
+building the Rust CLI from source. Python source builds include Xpress by
+default; pass `--no-default-features` only when you intentionally need a Python
+extension without Xpress support.
 
 <details>
 <summary>macOS quick smoke test directly from DMG (no copy needed)</summary>

--- a/justfile
+++ b/justfile
@@ -74,7 +74,7 @@ kdl-overlay-check:
 
 [group: 'python']
 py-build-ci: py-licenses
-    uv run --project bindings/python --with maturin maturin build --release --manifest-path bindings/python/Cargo.toml --features xpress -i ${PYTHON_WHEEL_INTERPRETER:-python3} --compatibility pypi --out dist
+    uv run --project bindings/python --with maturin maturin build --release --manifest-path bindings/python/Cargo.toml -i ${PYTHON_WHEEL_INTERPRETER:-python3} --compatibility pypi --out dist
     uv run --project bindings/python --with maturin maturin sdist --manifest-path bindings/python/Cargo.toml --out dist
 
 [group: 'python']


### PR DESCRIPTION
## Summary

- Enable the `xpress` feature by default for the `arco-python` crate and maturin package builds.
- Make `just py-build-ci` exercise the default Python package path instead of forcing `--features xpress`.
- Add a regression test for default Xpress packaging and update Python/solver documentation for runtime and opt-out behavior.

## Why

The Xpress adapter already resolves the proprietary runtime dynamically, so Python wheels and source builds can ship the backend by default without requiring the SDK at build time. Users still need the FICO Xpress runtime and license to solve with `arco.Xpress(...)`.

## Validation

- `uv run --project bindings/python --with pytest pytest bindings/python/tests/test_rust_boundaries.py::test_python_package_builds_with_xpress_support_by_default -q`
- `uv run --project bindings/python --with pytest pytest bindings/python/tests/test_xpress.py -q` (skipped locally because no Xpress runtime is installed)
- `just py-build-ci`
- `just py-smoke-wheel "dist/*.whl"`
- Push pre-push hooks: `pytest (quick)`, `typos`, `py type`
