### PR TITLE
chore(ci): fix windows pypi wheel shell

### DIFF
--- a/.github/workflows/pypi-manual-release.yaml
+++ b/.github/workflows/pypi-manual-release.yaml
@@ -66,12 +66,14 @@ jobs:
           save-uv-cache: "false"
 
       - name: Build wheel
+        shell: bash
         env:
           PYTHON_WHEEL_INTERPRETER: ${{ matrix.wheel_python }}
         run: just py-build-wheel
 
       - name: Build sdist
         if: matrix.build_sdist
+        shell: bash
         run: just py-build-sdist
 
       - name: Upload Python distributions

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -221,12 +221,14 @@ jobs:
           save-uv-cache: "false"
 
       - name: Build wheel
+        shell: bash
         env:
           PYTHON_WHEEL_INTERPRETER: ${{ matrix.wheel_python }}
         run: just py-build-wheel
 
       - name: Build sdist
         if: matrix.build_sdist
+        shell: bash
         run: just py-build-sdist
 
       - name: Store the distribution packages


### PR DESCRIPTION
## Summary
- run Python distribution build steps under Git Bash on Windows
- prevents just from resolving bash to the WSL launcher on Windows runners
- applies the fix to both manual PyPI and release-please Python distribution builds

## Validation
- `uvx zizmor --pedantic .github/`
- `git diff --check`
- commit/push hooks passed

## Context
Manual PyPI run 26973030098 failed in the Windows wheel job before maturin ran because `just py-build-wheel` invoked `py-licenses`, which resolved `bash` through WSL and failed with "Windows Subsystem for Linux has no installed distributions."