### PR TITLE
fix(vscode): add KDL helper extension

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,6 +67,7 @@ jobs:
       benchmarks: ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.benchmarks == 'true' }}
       release: ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.release == 'true' }}
       github_actions: ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.github_actions == 'true' }}
+      vscode_extension: ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.vscode_extension == 'true' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -119,6 +120,8 @@ jobs:
               - '.github/workflows/**'
               - '.github/build-setup.yml'
               - '.github/dependabot.yml'
+            vscode_extension:
+              - 'tools/vscode-arco-kdl/**'
 
       - name: Print CI plan
         env:
@@ -130,7 +133,31 @@ jobs:
           BENCHMARKS: ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.benchmarks == 'true' }}
           RELEASE: ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.release == 'true' }}
           ACTIONS_CONFIG: ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.github_actions == 'true' }}
+          VSCODE_EXTENSION: ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.vscode_extension == 'true' }}
         run: bash scripts/ci-plan.sh
+
+  vscode-extension:
+    name: VS Code extension
+    needs: [ci-plan]
+    if: needs.ci-plan.outputs.vscode_extension == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: "22"
+          package-manager-cache: false
+
+      - name: Check and package VS Code extension
+        working-directory: tools/vscode-arco-kdl
+        run: |
+          set -euo pipefail
+          npm run check
+          npm run package
 
   cargo-dist:
     name: cargo-dist workflow

--- a/scripts/ci-plan.sh
+++ b/scripts/ci-plan.sh
@@ -21,10 +21,12 @@ append_bucket_name() {
 
 enabled_buckets=""
 skipped_buckets=""
-for bucket in RUST PYTHON DOCS SOLVER KDL BENCHMARKS RELEASE ACTIONS_CONFIG; do
+for bucket in RUST PYTHON DOCS SOLVER KDL BENCHMARKS RELEASE ACTIONS_CONFIG VSCODE_EXTENSION; do
   label="$bucket"
   if [[ "$bucket" == "ACTIONS_CONFIG" ]]; then
     label="GITHUB_ACTIONS"
+  elif [[ "$bucket" == "VSCODE_EXTENSION" ]]; then
+    label="VS_CODE_EXTENSION"
   fi
 
   if bucket_enabled "$bucket"; then
@@ -68,6 +70,8 @@ release_or_actions_enabled="false"
 if bucket_enabled RELEASE || bucket_enabled ACTIONS_CONFIG; then
   release_or_actions_enabled="true"
 fi
+vscode_extension_enabled="false"
+bucket_enabled VSCODE_EXTENSION && vscode_extension_enabled="true"
 cli_build_enabled="false"
 if bucket_enabled RUST || bucket_enabled SOLVER || bucket_enabled KDL || bucket_enabled BENCHMARKS; then
   cli_build_enabled="true"
@@ -85,6 +89,7 @@ fi
   echo ''
   echo '| Job | Decision | Reason |'
   echo '|---|---|---|'
+  job_decision 'VS Code extension' "$vscode_extension_enabled" 'VS Code extension inputs changed' 'VS Code extension inputs unchanged'
   job_decision 'cargo-dist workflow' "$release_or_actions_enabled" 'release or GitHub Actions inputs changed' 'release and GitHub Actions inputs unchanged'
   job_decision 'Rust format check' "$rust_enabled" 'Rust bucket enabled' 'Rust bucket disabled'
   job_decision 'Rust clippy (all-features)' "$rust_enabled" 'Rust bucket enabled' 'Rust bucket disabled'

--- a/tools/vscode-arco-kdl/README.md
+++ b/tools/vscode-arco-kdl/README.md
@@ -20,7 +20,7 @@ The extension does not implement a second KDL parser. The Rust parser in
 
 Prerequisites:
 
-- VS Code with the `code` command available on PATH
+- VS Code with the `code` command available on PATH, or set `VSCODE_CLI` to the CLI path on systems where it is not named `code`
 - Node.js/npm
 - arco CLI available by one of these methods:
   - installed on PATH as `arco`
@@ -28,6 +28,8 @@ Prerequisites:
   - built in this workspace at `target/debug/arco` or `target/release/arco`
 
 One-command local install:
+
+This works on macOS, Linux, and Windows.
 
 ```sh
 cd tools/vscode-arco-kdl
@@ -38,6 +40,13 @@ If VS Code's CLI is not named `code`, set `VSCODE_CLI`:
 
 ```sh
 VSCODE_CLI="/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code" npm run install:local
+```
+
+On Windows PowerShell, for example:
+
+```powershell
+$env:VSCODE_CLI = "C:\\Program Files\\Microsoft VS Code\\bin\\code.cmd"
+npm run install:local
 ```
 
 Manual install:

--- a/tools/vscode-arco-kdl/extension.js
+++ b/tools/vscode-arco-kdl/extension.js
@@ -19,6 +19,8 @@ const COMMANDS = {
 let extensionContext;
 let missingCommandWarningShown = false;
 const activeValidations = new Map();
+const activeDiagnosticUris = new Map();
+const diagnosticReportsByUri = new Map();
 
 function activate(context) {
   extensionContext = context;
@@ -39,6 +41,10 @@ function activate(context) {
     ),
     vscode.commands.registerCommand(COMMANDS.showSetup, showSetupDocument),
     vscode.workspace.onDidOpenTextDocument(validateOpenDocument),
+    vscode.workspace.onDidCloseTextDocument((document) => {
+      if (isArcoKdlDocument(document))
+        clearDocumentDiagnostics(document, diagnostics);
+    }),
     vscode.workspace.onDidSaveTextDocument((document) => {
       if (configuration().get("validateOnSave", true))
         validateOpenDocument(document);
@@ -87,7 +93,7 @@ function isArcoKdlDocument(document) {
 
 function validateDocument(document, diagnostics) {
   if (document.isUntitled) {
-    diagnostics.delete(document.uri);
+    clearDocumentDiagnostics(document, diagnostics);
     return;
   }
 
@@ -101,7 +107,8 @@ function validateDocument(document, diagnostics) {
     [...CHECK_ARGS, document.fileName, ...JSON_FORMAT_ARGS],
     {
       cwd: workspaceDirectory(document),
-      shell: false,
+      shell:
+        process.platform === "win32" && isWindowsCommandShim(command),
     },
   );
   activeValidations.set(uri, { child, version });
@@ -120,8 +127,11 @@ function validateDocument(document, diagnostics) {
     if (activeValidations.get(uri)?.child !== child) return;
     spawnFailed = true;
     activeValidations.delete(uri);
-    diagnostics.set(document.uri, [
-      commandFailureDiagnostic(document, command, error.message),
+    setDocumentDiagnostics(document, diagnostics, [
+      {
+        uri: document.uri,
+        diagnostic: commandFailureDiagnostic(document, command, error.message),
+      },
     ]);
     if (!missingCommandWarningShown && error.code === "ENOENT") {
       missingCommandWarningShown = true;
@@ -135,14 +145,22 @@ function validateDocument(document, diagnostics) {
 
     const report = parseReport(stdout);
     if (!isKdlCheckReport(report)) {
-      diagnostics.set(document.uri, [
-        invalidOutputDiagnostic(document, command, stderr),
+      setDocumentDiagnostics(document, diagnostics, [
+        {
+          uri: document.uri,
+          diagnostic: invalidOutputDiagnostic(document, command, stderr),
+        },
       ]);
       return;
     }
-    diagnostics.set(
-      document.uri,
-      report.diagnostics.map((item) => toVsCodeDiagnostic(document, item)),
+
+    setDocumentDiagnostics(
+      document,
+      diagnostics,
+      report.diagnostics.map((item) => ({
+        uri: diagnosticUri(document, item),
+        diagnostic: toVsCodeDiagnostic(item),
+      })),
     );
   });
 }
@@ -193,6 +211,12 @@ function candidateExecutableNames(command, extensions) {
   ];
 }
 
+function isWindowsCommandShim(command) {
+  if (process.platform !== "win32") return false;
+  const extension = path.extname(command).toLowerCase();
+  return extension === ".cmd" || extension === ".bat";
+}
+
 function isExecutableFile(candidate) {
   try {
     fs.accessSync(candidate, fs.constants.X_OK);
@@ -232,9 +256,36 @@ function isKdlDiagnostic(diagnostic) {
   );
 }
 
-function toVsCodeDiagnostic(document, diagnostic) {
+function diagnosticUri(document, diagnostic) {
+  if (typeof diagnostic.file === "string" && diagnostic.file.trim()) {
+    const baseDirectory =
+      workspaceDirectory(document) ?? path.dirname(document.fileName);
+    return vscode.Uri.file(path.resolve(baseDirectory, diagnostic.file)).with({
+      scheme: document.uri.scheme,
+      authority: document.uri.authority,
+    });
+  }
+  return document.uri;
+}
+
+function diagnosticRange(diagnostic) {
+  if (
+    !Number.isInteger(diagnostic.line) ||
+    !Number.isInteger(diagnostic.column)
+  ) {
+    const start = new vscode.Position(0, 0);
+    return new vscode.Range(start, start.translate(0, 1));
+  }
+
+  const line = Math.max(diagnostic.line - 1, 0);
+  const column = Math.max(diagnostic.column - 1, 0);
+  const start = new vscode.Position(line, column);
+  return new vscode.Range(start, start.translate(0, 1));
+}
+
+function toVsCodeDiagnostic(diagnostic) {
   const item = new vscode.Diagnostic(
-    diagnosticRange(document, diagnostic),
+    diagnosticRange(diagnostic),
     diagnostic.message,
     diagnostic.severity === "warning"
       ? vscode.DiagnosticSeverity.Warning
@@ -245,19 +296,95 @@ function toVsCodeDiagnostic(document, diagnostic) {
   return item;
 }
 
-function diagnosticRange(document, diagnostic) {
-  if (
-    !Number.isInteger(diagnostic.line) ||
-    !Number.isInteger(diagnostic.column)
-  ) {
-    return document.lineAt(0).range;
+function setDocumentDiagnostics(document, diagnostics, records) {
+  const sourceUri = document.uri.toString();
+  const previousUris = activeDiagnosticUris.get(sourceUri) ?? new Set();
+  const grouped = new Map();
+
+  for (const record of records) {
+    const uri = record.uri.toString();
+    const current = grouped.get(uri) ?? [];
+    current.push(record.diagnostic);
+    grouped.set(uri, current);
   }
 
-  const line = Math.max(diagnostic.line - 1, 0);
-  const column = Math.max(diagnostic.column - 1, 0);
-  const range = document.lineAt(Math.min(line, document.lineCount - 1)).range;
-  const start = range.start.translate(0, Math.min(column, range.end.character));
-  return new vscode.Range(start, start.translate(0, 1));
+  const nextUris = new Set(grouped.keys());
+
+  for (const uri of previousUris) {
+    if (nextUris.has(uri)) continue;
+    const sourceReports = diagnosticReportsByUri.get(uri);
+    if (!sourceReports) continue;
+    sourceReports.delete(sourceUri);
+    if (sourceReports.size === 0) {
+      diagnosticReportsByUri.delete(uri);
+    }
+    publishDiagnostics(diagnostics, uri);
+  }
+
+  for (const [uri, items] of grouped) {
+    const sourceReports = diagnosticReportsByUri.get(uri) ?? new Map();
+    sourceReports.set(sourceUri, items);
+    diagnosticReportsByUri.set(uri, sourceReports);
+    publishDiagnostics(diagnostics, uri);
+  }
+
+  activeDiagnosticUris.set(sourceUri, nextUris);
+}
+
+function clearDocumentDiagnostics(document, diagnostics) {
+  const sourceUri = document.uri.toString();
+  const activeValidation = activeValidations.get(sourceUri);
+  if (activeValidation) {
+    activeValidation.child.kill();
+    activeValidations.delete(sourceUri);
+  }
+
+  const previousUris = activeDiagnosticUris.get(sourceUri) ?? new Set();
+  for (const uri of previousUris) {
+    const sourceReports = diagnosticReportsByUri.get(uri);
+    if (!sourceReports) continue;
+    sourceReports.delete(sourceUri);
+    if (sourceReports.size === 0) {
+      diagnosticReportsByUri.delete(uri);
+    }
+    publishDiagnostics(diagnostics, uri);
+  }
+  activeDiagnosticUris.delete(sourceUri);
+}
+
+function publishDiagnostics(diagnostics, uri) {
+  const sourceReports = diagnosticReportsByUri.get(uri);
+  if (!sourceReports || sourceReports.size === 0) {
+    diagnosticReportsByUri.delete(uri);
+    diagnostics.delete(vscode.Uri.parse(uri));
+    return;
+  }
+
+  const combined = [];
+  const seen = new Set();
+  for (const items of sourceReports.values()) {
+    for (const diagnostic of items) {
+      const key = diagnosticKey(diagnostic);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      combined.push(diagnostic);
+    }
+  }
+
+  diagnostics.set(vscode.Uri.parse(uri), combined);
+}
+
+function diagnosticKey(diagnostic) {
+  return [
+    diagnostic.range.start.line,
+    diagnostic.range.start.character,
+    diagnostic.range.end.line,
+    diagnostic.range.end.character,
+    diagnostic.message,
+    diagnostic.severity,
+    diagnostic.code ?? "",
+    diagnostic.source ?? "",
+  ].join("|");
 }
 
 function commandFailureDiagnostic(document, command, message) {

--- a/tools/vscode-arco-kdl/package.json
+++ b/tools/vscode-arco-kdl/package.json
@@ -32,6 +32,7 @@
     "onCommand:arcoKdl.selectCheckCommand",
     "onCommand:arcoKdl.showSetup"
   ],
+  "extensionKind": ["workspace"],
   "main": "./extension.js",
   "contributes": {
     "languages": [
@@ -91,7 +92,7 @@
   },
   "scripts": {
     "check": "node --check extension.js && node --check scripts/install-local.js",
-    "package": "npx --yes @vscode/vsce package --no-dependencies",
+    "package": "npx --yes @vscode/vsce@3.9.1 package --no-dependencies",
     "install:local": "npm run package && node scripts/install-local.js"
   }
 }

--- a/tools/vscode-arco-kdl/scripts/install-local.js
+++ b/tools/vscode-arco-kdl/scripts/install-local.js
@@ -14,9 +14,14 @@ if (!fs.existsSync(vsix)) {
   process.exit(1);
 }
 
-const codeCommand = process.env.VSCODE_CLI || 'code';
+const rawCodeCommand = process.env.VSCODE_CLI || 'code';
+const codeCommand =
+  process.platform === 'win32'
+    ? resolveWindowsCommand(rawCodeCommand) ?? rawCodeCommand
+    : rawCodeCommand;
 const result = spawnSync(codeCommand, ['--install-extension', vsix, '--force'], {
   stdio: 'inherit',
+  shell: process.platform === 'win32' && isWindowsCommandShim(codeCommand),
 });
 
 if (result.error) {
@@ -26,3 +31,53 @@ if (result.error) {
 }
 
 process.exit(result.status ?? 1);
+
+function resolveWindowsCommand(command) {
+  if (isExecutableFile(command)) return command;
+
+  const extensions = (process.env.PATHEXT || '.EXE;.CMD;.BAT').split(';');
+
+  for (const extension of extensions) {
+    const lowerCandidate = `${command}${extension.toLowerCase()}`;
+    if (isExecutableFile(lowerCandidate)) return lowerCandidate;
+
+    const upperCandidate = `${command}${extension.toUpperCase()}`;
+    if (isExecutableFile(upperCandidate)) return upperCandidate;
+  }
+
+  const paths = (process.env.PATH || '').split(path.delimiter).filter(Boolean);
+  for (const directory of paths) {
+    for (const candidateName of candidateExecutableNames(command, extensions)) {
+      const candidate = path.join(directory, candidateName);
+      if (isExecutableFile(candidate)) return candidate;
+    }
+  }
+
+  return undefined;
+}
+
+function candidateExecutableNames(command, extensions) {
+  return [
+    ...new Set(
+      extensions.flatMap((extension) => [
+        `${command}${extension.toLowerCase()}`,
+        `${command}${extension.toUpperCase()}`,
+      ]),
+    ),
+  ];
+}
+
+function isWindowsCommandShim(command) {
+  if (process.platform !== 'win32') return false;
+  const extension = path.extname(command).toLowerCase();
+  return extension === '.cmd' || extension === '.bat';
+}
+
+function isExecutableFile(candidate) {
+  try {
+    fs.accessSync(candidate, fs.constants.X_OK);
+    return true;
+  } catch (_error) {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

- Add a local VS Code helper extension for Arco KDL files
- Route diagnostics through the canonical `arco kdl check --format json` CLI
- Improve Windows CLI shim handling and workspace/remote diagnostic URI behavior
- Add CI coverage for packaging/checking the VS Code extension

## Validation

- `cd tools/vscode-arco-kdl && npm run check`
- `cd tools/vscode-arco-kdl && npm run package`
- `bash -n scripts/ci-plan.sh`
- `RUNNER_TEMP=$(mktemp -d) GITHUB_STEP_SUMMARY=$(mktemp) RUST=false PYTHON=false DOCS=false SOLVER=false KDL=false BENCHMARKS=false RELEASE=false ACTIONS_CONFIG=false VSCODE_EXTENSION=true bash scripts/ci-plan.sh`
- `git diff --check`
