### PR TITLE
chore(ci): build Python release wheels across versions

### DIFF
--- a/.github/workflows/pypi-manual-release.yaml
+++ b/.github/workflows/pypi-manual-release.yaml
@@ -30,64 +30,21 @@ env:
 
 jobs:
   py-build:
-    name: Build Python distributions (${{ matrix.os-label }}, py${{ matrix.python-version }})
-    runs-on: ${{ matrix.os }}
+    name: Build Python distributions (${{ matrix.platform.label }}, py${{ matrix.python-version }})
+    runs-on: ${{ matrix.platform.os }}
     timeout-minutes: 15
     permissions:
       contents: read
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - os-label: linux
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        platform:
+          - label: linux
             os: ubuntu-latest
-            python-version: "3.10"
-            build_sdist: false
             wheel_python: python3
-          - os-label: linux
-            os: ubuntu-latest
-            python-version: "3.11"
-            build_sdist: false
-            wheel_python: python3
-          - os-label: linux
-            os: ubuntu-latest
-            python-version: "3.12"
-            build_sdist: true
-            wheel_python: python3
-          - os-label: linux
-            os: ubuntu-latest
-            python-version: "3.13"
-            build_sdist: false
-            wheel_python: python3
-          - os-label: linux
-            os: ubuntu-latest
-            python-version: "3.14"
-            build_sdist: false
-            wheel_python: python3
-          - os-label: windows
+          - label: windows
             os: windows-latest
-            python-version: "3.10"
-            build_sdist: false
-            wheel_python: python
-          - os-label: windows
-            os: windows-latest
-            python-version: "3.11"
-            build_sdist: false
-            wheel_python: python
-          - os-label: windows
-            os: windows-latest
-            python-version: "3.12"
-            build_sdist: false
-            wheel_python: python
-          - os-label: windows
-            os: windows-latest
-            python-version: "3.13"
-            build_sdist: false
-            wheel_python: python
-          - os-label: windows
-            os: windows-latest
-            python-version: "3.14"
-            build_sdist: false
             wheel_python: python
     steps:
       - name: Checkout selected ref
@@ -110,7 +67,7 @@ jobs:
       - name: Build wheel
         shell: bash
         env:
-          PYTHON_WHEEL_INTERPRETER: ${{ matrix.wheel_python }}
+          PYTHON_WHEEL_INTERPRETER: ${{ matrix.platform.wheel_python }}
         run: |
           if [[ "${RUNNER_OS}" == "Windows" ]]; then
             just --shell "C:/Program Files/Git/bin/bash.exe" --shell-arg "-eu" --shell-arg "-o" --shell-arg "pipefail" --shell-arg "-c" py-build-wheel
@@ -119,14 +76,14 @@ jobs:
           fi
 
       - name: Build sdist
-        if: matrix.build_sdist
+        if: matrix.platform.label == 'linux' && matrix.python-version == '3.12'
         shell: bash
         run: just py-build-sdist
 
       - name: Upload Python distributions
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: python-package-distributions-${{ matrix.os-label }}-py${{ matrix.python-version }}
+          name: python-package-distributions-${{ matrix.platform.label }}-py${{ matrix.python-version }}
           path: dist/
           retention-days: 3
 

--- a/.github/workflows/pypi-manual-release.yaml
+++ b/.github/workflows/pypi-manual-release.yaml
@@ -30,7 +30,7 @@ env:
 
 jobs:
   py-build:
-    name: Build Python distributions (${{ matrix.label }})
+    name: Build Python distributions (${{ matrix.os-label }}, py${{ matrix.python-version }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     permissions:
@@ -39,12 +39,54 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - label: linux
+          - os-label: linux
             os: ubuntu-latest
+            python-version: "3.10"
+            build_sdist: false
+            wheel_python: python3
+          - os-label: linux
+            os: ubuntu-latest
+            python-version: "3.11"
+            build_sdist: false
+            wheel_python: python3
+          - os-label: linux
+            os: ubuntu-latest
+            python-version: "3.12"
             build_sdist: true
             wheel_python: python3
-          - label: windows
+          - os-label: linux
+            os: ubuntu-latest
+            python-version: "3.13"
+            build_sdist: false
+            wheel_python: python3
+          - os-label: linux
+            os: ubuntu-latest
+            python-version: "3.14"
+            build_sdist: false
+            wheel_python: python3
+          - os-label: windows
             os: windows-latest
+            python-version: "3.10"
+            build_sdist: false
+            wheel_python: python
+          - os-label: windows
+            os: windows-latest
+            python-version: "3.11"
+            build_sdist: false
+            wheel_python: python
+          - os-label: windows
+            os: windows-latest
+            python-version: "3.12"
+            build_sdist: false
+            wheel_python: python
+          - os-label: windows
+            os: windows-latest
+            python-version: "3.13"
+            build_sdist: false
+            wheel_python: python
+          - os-label: windows
+            os: windows-latest
+            python-version: "3.14"
             build_sdist: false
             wheel_python: python
     steps:
@@ -58,7 +100,7 @@ jobs:
       - name: Set up build environment
         uses: ./.github/actions/setup-build-env
         with:
-          python-version: ${{ env.PYTHON_LATEST }}
+          python-version: ${{ matrix.python-version }}
           uv-version: ${{ env.UV_VERSION }}
           just-version: ${{ env.JUST_VERSION }}
           rust-toolchain-version: ${{ env.RUST_TOOLCHAIN_VERSION }}
@@ -84,7 +126,7 @@ jobs:
       - name: Upload Python distributions
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: python-package-distributions-${{ matrix.label }}
+          name: python-package-distributions-${{ matrix.os-label }}-py${{ matrix.python-version }}
           path: dist/
           retention-days: 3
 

--- a/.github/workflows/pypi-manual-release.yaml
+++ b/.github/workflows/pypi-manual-release.yaml
@@ -69,7 +69,12 @@ jobs:
         shell: bash
         env:
           PYTHON_WHEEL_INTERPRETER: ${{ matrix.wheel_python }}
-        run: just py-build-wheel
+        run: |
+          if [[ "${RUNNER_OS}" == "Windows" ]]; then
+            just --shell "C:/Program Files/Git/bin/bash.exe" --shell-arg "-eu" --shell-arg "-o" --shell-arg "pipefail" --shell-arg "-c" py-build-wheel
+          else
+            just py-build-wheel
+          fi
 
       - name: Build sdist
         if: matrix.build_sdist

--- a/.github/workflows/pypi-manual-release.yaml
+++ b/.github/workflows/pypi-manual-release.yaml
@@ -70,6 +70,8 @@ jobs:
           PYTHON_WHEEL_INTERPRETER: ${{ matrix.platform.wheel_python }}
         run: |
           if [[ "${RUNNER_OS}" == "Windows" ]]; then
+            # TODO: After the next release, remove this tag-rebuild compatibility override.
+            # New release refs should rely on the justfile's windows-shell setting instead.
             just --shell "C:/Program Files/Git/bin/bash.exe" --shell-arg "-eu" --shell-arg "-o" --shell-arg "pipefail" --shell-arg "-c" py-build-wheel
           else
             just py-build-wheel

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -182,7 +182,7 @@ jobs:
         run: gh release upload "$TAG" arco-kdl-vscode.vsix --clobber
 
   py-build:
-    name: Python Build Artifacts (${{ matrix.os-label }}, py${{ matrix.python-version }})
+    name: Python Build Artifacts (${{ matrix.platform.label }}, py${{ matrix.python-version }})
     timeout-minutes: 15
     permissions:
       contents: read
@@ -192,58 +192,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - os-label: linux
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        platform:
+          - label: linux
             os: ubuntu-latest
-            python-version: "3.10"
-            build_sdist: false
             wheel_python: python3
-          - os-label: linux
-            os: ubuntu-latest
-            python-version: "3.11"
-            build_sdist: false
-            wheel_python: python3
-          - os-label: linux
-            os: ubuntu-latest
-            python-version: "3.12"
-            build_sdist: true
-            wheel_python: python3
-          - os-label: linux
-            os: ubuntu-latest
-            python-version: "3.13"
-            build_sdist: false
-            wheel_python: python3
-          - os-label: linux
-            os: ubuntu-latest
-            python-version: "3.14"
-            build_sdist: false
-            wheel_python: python3
-          - os-label: windows
+          - label: windows
             os: windows-latest
-            python-version: "3.10"
-            build_sdist: false
             wheel_python: python
-          - os-label: windows
-            os: windows-latest
-            python-version: "3.11"
-            build_sdist: false
-            wheel_python: python
-          - os-label: windows
-            os: windows-latest
-            python-version: "3.12"
-            build_sdist: false
-            wheel_python: python
-          - os-label: windows
-            os: windows-latest
-            python-version: "3.13"
-            build_sdist: false
-            wheel_python: python
-          - os-label: windows
-            os: windows-latest
-            python-version: "3.14"
-            build_sdist: false
-            wheel_python: python
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.platform.os }}
     steps:
       - name: Checkout release commit
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -265,7 +222,7 @@ jobs:
       - name: Build wheel
         shell: bash
         env:
-          PYTHON_WHEEL_INTERPRETER: ${{ matrix.wheel_python }}
+          PYTHON_WHEEL_INTERPRETER: ${{ matrix.platform.wheel_python }}
         run: |
           if [[ "${RUNNER_OS}" == "Windows" ]]; then
             just --shell "C:/Program Files/Git/bin/bash.exe" --shell-arg "-eu" --shell-arg "-o" --shell-arg "pipefail" --shell-arg "-c" py-build-wheel
@@ -274,14 +231,14 @@ jobs:
           fi
 
       - name: Build sdist
-        if: matrix.build_sdist
+        if: matrix.platform.label == 'linux' && matrix.python-version == '3.12'
         shell: bash
         run: just py-build-sdist
 
       - name: Store the distribution packages
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: python-package-distributions-${{ matrix.os-label }}-py${{ matrix.python-version }}
+          name: python-package-distributions-${{ matrix.platform.label }}-py${{ matrix.python-version }}
           path: dist/
           retention-days: 3
 

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -182,7 +182,7 @@ jobs:
         run: gh release upload "$TAG" arco-kdl-vscode.vsix --clobber
 
   py-build:
-    name: Python Build Artifacts (${{ matrix.label }})
+    name: Python Build Artifacts (${{ matrix.os-label }}, py${{ matrix.python-version }})
     timeout-minutes: 15
     permissions:
       contents: read
@@ -193,12 +193,54 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - label: linux
+          - os-label: linux
             os: ubuntu-latest
+            python-version: "3.10"
+            build_sdist: false
+            wheel_python: python3
+          - os-label: linux
+            os: ubuntu-latest
+            python-version: "3.11"
+            build_sdist: false
+            wheel_python: python3
+          - os-label: linux
+            os: ubuntu-latest
+            python-version: "3.12"
             build_sdist: true
             wheel_python: python3
-          - label: windows
+          - os-label: linux
+            os: ubuntu-latest
+            python-version: "3.13"
+            build_sdist: false
+            wheel_python: python3
+          - os-label: linux
+            os: ubuntu-latest
+            python-version: "3.14"
+            build_sdist: false
+            wheel_python: python3
+          - os-label: windows
             os: windows-latest
+            python-version: "3.10"
+            build_sdist: false
+            wheel_python: python
+          - os-label: windows
+            os: windows-latest
+            python-version: "3.11"
+            build_sdist: false
+            wheel_python: python
+          - os-label: windows
+            os: windows-latest
+            python-version: "3.12"
+            build_sdist: false
+            wheel_python: python
+          - os-label: windows
+            os: windows-latest
+            python-version: "3.13"
+            build_sdist: false
+            wheel_python: python
+          - os-label: windows
+            os: windows-latest
+            python-version: "3.14"
             build_sdist: false
             wheel_python: python
     runs-on: ${{ matrix.os }}
@@ -213,7 +255,7 @@ jobs:
       - name: Set up build environment
         uses: ./.github/actions/setup-build-env
         with:
-          python-version: ${{ env.PYTHON_LATEST }}
+          python-version: ${{ matrix.python-version }}
           uv-version: ${{ env.UV_VERSION }}
           just-version: ${{ env.JUST_VERSION }}
           rust-toolchain-version: ${{ env.RUST_TOOLCHAIN_VERSION }}
@@ -239,7 +281,7 @@ jobs:
       - name: Store the distribution packages
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: python-package-distributions-${{ matrix.label }}
+          name: python-package-distributions-${{ matrix.os-label }}-py${{ matrix.python-version }}
           path: dist/
           retention-days: 3
 

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -224,7 +224,12 @@ jobs:
         shell: bash
         env:
           PYTHON_WHEEL_INTERPRETER: ${{ matrix.wheel_python }}
-        run: just py-build-wheel
+        run: |
+          if [[ "${RUNNER_OS}" == "Windows" ]]; then
+            just --shell "C:/Program Files/Git/bin/bash.exe" --shell-arg "-eu" --shell-arg "-o" --shell-arg "pipefail" --shell-arg "-c" py-build-wheel
+          else
+            just py-build-wheel
+          fi
 
       - name: Build sdist
         if: matrix.build_sdist

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -225,6 +225,8 @@ jobs:
           PYTHON_WHEEL_INTERPRETER: ${{ matrix.platform.wheel_python }}
         run: |
           if [[ "${RUNNER_OS}" == "Windows" ]]; then
+            # TODO: After the next release, remove this tag-rebuild compatibility override.
+            # New release refs should rely on the justfile's windows-shell setting instead.
             just --shell "C:/Program Files/Git/bin/bash.exe" --shell-arg "-eu" --shell-arg "-o" --shell-arg "pipefail" --shell-arg "-c" py-build-wheel
           else
             just py-build-wheel

--- a/justfile
+++ b/justfile
@@ -1,6 +1,7 @@
 #!/usr/bin/env -S just --justfile
 
 set shell := ["bash", "-eu", "-o", "pipefail", "-c"]
+set windows-shell := ["C:/Program Files/Git/bin/bash.exe", "-eu", "-o", "pipefail", "-c"]
 
 export UV_CACHE_DIR := justfile_directory() / ".uv-cache"
 


### PR DESCRIPTION
## Summary
- force `just` to use Git Bash for Windows wheel recipes in PyPI release workflows
- add a Windows-specific `justfile` shell so future Windows recipe runs avoid the WSL `bash.exe` launcher
- build release wheels for CPython 3.10, 3.11, 3.12, 3.13, and 3.14 on Linux and Windows
- keep sdist generation to the Linux Python 3.12 job so only one sdist is published

## Why
The manual PyPI release for `v0.7.0` still failed after adding `shell: bash` because `just` re-runs recipe lines with its own configured `bash`, which can resolve to the Windows WSL launcher when building a checked-out tag. Passing `--shell C:/Program Files/Git/bin/bash.exe` from the current workflow fixes historical tag builds too.

The package does not currently use PyO3 `abi3`, so CPython 3.14 cannot consume a `cp312` wheel. The release workflows now build interpreter-specific wheels for each supported CPython version.

## Validation
- branch rebased with `origin/main` (`git rebase origin/main`: already up to date)
- `uvx --from actionlint-py actionlint .github/workflows/*.yaml`
- `just workflow-quality`
- `git diff --check`
- commit hooks and pre-push hooks: cargo fmt, cargo clippy, cargo test fast
