### PR TITLE
chore(ci): use hybrid Python release wheel matrix

### DIFF
--- a/.github/workflows/pypi-manual-release.yaml
+++ b/.github/workflows/pypi-manual-release.yaml
@@ -30,7 +30,7 @@ env:
 
 jobs:
   py-build:
-    name: Build Python distributions (${{ matrix.platform.label }}, py${{ matrix.python-version }})
+    name: Build Python distributions (${{ matrix.platform.label }})
     runs-on: ${{ matrix.platform.os }}
     timeout-minutes: 15
     permissions:
@@ -38,7 +38,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         platform:
           - label: linux
             os: ubuntu-latest
@@ -63,7 +62,7 @@ jobs:
       - name: Set up build environment
         uses: ./.github/actions/setup-build-env
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ env.PYTHON_LATEST }}
           uv-version: ${{ env.UV_VERSION }}
           just-version: ${{ env.JUST_VERSION }}
           rust-toolchain-version: ${{ env.RUST_TOOLCHAIN_VERSION }}
@@ -84,14 +83,14 @@ jobs:
           fi
 
       - name: Build sdist
-        if: matrix.platform.label == 'linux' && matrix.python-version == '3.12'
+        if: matrix.platform.label == 'linux'
         shell: bash
         run: just py-build-sdist
 
       - name: Upload Python distributions
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: python-package-distributions-${{ matrix.platform.label }}-py${{ matrix.python-version }}
+          name: python-package-distributions-${{ matrix.platform.label }}
           path: dist/
           retention-days: 3
 

--- a/.github/workflows/pypi-manual-release.yaml
+++ b/.github/workflows/pypi-manual-release.yaml
@@ -30,7 +30,7 @@ env:
 
 jobs:
   py-build:
-    name: Build Python distributions (${{ matrix.platform.label }})
+    name: Build Python distributions (${{ matrix.platform.label }}, ${{ matrix.python.label }})
     runs-on: ${{ matrix.platform.os }}
     timeout-minutes: 15
     permissions:
@@ -38,6 +38,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        python:
+          - label: cp310
+            version: "3.10"
+            wheel_features: ""
+          - label: abi3
+            version: "3.11"
+            wheel_features: "pyo3/extension-module,pyo3/abi3-py311,xpress"
         platform:
           - label: linux
             os: ubuntu-latest
@@ -62,7 +69,7 @@ jobs:
       - name: Set up build environment
         uses: ./.github/actions/setup-build-env
         with:
-          python-version: ${{ env.PYTHON_LATEST }}
+          python-version: ${{ matrix.python.version }}
           uv-version: ${{ env.UV_VERSION }}
           just-version: ${{ env.JUST_VERSION }}
           rust-toolchain-version: ${{ env.RUST_TOOLCHAIN_VERSION }}
@@ -73,6 +80,7 @@ jobs:
         shell: bash
         env:
           PYTHON_WHEEL_INTERPRETER: ${{ matrix.platform.wheel_python }}
+          PYTHON_WHEEL_FEATURES: ${{ matrix.python.wheel_features }}
         run: |
           if [[ "${RUNNER_OS}" == "Windows" ]]; then
             # TODO: After the next release, remove this tag-rebuild compatibility override.
@@ -83,14 +91,14 @@ jobs:
           fi
 
       - name: Build sdist
-        if: matrix.platform.label == 'linux'
+        if: matrix.platform.label == 'linux' && matrix.python.label == 'abi3'
         shell: bash
         run: just py-build-sdist
 
       - name: Upload Python distributions
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: python-package-distributions-${{ matrix.platform.label }}
+          name: python-package-distributions-${{ matrix.platform.label }}-${{ matrix.python.label }}
           path: dist/
           retention-days: 3
 

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -182,7 +182,7 @@ jobs:
         run: gh release upload "$TAG" arco-kdl-vscode.vsix --clobber
 
   py-build:
-    name: Python Build Artifacts (${{ matrix.platform.label }})
+    name: Python Build Artifacts (${{ matrix.platform.label }}, ${{ matrix.python.label }})
     timeout-minutes: 15
     permissions:
       contents: read
@@ -192,6 +192,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        python:
+          - label: cp310
+            version: "3.10"
+            wheel_features: ""
+          - label: abi3
+            version: "3.11"
+            wheel_features: "pyo3/extension-module,pyo3/abi3-py311,xpress"
         platform:
           - label: linux
             os: ubuntu-latest
@@ -217,7 +224,7 @@ jobs:
       - name: Set up build environment
         uses: ./.github/actions/setup-build-env
         with:
-          python-version: ${{ env.PYTHON_LATEST }}
+          python-version: ${{ matrix.python.version }}
           uv-version: ${{ env.UV_VERSION }}
           just-version: ${{ env.JUST_VERSION }}
           rust-toolchain-version: ${{ env.RUST_TOOLCHAIN_VERSION }}
@@ -228,6 +235,7 @@ jobs:
         shell: bash
         env:
           PYTHON_WHEEL_INTERPRETER: ${{ matrix.platform.wheel_python }}
+          PYTHON_WHEEL_FEATURES: ${{ matrix.python.wheel_features }}
         run: |
           if [[ "${RUNNER_OS}" == "Windows" ]]; then
             # TODO: After the next release, remove this tag-rebuild compatibility override.
@@ -238,14 +246,14 @@ jobs:
           fi
 
       - name: Build sdist
-        if: matrix.platform.label == 'linux'
+        if: matrix.platform.label == 'linux' && matrix.python.label == 'abi3'
         shell: bash
         run: just py-build-sdist
 
       - name: Store the distribution packages
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: python-package-distributions-${{ matrix.platform.label }}
+          name: python-package-distributions-${{ matrix.platform.label }}-${{ matrix.python.label }}
           path: dist/
           retention-days: 3
 

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -182,7 +182,7 @@ jobs:
         run: gh release upload "$TAG" arco-kdl-vscode.vsix --clobber
 
   py-build:
-    name: Python Build Artifacts (${{ matrix.platform.label }}, py${{ matrix.python-version }})
+    name: Python Build Artifacts (${{ matrix.platform.label }})
     timeout-minutes: 15
     permissions:
       contents: read
@@ -192,7 +192,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         platform:
           - label: linux
             os: ubuntu-latest
@@ -218,7 +217,7 @@ jobs:
       - name: Set up build environment
         uses: ./.github/actions/setup-build-env
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ env.PYTHON_LATEST }}
           uv-version: ${{ env.UV_VERSION }}
           just-version: ${{ env.JUST_VERSION }}
           rust-toolchain-version: ${{ env.RUST_TOOLCHAIN_VERSION }}
@@ -239,14 +238,14 @@ jobs:
           fi
 
       - name: Build sdist
-        if: matrix.platform.label == 'linux' && matrix.python-version == '3.12'
+        if: matrix.platform.label == 'linux'
         shell: bash
         run: just py-build-sdist
 
       - name: Store the distribution packages
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: python-package-distributions-${{ matrix.platform.label }}-py${{ matrix.python-version }}
+          name: python-package-distributions-${{ matrix.platform.label }}
           path: dist/
           retention-days: 3
 

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -38,7 +38,7 @@ Issues = "https://github.com/NatLabRockies/arco/issues"
 Changelog = "https://github.com/NatLabRockies/arco/releases"
 
 [tool.maturin]
-features = ["pyo3/extension-module", "pyo3/abi3-py311", "xpress"]
+features = ["pyo3/extension-module", "xpress"]
 include = [
   "arco/py.typed",
   "arco/arco.pyi",

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -38,7 +38,7 @@ Issues = "https://github.com/NatLabRockies/arco/issues"
 Changelog = "https://github.com/NatLabRockies/arco/releases"
 
 [tool.maturin]
-features = ["pyo3/extension-module", "xpress"]
+features = ["pyo3/extension-module", "pyo3/abi3-py311", "xpress"]
 include = [
   "arco/py.typed",
   "arco/arco.pyi",

--- a/justfile
+++ b/justfile
@@ -168,7 +168,7 @@ py-test: py-dev py-cli-build
 
 [group: 'python']
 py-build-wheel: py-licenses
-    uv run --project bindings/python --with maturin maturin build --release --manifest-path bindings/python/Cargo.toml -i ${PYTHON_WHEEL_INTERPRETER:-python3} --compatibility pypi --out dist
+    if [[ -n "${PYTHON_WHEEL_FEATURES:-}" ]]; then uv run --project bindings/python --with maturin maturin build --release --manifest-path bindings/python/Cargo.toml -i ${PYTHON_WHEEL_INTERPRETER:-python3} --compatibility pypi --out dist --features "$PYTHON_WHEEL_FEATURES"; else uv run --project bindings/python --with maturin maturin build --release --manifest-path bindings/python/Cargo.toml -i ${PYTHON_WHEEL_INTERPRETER:-python3} --compatibility pypi --out dist; fi
 
 [group: 'python']
 py-build-sdist:


### PR DESCRIPTION
## Summary
- use a hybrid Python wheel matrix for better compatibility with fewer jobs
- publish CPython 3.10 version-specific wheels for each platform
- publish `cp311-abi3` stable-ABI wheels for each platform to cover CPython 3.11+
- keep Linux sdist publishing and existing Linux/macOS/Windows platform coverage

## Why
A full OS/arch × Python-version matrix is very broad but creates too many release jobs. Pure `abi3-py311` is much smaller but drops prebuilt wheel coverage for Python 3.10.

This hybrid keeps Python 3.10 wheel coverage while using stable ABI wheels for Python 3.11 and newer. I tried `abi3-py39` to cover the full `requires-python >=3.9` range with one wheel per platform, but Arco uses PyO3 `PyBuffer`; limited API buffer support starts at Python 3.11, so `abi3-py311` is the lowest currently validated stable ABI target without refactoring that path.

## Validation
- `uvx --from actionlint-py actionlint .github/workflows/*.yaml`
- `just workflow-quality`
- `git diff --check`
- `PYTHON_WHEEL_FEATURES='pyo3/extension-module,pyo3/abi3-py311,xpress' just py-build-wheel`
- `env -u PYTHON_WHEEL_FEATURES just py-build-wheel`
- `just py-smoke-wheel 'dist/*cp314*.whl'`
- `just py-smoke-wheel 'dist/*abi3*.whl'`
- commit validation
- pre-push hooks: cargo fmt, cargo clippy, cargo test fast
