### PR TITLE
chore(ci): add macOS PyPI release wheels

### DIFF
--- a/.github/workflows/pypi-manual-release.yaml
+++ b/.github/workflows/pypi-manual-release.yaml
@@ -43,6 +43,12 @@ jobs:
           - label: linux
             os: ubuntu-latest
             wheel_python: python3
+          - label: macos-x64
+            os: macos-13
+            wheel_python: python3
+          - label: macos-arm64
+            os: macos-14
+            wheel_python: python3
           - label: windows
             os: windows-latest
             wheel_python: python

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -197,6 +197,12 @@ jobs:
           - label: linux
             os: ubuntu-latest
             wheel_python: python3
+          - label: macos-x64
+            os: macos-13
+            wheel_python: python3
+          - label: macos-arm64
+            os: macos-14
+            wheel_python: python3
           - label: windows
             os: windows-latest
             wheel_python: python


### PR DESCRIPTION
## Summary
- add macOS x64 and arm64 runners to the manual PyPI release wheel matrix
- add the same macOS wheel coverage to the release-please PyPI publish workflow
- keep existing Linux, Windows, Python-version, and single-sdist behavior unchanged

## Why
macOS users otherwise fall back to building from sdist during `pip install arco`, which requires local Rust/Python build tooling. Publishing macOS wheels gives macOS users the same prebuilt install path as Linux and Windows.

## Validation
- `uvx --from actionlint-py actionlint .github/workflows/*.yaml`
- `just workflow-quality`
- `git diff --check`
- commit validation
- pre-push hooks: cargo fmt, cargo clippy, cargo test fast
