### PR TITLE
fix: resolve zizmor template-injection findings in release workflows

### DIFF
--- a/.github/workflows/pypi-manual-release.yaml
+++ b/.github/workflows/pypi-manual-release.yaml
@@ -67,10 +67,12 @@ jobs:
 
       - name: Build wheel
         shell: bash
+        env:
+          DEFAULT_WHEEL_PYTHON: ${{ matrix.wheel_python }}
         run: |
           set -euo pipefail
           just py-licenses
-          uv run --project bindings/python --with maturin maturin build --release --manifest-path bindings/python/Cargo.toml -i "${PYTHON_WHEEL_INTERPRETER:-${{ matrix.wheel_python }}}" --compatibility pypi --out dist
+          uv run --project bindings/python --with maturin maturin build --release --manifest-path bindings/python/Cargo.toml -i "${PYTHON_WHEEL_INTERPRETER:-$DEFAULT_WHEEL_PYTHON}" --compatibility pypi --out dist
 
       - name: Build sdist (linux only)
         if: matrix.build_sdist

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -154,10 +154,12 @@ jobs:
 
       - name: Build wheel
         shell: bash
+        env:
+          DEFAULT_WHEEL_PYTHON: ${{ matrix.wheel_python }}
         run: |
           set -euo pipefail
           just py-licenses
-          uv run --project bindings/python --with maturin maturin build --release --manifest-path bindings/python/Cargo.toml -i "${PYTHON_WHEEL_INTERPRETER:-${{ matrix.wheel_python }}}" --compatibility pypi --out dist
+          uv run --project bindings/python --with maturin maturin build --release --manifest-path bindings/python/Cargo.toml -i "${PYTHON_WHEEL_INTERPRETER:-$DEFAULT_WHEEL_PYTHON}" --compatibility pypi --out dist
 
       - name: Build sdist (linux only)
         if: matrix.build_sdist


### PR DESCRIPTION
## Summary
- fix zizmor template-injection findings in workflow shell command interpolation
- move matrix interpreter value into step env and reference it from bash fallback
- apply the same hardening to both `.github/workflows/pypi-manual-release.yaml` and `.github/workflows/release-please.yaml`

## Validation
- local: ran the same `uvx zizmor --pedantic ...` audit used by workflow-quality; no findings
- push hooks: `zizmor` and `actionlint` both passed

Fixes failing run: https://github.com/NatLabRockies/arco/actions/runs/26661480890/job/78584829071
