### PR TITLE
fix: harden PyPI release wheel jobs for zizmor and windows

### DIFF
--- a/.github/workflows/pypi-manual-release.yaml
+++ b/.github/workflows/pypi-manual-release.yaml
@@ -65,7 +65,8 @@ jobs:
           save-rust-cache: "false"
           save-uv-cache: "false"
 
-      - name: Build wheel
+      - name: Build wheel (linux)
+        if: runner.os != 'Windows'
         shell: bash
         env:
           DEFAULT_WHEEL_PYTHON: ${{ matrix.wheel_python }}
@@ -73,6 +74,18 @@ jobs:
           set -euo pipefail
           just py-licenses
           uv run --project bindings/python --with maturin maturin build --release --manifest-path bindings/python/Cargo.toml -i "${PYTHON_WHEEL_INTERPRETER:-$DEFAULT_WHEEL_PYTHON}" --compatibility pypi --out dist
+
+      - name: Build wheel (windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        env:
+          DEFAULT_WHEEL_PYTHON: ${{ matrix.wheel_python }}
+        run: |
+          if (-not $env:PYTHON_WHEEL_INTERPRETER) {
+            $env:PYTHON_WHEEL_INTERPRETER = $env:DEFAULT_WHEEL_PYTHON
+          }
+          uv run python scripts/sync_python_licenses.py
+          uv run --project bindings/python --with maturin maturin build --release --manifest-path bindings/python/Cargo.toml -i "$env:PYTHON_WHEEL_INTERPRETER" --compatibility pypi --out dist
 
       - name: Build sdist (linux only)
         if: matrix.build_sdist

--- a/.github/workflows/pypi-manual-release.yaml
+++ b/.github/workflows/pypi-manual-release.yaml
@@ -67,10 +67,12 @@ jobs:
 
       - name: Build wheel
         shell: bash
+        env:
+          DEFAULT_WHEEL_PYTHON: ${{ matrix.wheel_python }}
         run: |
           set -euo pipefail
           just py-licenses
-          uv run --project bindings/python --with maturin maturin build --release --manifest-path bindings/python/Cargo.toml -i "${PYTHON_WHEEL_INTERPRETER:-${{ matrix.wheel_python }}}" --compatibility pypi --out dist
+          uv run --project bindings/python --with maturin maturin build --release --manifest-path bindings/python/Cargo.toml -i "${PYTHON_WHEEL_INTERPRETER:-$DEFAULT_WHEEL_PYTHON}" --compatibility pypi --out dist
 
       - name: Build sdist (linux only)
         if: matrix.build_sdist

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -152,7 +152,8 @@ jobs:
           save-rust-cache: "false"
           save-uv-cache: "false"
 
-      - name: Build wheel
+      - name: Build wheel (linux)
+        if: runner.os != 'Windows'
         shell: bash
         env:
           DEFAULT_WHEEL_PYTHON: ${{ matrix.wheel_python }}
@@ -160,6 +161,18 @@ jobs:
           set -euo pipefail
           just py-licenses
           uv run --project bindings/python --with maturin maturin build --release --manifest-path bindings/python/Cargo.toml -i "${PYTHON_WHEEL_INTERPRETER:-$DEFAULT_WHEEL_PYTHON}" --compatibility pypi --out dist
+
+      - name: Build wheel (windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        env:
+          DEFAULT_WHEEL_PYTHON: ${{ matrix.wheel_python }}
+        run: |
+          if (-not $env:PYTHON_WHEEL_INTERPRETER) {
+            $env:PYTHON_WHEEL_INTERPRETER = $env:DEFAULT_WHEEL_PYTHON
+          }
+          uv run python scripts/sync_python_licenses.py
+          uv run --project bindings/python --with maturin maturin build --release --manifest-path bindings/python/Cargo.toml -i "$env:PYTHON_WHEEL_INTERPRETER" --compatibility pypi --out dist
 
       - name: Build sdist (linux only)
         if: matrix.build_sdist

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -154,10 +154,12 @@ jobs:
 
       - name: Build wheel
         shell: bash
+        env:
+          DEFAULT_WHEEL_PYTHON: ${{ matrix.wheel_python }}
         run: |
           set -euo pipefail
           just py-licenses
-          uv run --project bindings/python --with maturin maturin build --release --manifest-path bindings/python/Cargo.toml -i "${PYTHON_WHEEL_INTERPRETER:-${{ matrix.wheel_python }}}" --compatibility pypi --out dist
+          uv run --project bindings/python --with maturin maturin build --release --manifest-path bindings/python/Cargo.toml -i "${PYTHON_WHEEL_INTERPRETER:-$DEFAULT_WHEEL_PYTHON}" --compatibility pypi --out dist
 
       - name: Build sdist (linux only)
         if: matrix.build_sdist


### PR DESCRIPTION
## Summary
- fix zizmor template-injection findings by moving matrix fallback into step env
- avoid `just py-licenses` on Windows wheel jobs (which uses bash/WSL), and run the license sync script directly in `pwsh`
- apply both fixes to:
  - `.github/workflows/pypi-manual-release.yaml`
  - `.github/workflows/release-please.yaml`

## Validation
- local `uvx zizmor --pedantic` against workflows: no findings
- pre-push hooks passed: `zizmor`, `actionlint`

Fixes workflow failure:
https://github.com/NatLabRockies/arco/actions/runs/26661480890/job/78584829071
