### PR TITLE
chore(ci): harden dist release builds

### DIFF
--- a/.github/build-setup.yml
+++ b/.github/build-setup.yml
@@ -1,3 +1,24 @@
+- name: Install Rust toolchain manager
+  shell: bash
+  run: |
+    set -euo pipefail
+
+    if command -v rustup >/dev/null 2>&1; then
+      exit 0
+    fi
+
+    for attempt in 1 2 3 4 5; do
+      if curl --proto '=https' --tlsv1.2 -LsSf https://sh.rustup.rs -o /tmp/rustup-init.sh; then
+        sh /tmp/rustup-init.sh -y --profile minimal --default-toolchain none
+        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+        exit 0
+      fi
+      sleep $((attempt * 5))
+    done
+
+    echo "failed to download rustup installer after 5 attempts" >&2
+    exit 1
+
 - name: Use workspace Rust toolchain
   run: rustup update "1.85" --no-self-update && rustup default "1.85"
 

--- a/.github/workflows/v-release.yml
+++ b/.github/workflows/v-release.yml
@@ -130,6 +130,26 @@ jobs:
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
             echo "$HOME/.cargo/bin" >> $GITHUB_PATH
           fi
+      - name: "Install Rust toolchain manager"
+        run: |
+          set -euo pipefail
+
+          if command -v rustup >/dev/null 2>&1; then
+            exit 0
+          fi
+
+          for attempt in 1 2 3 4 5; do
+            if curl --proto '=https' --tlsv1.2 -LsSf https://sh.rustup.rs -o /tmp/rustup-init.sh; then
+              sh /tmp/rustup-init.sh -y --profile minimal --default-toolchain none
+              echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+              exit 0
+            fi
+            sleep $((attempt * 5))
+          done
+
+          echo "failed to download rustup installer after 5 attempts" >&2
+          exit 1
+        shell: "bash"
       - name: "Use workspace Rust toolchain"
         run: "rustup update \"1.85\" --no-self-update && rustup default \"1.85\""
       - name: "Configure manylinux native dependency builds"


### PR DESCRIPTION
## Summary
- add a retrying rustup installer setup step for generated cargo-dist release jobs
- switch cargo-dist PR runs to upload artifacts so release builds can be checked on PRs
- pin the generated swatinem/rust-cache action and regenerate v-release.yml

## Validation
- `dist generate-ci`
- `uvx zizmor --pedantic .github/`
- pre-commit/pre-push hooks during commit/push: formatting, TOML/YAML checks, prettier, zizmor, taplo, commitizen, cargo fmt, clippy, and fast tests

## Release behavior
This PR uses a `chore(ci): ...` commit/title so release-please should not create a version release from it.
