### PR TITLE
perf: expose ReEDS memory-performance branch

### DIFF
--- a/bindings/python/arco/__init__.py
+++ b/bindings/python/arco/__init__.py
@@ -580,10 +580,49 @@ def _param_einsum(subscripts: object, *operands: object, **kwargs: object) -> ob
     return np.einsum(subscripts, *dense_operands, **kwargs)
 
 
+_MODEL_ADD_VARIABLES = _arco.Model.add_variables
+
+
+def _normalise_axis_args(
+    axis_args: tuple[object, ...], axes: tuple[object, ...] | None
+) -> tuple[object, ...]:
+    if axis_args and axes is not None:
+        raise TypeError("axes may be provided positionally or by keyword, not both")
+    if axes is not None:
+        return tuple(axes)
+    if len(axis_args) == 1 and isinstance(axis_args[0], tuple):
+        return tuple(axis_args[0])
+    return tuple(axis_args)
+
+
+def _add_variables_compat(
+    self: object,
+    *axis_args: object,
+    axes: tuple[object, ...] | None = None,
+    bounds: object | None = None,
+    is_integer: bool = False,
+    is_binary: bool = False,
+    active: object | None = None,
+    name: str | None = None,
+) -> object:
+    return _MODEL_ADD_VARIABLES(
+        self,
+        axes=_normalise_axis_args(axis_args, axes),
+        bounds=bounds,
+        is_integer=is_integer,
+        is_binary=is_binary,
+        active=active,
+        name=name,
+    )
+
+
+_arco.Model.add_variables = _add_variables_compat
+
+
 def param(
     values: object,
-    *,
-    axes: tuple[object, ...],
+    *axis_args: object,
+    axes: tuple[object, ...] | None = None,
     name: str | None = None,
 ) -> ParamArray:
     try:
@@ -593,7 +632,7 @@ def param(
 
     np_values = np.asarray(values)
 
-    resolved_axes = tuple(axes)
+    resolved_axes = _normalise_axis_args(axis_args, axes)
 
     if np_values.ndim != len(resolved_axes):
         raise _arco.ArrayDimensionError(

--- a/bindings/python/arco/arco.pyi
+++ b/bindings/python/arco/arco.pyi
@@ -30,6 +30,7 @@ class SolverRuntimeInfo(TypedDict):
     license_env_var: str | None
     runtime_env_var: str | None
     runtime_dir: str | None
+    runtime_available: bool
     configured_license_path: str | None
     backend_enabled: bool
 
@@ -150,7 +151,6 @@ Binary: BoundType
 class Bounds:
     def __init__(
         self,
-        *,
         lower: BoundValue | None = None,
         upper: BoundValue | None = None,
     ) -> None: ...
@@ -268,6 +268,15 @@ class Scip(Solver):
     ) -> None: ...
 
 class IndexSet:
+    @overload
+    def __init__(
+        self,
+        name: str,
+        *,
+        size: int | None = None,
+        members: Sequence[IndexMember] | None = None,
+    ) -> None: ...
+    @overload
     def __init__(
         self,
         *,
@@ -315,8 +324,8 @@ class ParamArray:
 
 def param(
     values: object,
-    *,
-    axes: tuple[IndexSet, ...],
+    *axes_pos: IndexSet,
+    axes: tuple[IndexSet, ...] | None = None,
     name: str | None = None,
 ) -> ParamArray: ...
 
@@ -738,6 +747,12 @@ class Model:
         is_integer: object,
         simplify_level: SimplifyLevel | None = None,
     ) -> Model: ...
+    def reserve(
+        self,
+        *,
+        num_variables: int = 0,
+        num_constraints: int = 0,
+    ) -> None: ...
     def add_variable(
         self,
         *,
@@ -748,8 +763,8 @@ class Model:
     ) -> Variable: ...
     def add_variables(
         self,
-        *,
-        axes: tuple[IndexSet, ...],
+        *axes_pos: IndexSet,
+        axes: tuple[IndexSet, ...] | None = None,
         bounds: Bounds | BoundType,
         is_integer: bool = False,
         is_binary: bool = False,
@@ -820,6 +835,10 @@ class Model:
         *,
         name: str | None = None,
     ) -> None: ...
+    def add_objective_terms(
+        self,
+        expr: Expr | Variable | VariableArray | ExprArray,
+    ) -> None: ...
     def solve(
         self,
         *,
@@ -838,6 +857,9 @@ class Model:
         variable_ids: Sequence[int] | None = None,
         constraint_ids: Sequence[int] | None = None,
     ) -> ModelSnapshot: ...
+    def matrix_profile(
+        self, *, top_n: int = 20, dense_threshold: int = 100
+    ) -> dict[str, object]: ...
     def pprint(self) -> None: ...
     def add_block(
         self,

--- a/bindings/python/src/arrays.rs
+++ b/bindings/python/src/arrays.rs
@@ -30,7 +30,7 @@ pub use expr_array::PyExprArray;
 pub use variable_array::PyVariableArray;
 
 // Re-export compact types for use in lib.rs
-pub(crate) use constraint_array::CompactConstraintStorage;
+pub(crate) use constraint_array::{CompactConstraintStorage, CompactRhs};
 
 type LabeledOperand = (Vec<Py<PyIndexSet>>, Vec<f64>);
 
@@ -263,6 +263,617 @@ fn multiply_with_labeled_union(
         target_shape.shape(),
         values,
     )))
+}
+
+pub(super) fn multiply_sparse_variables_with_scalar(
+    index_sets: &[Py<PyIndexSet>],
+    shape: &[usize],
+    active_indices: &[usize],
+    var_ids: &[u32],
+    factor: f64,
+) -> PyExprArray {
+    let values = var_ids
+        .iter()
+        .map(|var_id| PyExpr::from_term(*var_id, 1.0).scale(factor))
+        .collect();
+    PyExprArray::from_sparse(
+        Python::attach(|py| index_sets.iter().map(|set| set.clone_ref(py)).collect()),
+        shape.to_vec(),
+        active_indices.to_vec(),
+        values,
+    )
+}
+
+pub(super) fn multiply_sparse_variables_with_labeled_operand(
+    index_sets: &[Py<PyIndexSet>],
+    active_indices: &[usize],
+    var_ids: &[u32],
+    py: Python<'_>,
+    other: &Bound<'_, PyAny>,
+) -> PyResult<Option<PyExprArray>> {
+    let Some((source_index_sets, source_values)) = extract_labeled_operand(py, other)? else {
+        return Ok(None);
+    };
+
+    let mut union_index_sets = source_index_sets
+        .iter()
+        .map(|index_set| index_set.clone_ref(py))
+        .collect::<Vec<_>>();
+    let union_names = source_index_sets
+        .iter()
+        .map(|index_set| index_set.bind(py).borrow().name.clone())
+        .collect::<BTreeSet<_>>();
+    for index_set in index_sets {
+        let name = index_set.bind(py).borrow().name.clone();
+        if !union_names.contains(&name) {
+            union_index_sets.push(index_set.clone_ref(py));
+        }
+    }
+
+    let target_shape = labeled_shape_from_index_sets(&union_index_sets)?;
+    let variable_shape = labeled_shape_from_index_sets(index_sets)?;
+    let source_shape = labeled_shape_from_index_sets(&source_index_sets)?;
+    let variable_plan = BroadcastPlan::new(variable_shape.clone(), target_shape.clone())
+        .map_err(|err| ArrayShapeMismatchError::new_err(err.to_string()))?;
+    let source_plan = BroadcastPlan::new(source_shape, target_shape.clone())
+        .map_err(|err| ArrayShapeMismatchError::new_err(err.to_string()))?;
+
+    let variable_total = variable_shape.total_len();
+    let mut active_lookup = vec![None; variable_total];
+    for (active_pos, active_idx) in active_indices.iter().copied().enumerate() {
+        if active_idx >= variable_total {
+            return Err(ArrayIndexError::new_err(format!(
+                "active index {active_idx} out of range for sparse array of size {variable_total}"
+            )));
+        }
+        active_lookup[active_idx] = Some(active_pos);
+    }
+
+    let mut out_indices = Vec::new();
+    let mut out_values = Vec::new();
+    for target_flat in 0..target_shape.total_len() {
+        let variable_flat = variable_plan.source_offset_for_target_flat(target_flat);
+        let Some(active_pos) = active_lookup[variable_flat] else {
+            continue;
+        };
+        let source_flat = source_plan.source_offset_for_target_flat(target_flat);
+        let weight = source_values[source_flat];
+        if weight == 0.0 {
+            continue;
+        }
+        out_indices.push(target_flat);
+        out_values.push(PyExpr::from_term(var_ids[active_pos], 1.0).scale(weight));
+    }
+
+    Ok(Some(PyExprArray::from_sparse(
+        union_index_sets,
+        target_shape.shape(),
+        out_indices,
+        out_values,
+    )))
+}
+
+pub(super) fn multiply_sparse_expr_with_scalar(
+    index_sets: &[Py<PyIndexSet>],
+    shape: &[usize],
+    sparse: &SparseExprStorage,
+    factor: f64,
+) -> PyExprArray {
+    let values = sparse
+        .values
+        .iter()
+        .map(|expr| expr.scale(factor))
+        .collect();
+    PyExprArray::from_sparse(
+        Python::attach(|py| index_sets.iter().map(|set| set.clone_ref(py)).collect()),
+        shape.to_vec(),
+        sparse.active_indices.clone(),
+        values,
+    )
+}
+
+pub(super) fn multiply_sparse_expr_with_labeled_operand(
+    index_sets: &[Py<PyIndexSet>],
+    sparse: &SparseExprStorage,
+    py: Python<'_>,
+    other: &Bound<'_, PyAny>,
+) -> PyResult<Option<PyExprArray>> {
+    let Some((source_index_sets, source_values)) = extract_labeled_operand(py, other)? else {
+        return Ok(None);
+    };
+
+    let mut union_index_sets = source_index_sets
+        .iter()
+        .map(|index_set| index_set.clone_ref(py))
+        .collect::<Vec<_>>();
+    let union_names = source_index_sets
+        .iter()
+        .map(|index_set| index_set.bind(py).borrow().name.clone())
+        .collect::<BTreeSet<_>>();
+    for index_set in index_sets {
+        let name = index_set.bind(py).borrow().name.clone();
+        if !union_names.contains(&name) {
+            union_index_sets.push(index_set.clone_ref(py));
+        }
+    }
+
+    let target_shape = labeled_shape_from_index_sets(&union_index_sets)?;
+    let expr_shape = labeled_shape_from_index_sets(index_sets)?;
+    let source_shape = labeled_shape_from_index_sets(&source_index_sets)?;
+    let expr_plan = BroadcastPlan::new(expr_shape.clone(), target_shape.clone())
+        .map_err(|err| ArrayShapeMismatchError::new_err(err.to_string()))?;
+    let source_plan = BroadcastPlan::new(source_shape, target_shape.clone())
+        .map_err(|err| ArrayShapeMismatchError::new_err(err.to_string()))?;
+
+    let expr_total = expr_shape.total_len();
+    let mut active_lookup = vec![None; expr_total];
+    for (active_pos, active_idx) in sparse.active_indices.iter().copied().enumerate() {
+        if active_idx >= expr_total {
+            return Err(ArrayIndexError::new_err(format!(
+                "active index {active_idx} out of range for sparse expression array of size {expr_total}"
+            )));
+        }
+        active_lookup[active_idx] = Some(active_pos);
+    }
+
+    let mut out_indices = Vec::new();
+    let mut out_values = Vec::new();
+    for target_flat in 0..target_shape.total_len() {
+        let expr_flat = expr_plan.source_offset_for_target_flat(target_flat);
+        let Some(active_pos) = active_lookup[expr_flat] else {
+            continue;
+        };
+        let source_flat = source_plan.source_offset_for_target_flat(target_flat);
+        let weight = source_values[source_flat];
+        if weight == 0.0 {
+            continue;
+        }
+        out_indices.push(target_flat);
+        out_values.push(sparse.values[active_pos].scale(weight));
+    }
+
+    Ok(Some(PyExprArray::from_sparse(
+        union_index_sets,
+        target_shape.shape(),
+        out_indices,
+        out_values,
+    )))
+}
+
+fn find_sparse_axis(
+    index_sets: &[Py<PyIndexSet>],
+    py: Python<'_>,
+    index_set: &Bound<'_, PyIndexSet>,
+) -> PyResult<usize> {
+    let target_ptr = index_set.as_ptr();
+    for (idx, stored) in index_sets.iter().enumerate() {
+        if stored.as_ptr() == target_ptr {
+            return Ok(idx);
+        }
+    }
+
+    let target_name = &index_set.borrow().name;
+    for (idx, stored) in index_sets.iter().enumerate() {
+        let stored_ref = stored.bind(py).borrow();
+        if &stored_ref.name == target_name {
+            return Ok(idx);
+        }
+    }
+
+    Err(ArrayIndexError::new_err(format!(
+        "IndexSet '{}' is not a dimension of this array",
+        index_set.borrow().name
+    )))
+}
+
+fn parse_sparse_axes(
+    index_sets: &[Py<PyIndexSet>],
+    py: Python<'_>,
+    selection: &Bound<'_, PyAny>,
+) -> PyResult<Vec<usize>> {
+    let mut axes = Vec::new();
+    if let Ok(single) = selection.cast::<PyIndexSet>() {
+        axes.push(find_sparse_axis(index_sets, py, single)?);
+    } else {
+        let items: Vec<Bound<'_, PyAny>> = selection.try_iter()?.collect::<PyResult<Vec<_>>>()?;
+        for item in &items {
+            let index_set = item.cast::<PyIndexSet>().map_err(|_| {
+                ArrayTypeError::new_err("axis/over must be an IndexSet or tuple of IndexSets")
+            })?;
+            axes.push(find_sparse_axis(index_sets, py, index_set)?);
+        }
+    }
+
+    let mut seen = Vec::with_capacity(axes.len());
+    for axis in &axes {
+        if seen.contains(axis) {
+            return Err(ArrayDimensionError::new_err(
+                "axis/over cannot contain duplicate IndexSet dimensions",
+            ));
+        }
+        seen.push(*axis);
+    }
+    Ok(axes)
+}
+
+fn reduced_sparse_flat_index(
+    flat_idx: usize,
+    shape: &[usize],
+    source_strides: &[usize],
+    reduced_strides: &[usize],
+    summed_axes: &[bool],
+) -> usize {
+    let mut remainder = flat_idx;
+    let mut reduced_axis = 0usize;
+    let mut reduced_idx = 0usize;
+
+    for axis in 0..shape.len() {
+        let coordinate = remainder / source_strides[axis];
+        remainder %= source_strides[axis];
+        if !summed_axes[axis] {
+            reduced_idx += coordinate * reduced_strides[reduced_axis];
+            reduced_axis += 1;
+        }
+    }
+
+    reduced_idx
+}
+
+pub(super) fn sum_sparse_expr(
+    index_sets: &[Py<PyIndexSet>],
+    shape: &[usize],
+    sparse: &SparseExprStorage,
+    py: Python<'_>,
+    over: Option<&Bound<'_, PyAny>>,
+) -> PyResult<PyObject> {
+    let Some(over) = over else {
+        let mut acc = PyExpr::default();
+        for expr in &sparse.values {
+            acc.add_assign(expr);
+        }
+        return Ok(acc.into_pyobject(py)?.into_any().unbind());
+    };
+
+    let axes = parse_sparse_axes(index_sets, py, over)?;
+    let mut summed_axes = vec![false; shape.len()];
+    for axis in axes {
+        summed_axes[axis] = true;
+    }
+
+    let mut out_shape = Vec::new();
+    let mut out_index_sets = Vec::new();
+    for (axis, index_set) in index_sets.iter().enumerate() {
+        if !summed_axes[axis] {
+            out_shape.push(shape[axis]);
+            out_index_sets.push(index_set.clone_ref(py));
+        }
+    }
+
+    let source_strides = arco_arrays::row_major_strides(shape);
+    let reduced_strides = arco_arrays::row_major_strides(&out_shape);
+    let out_len = out_shape.iter().product::<usize>().max(1);
+    let mut values = vec![PyExpr::default(); out_len];
+
+    for (active_idx, expr) in sparse.active_indices.iter().zip(sparse.values.iter()) {
+        let reduced_idx = reduced_sparse_flat_index(
+            *active_idx,
+            shape,
+            &source_strides,
+            &reduced_strides,
+            &summed_axes,
+        );
+        values[reduced_idx].add_assign(expr);
+    }
+
+    if out_shape.is_empty() {
+        let expr = values.pop().unwrap_or_default();
+        Ok(expr.into_pyobject(py)?.into_any().unbind())
+    } else {
+        let array = PyExprArray::new(out_index_sets, out_shape, values);
+        Ok(array.into_pyobject(py)?.into_any().unbind())
+    }
+}
+
+fn sparse_output_flat_for_source(
+    flat_idx: usize,
+    shape: &[usize],
+    source_strides: &[usize],
+    output_strides: &[usize],
+    diff_axis: usize,
+    output_axis_coordinate: usize,
+) -> usize {
+    let mut remainder = flat_idx;
+    let mut output_flat = 0usize;
+
+    for axis in 0..shape.len() {
+        let mut coordinate = remainder / source_strides[axis];
+        remainder %= source_strides[axis];
+        if axis == diff_axis {
+            coordinate = output_axis_coordinate;
+        }
+        output_flat += coordinate * output_strides[axis];
+    }
+
+    output_flat
+}
+
+pub(super) fn diff_sparse_expr(
+    index_sets: &[Py<PyIndexSet>],
+    shape: &[usize],
+    active_indices: &[usize],
+    values: &[PyExpr],
+    py: Python<'_>,
+    over: &Bound<'_, PyAny>,
+) -> PyResult<PyObject> {
+    let axes = parse_sparse_axes(index_sets, py, over)?;
+    if axes.len() != 1 {
+        return Err(ArrayDimensionError::new_err(
+            "np.diff requires exactly one IndexSet axis",
+        ));
+    }
+    let axis = axes[0];
+    let axis_size = shape[axis];
+
+    let mut out_shape = shape.to_vec();
+    out_shape[axis] = axis_size.saturating_sub(1);
+    let mut out_index_sets = Python::attach(|py| {
+        index_sets
+            .iter()
+            .map(|index_set| index_set.clone_ref(py))
+            .collect::<Vec<_>>()
+    });
+    let selected = (1..axis_size).collect::<Vec<_>>();
+    out_index_sets[axis] = slice_index_set(py, &index_sets[axis], &selected)?;
+
+    if axis_size <= 1 {
+        return Ok(
+            PyExprArray::from_sparse(out_index_sets, out_shape, Vec::new(), Vec::new())
+                .into_pyobject(py)?
+                .into_any()
+                .unbind(),
+        );
+    }
+
+    let source_strides = arco_arrays::row_major_strides(shape);
+    let output_strides = arco_arrays::row_major_strides(&out_shape);
+    let mut contributions =
+        Vec::<(usize, PyExpr)>::with_capacity(active_indices.len().saturating_mul(2));
+
+    for (active_idx, expr) in active_indices.iter().zip(values.iter()) {
+        let axis_coordinate = (active_idx / source_strides[axis]) % axis_size;
+        if axis_coordinate > 0 {
+            let output_flat = sparse_output_flat_for_source(
+                *active_idx,
+                shape,
+                &source_strides,
+                &output_strides,
+                axis,
+                axis_coordinate - 1,
+            );
+            contributions.push((output_flat, expr.clone()));
+        }
+        if axis_coordinate + 1 < axis_size {
+            let output_flat = sparse_output_flat_for_source(
+                *active_idx,
+                shape,
+                &source_strides,
+                &output_strides,
+                axis,
+                axis_coordinate,
+            );
+            contributions.push((output_flat, expr.scale(-1.0)));
+        }
+    }
+
+    contributions.sort_unstable_by_key(|(idx, _)| *idx);
+    let mut out_indices = Vec::new();
+    let mut out_values = Vec::<PyExpr>::new();
+    for (idx, expr) in contributions {
+        if out_indices.last().copied() == Some(idx) {
+            if let Some(last) = out_values.last_mut() {
+                last.add_assign_owned(expr);
+            }
+            continue;
+        }
+        if expr.inner().num_terms() == 0 && expr.constant() == 0.0 {
+            continue;
+        }
+        out_indices.push(idx);
+        out_values.push(expr);
+    }
+
+    Ok(
+        PyExprArray::from_sparse(out_index_sets, out_shape, out_indices, out_values)
+            .into_pyobject(py)?
+            .into_any()
+            .unbind(),
+    )
+}
+
+fn sparse_rolled_flat_index(
+    flat_idx: usize,
+    shape: &[usize],
+    strides: &[usize],
+    roll_axis: usize,
+    shift: isize,
+) -> usize {
+    let axis_size = shape[roll_axis];
+    let mut remainder = flat_idx;
+    let mut output_flat = 0usize;
+
+    for (axis, stride) in strides.iter().copied().enumerate().take(shape.len()) {
+        let mut coordinate = remainder / stride;
+        remainder %= stride;
+        if axis == roll_axis && axis_size > 0 {
+            coordinate = (coordinate as isize + shift).rem_euclid(axis_size as isize) as usize;
+        }
+        output_flat += coordinate * stride;
+    }
+
+    output_flat
+}
+
+pub(super) fn roll_sparse_expr(
+    index_sets: &[Py<PyIndexSet>],
+    shape: &[usize],
+    active_indices: &[usize],
+    values: &[PyExpr],
+    py: Python<'_>,
+    shift: isize,
+    over: &Bound<'_, PyAny>,
+) -> PyResult<PyObject> {
+    let axes = parse_sparse_axes(index_sets, py, over)?;
+    if axes.len() != 1 {
+        return Err(ArrayDimensionError::new_err(
+            "np.roll requires exactly one IndexSet axis",
+        ));
+    }
+
+    if shape[axes[0]] == 0 {
+        return Ok(PyExprArray::from_sparse(
+            Python::attach(|py| index_sets.iter().map(|set| set.clone_ref(py)).collect()),
+            shape.to_vec(),
+            Vec::new(),
+            Vec::new(),
+        )
+        .into_pyobject(py)?
+        .into_any()
+        .unbind());
+    }
+
+    let strides = arco_arrays::row_major_strides(shape);
+    let mut rolled = active_indices
+        .iter()
+        .copied()
+        .zip(values.iter().cloned())
+        .map(|(active_idx, expr)| {
+            (
+                sparse_rolled_flat_index(active_idx, shape, &strides, axes[0], shift),
+                expr,
+            )
+        })
+        .collect::<Vec<_>>();
+    rolled.sort_unstable_by_key(|(idx, _)| *idx);
+
+    let (out_indices, out_values): (Vec<_>, Vec<_>) = rolled.into_iter().unzip();
+    Ok(PyExprArray::from_sparse(
+        Python::attach(|py| index_sets.iter().map(|set| set.clone_ref(py)).collect()),
+        shape.to_vec(),
+        out_indices,
+        out_values,
+    )
+    .into_pyobject(py)?
+    .into_any()
+    .unbind())
+}
+
+pub(super) fn combine_sparse_expr_same_shape(
+    index_sets: &[Py<PyIndexSet>],
+    shape: &[usize],
+    left_indices: &[usize],
+    left_values: &[PyExpr],
+    right_indices: &[usize],
+    right_values: &[PyExpr],
+    right_scale: f64,
+) -> PyExprArray {
+    let mut left_pos = 0usize;
+    let mut right_pos = 0usize;
+    let mut out_indices = Vec::with_capacity(left_indices.len().max(right_indices.len()));
+    let mut out_values = Vec::with_capacity(out_indices.capacity());
+
+    while left_pos < left_indices.len() || right_pos < right_indices.len() {
+        let left_idx = left_indices.get(left_pos).copied();
+        let right_idx = right_indices.get(right_pos).copied();
+        let current_idx = match (left_idx, right_idx) {
+            (Some(left), Some(right)) => left.min(right),
+            (Some(left), None) => left,
+            (None, Some(right)) => right,
+            (None, None) => break,
+        };
+
+        let mut expr = PyExpr::default();
+        if left_idx == Some(current_idx) {
+            expr.add_assign(&left_values[left_pos]);
+            left_pos += 1;
+        }
+        if right_idx == Some(current_idx) {
+            expr.add_assign_owned(right_values[right_pos].scale(right_scale));
+            right_pos += 1;
+        }
+
+        if expr.inner().num_terms() == 0 && expr.constant() == 0.0 {
+            continue;
+        }
+        out_indices.push(current_idx);
+        out_values.push(expr);
+    }
+
+    PyExprArray::from_sparse(
+        Python::attach(|py| index_sets.iter().map(|set| set.clone_ref(py)).collect()),
+        shape.to_vec(),
+        out_indices,
+        out_values,
+    )
+}
+
+pub(super) fn compare_sparse_expr_same_shape(
+    index_sets: &[Py<PyIndexSet>],
+    shape: &[usize],
+    left_indices: &[usize],
+    left_values: &[PyExpr],
+    right_indices: &[usize],
+    right_values: &[PyExpr],
+    sense: ComparisonSense,
+) -> PyConstraintArray {
+    let mut left_pos = 0usize;
+    let mut right_pos = 0usize;
+    let mut exprs = Vec::with_capacity(left_indices.len().max(right_indices.len()));
+    let mut rhs = Vec::with_capacity(exprs.capacity());
+    let mut active_indices = Vec::with_capacity(exprs.capacity());
+
+    while left_pos < left_indices.len() || right_pos < right_indices.len() {
+        let left_idx = left_indices.get(left_pos).copied();
+        let right_idx = right_indices.get(right_pos).copied();
+        let current_idx = match (left_idx, right_idx) {
+            (Some(left), Some(right)) => left.min(right),
+            (Some(left), None) => left,
+            (None, Some(right)) => right,
+            (None, None) => break,
+        };
+
+        let left_expr = if left_idx == Some(current_idx) {
+            let expr = left_values[left_pos].clone();
+            left_pos += 1;
+            expr
+        } else {
+            PyExpr::default()
+        };
+        let right_expr = if right_idx == Some(current_idx) {
+            let expr = right_values[right_pos].clone();
+            right_pos += 1;
+            expr
+        } else {
+            PyExpr::default()
+        };
+
+        let diff = left_expr.inner().add(&right_expr.inner().scale(-1.0));
+        let diff_expr = PyExpr::from_expr(diff);
+        if diff_expr.inner().num_terms() == 0 && diff_expr.constant() == 0.0 {
+            continue;
+        }
+        active_indices.push(current_idx);
+        rhs.push(-diff_expr.constant());
+        exprs.push(diff_expr.without_constant());
+    }
+
+    PyConstraintArray::from_sparse_rows(
+        exprs,
+        sense,
+        rhs,
+        active_indices,
+        shape.to_vec(),
+        Python::attach(|py| index_sets.iter().map(|set| set.clone_ref(py)).collect()),
+    )
 }
 
 fn parse_named_axes(
@@ -655,6 +1266,34 @@ pub(crate) struct CompactExprStorage {
     pub count: usize,
 }
 
+/// Sparse expression storage: inactive dense slots are implicit zeros.
+#[derive(Clone, Debug)]
+pub(crate) struct SparseExprStorage {
+    pub active_indices: Vec<usize>,
+    pub values: Vec<PyExpr>,
+}
+
+impl SparseExprStorage {
+    pub fn term_counts(&self) -> ExpressionTermCounts {
+        expression_term_counts(&self.values)
+    }
+
+    pub fn to_core(&self, index_sets: &[Py<PyIndexSet>], shape: &[usize]) -> LinearArrayCore {
+        let total = shape.iter().product();
+        let mut values = vec![PyExpr::default(); total];
+        for (active_idx, expr) in self.active_indices.iter().zip(self.values.iter()) {
+            values[*active_idx] = expr.clone();
+        }
+        Python::attach(|py| {
+            LinearArrayCore::new(
+                index_sets.iter().map(|set| set.clone_ref(py)).collect(),
+                shape.to_vec(),
+                values,
+            )
+        })
+    }
+}
+
 impl CompactExprStorage {
     /// Create from a single variable array (coefficient 1.0, constant 0.0).
     pub fn from_variable_array(start_var_id: u32, count: usize) -> Self {
@@ -781,6 +1420,11 @@ pub(crate) enum ExprArrayStorage {
         index_sets: Vec<Py<PyIndexSet>>,
         shape: Vec<usize>,
     },
+    Sparse {
+        storage: SparseExprStorage,
+        index_sets: Vec<Py<PyIndexSet>>,
+        shape: Vec<usize>,
+    },
 }
 
 impl ExprArrayStorage {
@@ -793,6 +1437,11 @@ impl ExprArrayStorage {
                 index_sets,
                 shape,
             } => storage.to_core(index_sets, shape),
+            ExprArrayStorage::Sparse {
+                storage,
+                index_sets,
+                shape,
+            } => storage.to_core(index_sets, shape),
         }
     }
 
@@ -800,6 +1449,7 @@ impl ExprArrayStorage {
         match self {
             ExprArrayStorage::Full(core) => core.values.len(),
             ExprArrayStorage::Compact { storage, .. } => storage.count,
+            ExprArrayStorage::Sparse { shape, .. } => shape.iter().product(),
         }
     }
 
@@ -807,6 +1457,7 @@ impl ExprArrayStorage {
         match self {
             ExprArrayStorage::Full(core) => &core.shape,
             ExprArrayStorage::Compact { shape, .. } => shape,
+            ExprArrayStorage::Sparse { shape, .. } => shape,
         }
     }
 
@@ -814,6 +1465,7 @@ impl ExprArrayStorage {
         match self {
             ExprArrayStorage::Full(core) => &core.index_sets,
             ExprArrayStorage::Compact { index_sets, .. } => index_sets,
+            ExprArrayStorage::Sparse { index_sets, .. } => index_sets,
         }
     }
 
@@ -830,7 +1482,14 @@ impl ExprArrayStorage {
     pub fn as_compact(&self) -> Option<&CompactExprStorage> {
         match self {
             ExprArrayStorage::Compact { storage, .. } => Some(storage),
-            ExprArrayStorage::Full(_) => None,
+            ExprArrayStorage::Full(_) | ExprArrayStorage::Sparse { .. } => None,
+        }
+    }
+
+    pub fn as_sparse(&self) -> Option<&SparseExprStorage> {
+        match self {
+            ExprArrayStorage::Sparse { storage, .. } => Some(storage),
+            ExprArrayStorage::Full(_) | ExprArrayStorage::Compact { .. } => None,
         }
     }
 }

--- a/bindings/python/src/arrays/constraint_array.rs
+++ b/bindings/python/src/arrays/constraint_array.rs
@@ -12,6 +12,8 @@ use crate::py_modules::index_set::PyIndexSet;
 use super::CompactTerm;
 use super::LinearArrayCore;
 
+pub(crate) type SparseConstraintRows<'a> = (&'a [PyExpr], &'a [f64], &'a [usize], ComparisonSense);
+
 /// Right-hand side for compact constraints.
 #[derive(Clone, Debug)]
 pub(crate) enum CompactRhs {
@@ -57,6 +59,12 @@ pub(crate) enum ConstraintArrayStorage {
         sense: ComparisonSense,
         rhs: Vec<f64>,
     },
+    SparseRows {
+        exprs: Vec<PyExpr>,
+        sense: ComparisonSense,
+        rhs: Vec<f64>,
+        active_indices: Vec<usize>,
+    },
     /// Lazy array-vs-array comparison used to apply active masks before
     /// allocating per-row terms.
     LazyCompare {
@@ -97,6 +105,28 @@ impl PyConstraintArray {
         }
     }
 
+    pub(crate) fn from_sparse_rows(
+        exprs: Vec<PyExpr>,
+        sense: ComparisonSense,
+        rhs: Vec<f64>,
+        active_indices: Vec<usize>,
+        shape: Vec<usize>,
+        index_sets: Vec<Py<PyIndexSet>>,
+    ) -> Self {
+        Self {
+            storage: ConstraintArrayStorage::SparseRows {
+                exprs,
+                sense,
+                rhs,
+                active_indices,
+            },
+            shape,
+            index_sets,
+            first_constraint_id: None,
+            name: None,
+        }
+    }
+
     /// Create a ConstraintArray from compact constraint storage.
     pub(crate) fn from_compact(
         compact: CompactConstraintStorage,
@@ -130,7 +160,8 @@ impl PyConstraintArray {
 
     pub fn exprs(&self) -> &[PyExpr] {
         match &self.storage {
-            ConstraintArrayStorage::Full { exprs, .. } => exprs,
+            ConstraintArrayStorage::Full { exprs, .. }
+            | ConstraintArrayStorage::SparseRows { exprs, .. } => exprs,
             ConstraintArrayStorage::LazyCompare { .. } => &[],
             ConstraintArrayStorage::Compact(_) => &[], // Should not be called on compact
         }
@@ -138,7 +169,8 @@ impl PyConstraintArray {
 
     pub fn get_sense(&self) -> ComparisonSense {
         match &self.storage {
-            ConstraintArrayStorage::Full { sense, .. } => *sense,
+            ConstraintArrayStorage::Full { sense, .. }
+            | ConstraintArrayStorage::SparseRows { sense, .. } => *sense,
             ConstraintArrayStorage::LazyCompare { sense, .. } => *sense,
             ConstraintArrayStorage::Compact(c) => c.sense,
         }
@@ -146,7 +178,8 @@ impl PyConstraintArray {
 
     pub fn get_rhs(&self) -> Vec<f64> {
         match &self.storage {
-            ConstraintArrayStorage::Full { rhs, .. } => rhs.clone(),
+            ConstraintArrayStorage::Full { rhs, .. }
+            | ConstraintArrayStorage::SparseRows { rhs, .. } => rhs.clone(),
             ConstraintArrayStorage::LazyCompare { left, right, .. } => left
                 .values
                 .iter()
@@ -177,7 +210,7 @@ impl PyConstraintArray {
     pub(crate) fn as_compact(&self) -> Option<&CompactConstraintStorage> {
         match &self.storage {
             ConstraintArrayStorage::Compact(c) => Some(c),
-            ConstraintArrayStorage::Full { .. } => None,
+            ConstraintArrayStorage::Full { .. } | ConstraintArrayStorage::SparseRows { .. } => None,
             ConstraintArrayStorage::LazyCompare { .. } => None,
         }
     }
@@ -189,7 +222,23 @@ impl PyConstraintArray {
             ConstraintArrayStorage::LazyCompare { left, right, sense } => {
                 Some((left, right, *sense))
             }
-            ConstraintArrayStorage::Full { .. } | ConstraintArrayStorage::Compact(_) => None,
+            ConstraintArrayStorage::Full { .. }
+            | ConstraintArrayStorage::SparseRows { .. }
+            | ConstraintArrayStorage::Compact(_) => None,
+        }
+    }
+
+    pub(crate) fn as_sparse_rows(&self) -> Option<SparseConstraintRows<'_>> {
+        match &self.storage {
+            ConstraintArrayStorage::SparseRows {
+                exprs,
+                sense,
+                rhs,
+                active_indices,
+            } => Some((exprs, rhs, active_indices, *sense)),
+            ConstraintArrayStorage::Full { .. }
+            | ConstraintArrayStorage::LazyCompare { .. }
+            | ConstraintArrayStorage::Compact(_) => None,
         }
     }
 
@@ -238,7 +287,8 @@ impl PyConstraintArray {
 
     fn len(&self) -> usize {
         match &self.storage {
-            ConstraintArrayStorage::Full { rhs, .. } => rhs.len(),
+            ConstraintArrayStorage::Full { rhs, .. }
+            | ConstraintArrayStorage::SparseRows { rhs, .. } => rhs.len(),
             ConstraintArrayStorage::LazyCompare { left, .. } => left.values.len(),
             ConstraintArrayStorage::Compact(c) => c.count,
         }
@@ -247,7 +297,8 @@ impl PyConstraintArray {
     /// Get the rhs value at a specific index without allocating.
     fn rhs_at(&self, index: usize) -> f64 {
         match &self.storage {
-            ConstraintArrayStorage::Full { rhs, .. } => rhs[index],
+            ConstraintArrayStorage::Full { rhs, .. }
+            | ConstraintArrayStorage::SparseRows { rhs, .. } => rhs[index],
             ConstraintArrayStorage::LazyCompare { left, right, .. } => {
                 let diff = left.values[index]
                     .inner()
@@ -321,8 +372,7 @@ impl PyConstraintArray {
             .collect::<PyResult<Vec<_>>>()?;
         Ok(PyList::new(py, constraints)?
             .call_method0("__iter__")?
-            .unbind()
-            .into())
+            .unbind())
     }
 
     fn __getitem__(&self, index: usize) -> PyResult<PyConstraint> {

--- a/bindings/python/src/arrays/expr_array.rs
+++ b/bindings/python/src/arrays/expr_array.rs
@@ -12,8 +12,11 @@ use super::indexing::{
 };
 use crate::py_modules::arrays::{
     CompactExprStorage, ComparisonSense, ExprArrayStorage, ExpressionTermCounts, LinearArrayCore,
-    PyConstraintArray, array_cumsum, array_diff, array_roll, compare_with_compact_fallback,
-    expression_term_counts, set_solver_matrix_memory_estimate, try_extract_compact,
+    PyConstraintArray, PyVariableArray, SparseExprStorage, array_cumsum, array_diff, array_roll,
+    combine_sparse_expr_same_shape, compare_sparse_expr_same_shape, compare_with_compact_fallback,
+    diff_sparse_expr, expression_term_counts, multiply_sparse_expr_with_labeled_operand,
+    multiply_sparse_expr_with_scalar, roll_sparse_expr, set_solver_matrix_memory_estimate,
+    sum_sparse_expr, try_extract_compact,
 };
 
 /// A multi-dimensional array of linear expressions.
@@ -38,6 +41,24 @@ impl PyExprArray {
         Self {
             storage: ExprArrayStorage::Compact {
                 storage: compact,
+                index_sets,
+                shape,
+            },
+        }
+    }
+
+    pub(crate) fn from_sparse(
+        index_sets: Vec<Py<PyIndexSet>>,
+        shape: Vec<usize>,
+        active_indices: Vec<usize>,
+        values: Vec<PyExpr>,
+    ) -> Self {
+        Self {
+            storage: ExprArrayStorage::Sparse {
+                storage: SparseExprStorage {
+                    active_indices,
+                    values,
+                },
                 index_sets,
                 shape,
             },
@@ -69,6 +90,38 @@ impl PyExprArray {
         rhs: &Bound<'_, PyAny>,
         sense: ComparisonSense,
     ) -> PyResult<PyConstraintArray> {
+        if let Some((left_indices, left_values)) = self.sparse_entries() {
+            if let Ok(rhs_array) = rhs.extract::<PyRef<'_, PyExprArray>>() {
+                if rhs_array.storage.shape() == self.storage.shape() {
+                    if let Some((right_indices, right_values)) = rhs_array.sparse_entries() {
+                        return Ok(compare_sparse_expr_same_shape(
+                            self.storage.index_sets_ref(),
+                            self.storage.shape(),
+                            left_indices,
+                            left_values,
+                            right_indices,
+                            right_values,
+                            sense,
+                        ));
+                    }
+                }
+            }
+            if let Ok(rhs_array) = rhs.extract::<PyRef<'_, PyVariableArray>>() {
+                if rhs_array.get_shape() == self.storage.shape() {
+                    if let Some((right_indices, right_values)) = rhs_array.sparse_expr_entries() {
+                        return Ok(compare_sparse_expr_same_shape(
+                            self.storage.index_sets_ref(),
+                            self.storage.shape(),
+                            left_indices,
+                            left_values,
+                            right_indices,
+                            &right_values,
+                            sense,
+                        ));
+                    }
+                }
+            }
+        }
         compare_with_compact_fallback(
             self.as_compact(),
             self.storage.shape(),
@@ -168,12 +221,18 @@ impl PyExprArray {
                 index_sets,
                 shape,
             } => storage.to_core(index_sets, shape).values,
+            ExprArrayStorage::Sparse {
+                storage,
+                index_sets,
+                shape,
+            } => storage.to_core(index_sets, shape).values,
         }
     }
 
     fn storage_kind(&self) -> &'static str {
         match &self.storage {
             ExprArrayStorage::Compact { .. } => "compact",
+            ExprArrayStorage::Sparse { .. } => "sparse",
             ExprArrayStorage::Full(_) => "full",
         }
     }
@@ -181,7 +240,73 @@ impl PyExprArray {
     fn term_counts(&self) -> ExpressionTermCounts {
         match &self.storage {
             ExprArrayStorage::Compact { storage, .. } => storage.term_counts(),
+            ExprArrayStorage::Sparse { storage, .. } => storage.term_counts(),
             ExprArrayStorage::Full(core) => expression_term_counts(&core.values),
+        }
+    }
+
+    pub(crate) fn sparse_entries(&self) -> Option<(&[usize], &[PyExpr])> {
+        self.storage
+            .as_sparse()
+            .map(|storage| (storage.active_indices.as_slice(), storage.values.as_slice()))
+    }
+
+    fn relabeled_axis(
+        &self,
+        py: Python<'_>,
+        old_axis: &Bound<'_, PyIndexSet>,
+        new_axis: &Bound<'_, PyIndexSet>,
+    ) -> PyResult<Self> {
+        let old_name = old_axis.borrow().name.clone();
+        let new_len = new_axis.borrow().members.len();
+        let index_sets = self.storage.index_sets_ref();
+        let mut axis_idx = None;
+        for (idx, index_set) in index_sets.iter().enumerate() {
+            let stored = index_set.bind(py).borrow();
+            if stored.name == old_name {
+                if stored.members.len() != new_len {
+                    return Err(ArrayDimensionError::new_err(format!(
+                        "cannot relabel axis '{}' of length {} to '{}' of length {}",
+                        stored.name,
+                        stored.members.len(),
+                        new_axis.borrow().name,
+                        new_len
+                    )));
+                }
+                axis_idx = Some(idx);
+                break;
+            }
+        }
+        let axis_idx = axis_idx.ok_or_else(|| {
+            ArrayIndexError::new_err(format!(
+                "IndexSet '{}' is not a dimension of this array",
+                old_name
+            ))
+        })?;
+
+        let mut new_index_sets = index_sets
+            .iter()
+            .map(|index_set| index_set.clone_ref(py))
+            .collect::<Vec<_>>();
+        new_index_sets[axis_idx] = new_axis.clone().unbind();
+
+        match &self.storage {
+            ExprArrayStorage::Full(core) => Ok(Self::new(
+                new_index_sets,
+                core.shape.clone(),
+                core.values.clone(),
+            )),
+            ExprArrayStorage::Compact { storage, shape, .. } => Ok(Self::from_compact(
+                storage.clone(),
+                new_index_sets,
+                shape.clone(),
+            )),
+            ExprArrayStorage::Sparse { storage, shape, .. } => Ok(Self::from_sparse(
+                new_index_sets,
+                shape.clone(),
+                storage.active_indices.clone(),
+                storage.values.clone(),
+            )),
         }
     }
 }
@@ -198,6 +323,38 @@ impl PyExprArray {
             }
             if let Ok(value) = other.extract::<f64>() {
                 return Ok(self.wrap_compact(self_compact.add_constant(value)));
+            }
+        }
+        if let Some((left_indices, left_values)) = self.sparse_entries() {
+            if let Ok(other_array) = other.extract::<PyRef<'_, PyExprArray>>() {
+                if other_array.storage.shape() == self.storage.shape() {
+                    if let Some((right_indices, right_values)) = other_array.sparse_entries() {
+                        return Ok(combine_sparse_expr_same_shape(
+                            self.storage.index_sets_ref(),
+                            self.storage.shape(),
+                            left_indices,
+                            left_values,
+                            right_indices,
+                            right_values,
+                            1.0,
+                        ));
+                    }
+                }
+            }
+            if let Ok(other_array) = other.extract::<PyRef<'_, PyVariableArray>>() {
+                if other_array.get_shape() == self.storage.shape() {
+                    if let Some((right_indices, right_values)) = other_array.sparse_expr_entries() {
+                        return Ok(combine_sparse_expr_same_shape(
+                            self.storage.index_sets_ref(),
+                            self.storage.shape(),
+                            left_indices,
+                            left_values,
+                            right_indices,
+                            &right_values,
+                            1.0,
+                        ));
+                    }
+                }
             }
         }
         let core = self.to_core();
@@ -219,6 +376,38 @@ impl PyExprArray {
                 return Ok(self.wrap_compact(self_compact.add_constant(-value)));
             }
         }
+        if let Some((left_indices, left_values)) = self.sparse_entries() {
+            if let Ok(other_array) = other.extract::<PyRef<'_, PyExprArray>>() {
+                if other_array.storage.shape() == self.storage.shape() {
+                    if let Some((right_indices, right_values)) = other_array.sparse_entries() {
+                        return Ok(combine_sparse_expr_same_shape(
+                            self.storage.index_sets_ref(),
+                            self.storage.shape(),
+                            left_indices,
+                            left_values,
+                            right_indices,
+                            right_values,
+                            -1.0,
+                        ));
+                    }
+                }
+            }
+            if let Ok(other_array) = other.extract::<PyRef<'_, PyVariableArray>>() {
+                if other_array.get_shape() == self.storage.shape() {
+                    if let Some((right_indices, right_values)) = other_array.sparse_expr_entries() {
+                        return Ok(combine_sparse_expr_same_shape(
+                            self.storage.index_sets_ref(),
+                            self.storage.shape(),
+                            left_indices,
+                            left_values,
+                            right_indices,
+                            &right_values,
+                            -1.0,
+                        ));
+                    }
+                }
+            }
+        }
         let core = self.to_core();
         super::array_sub(&core, other)
     }
@@ -234,6 +423,38 @@ impl PyExprArray {
                 }
             }
         }
+        if let Some((right_indices, right_values)) = self.sparse_entries() {
+            if let Ok(other_array) = other.extract::<PyRef<'_, PyExprArray>>() {
+                if other_array.storage.shape() == self.storage.shape() {
+                    if let Some((left_indices, left_values)) = other_array.sparse_entries() {
+                        return Ok(combine_sparse_expr_same_shape(
+                            self.storage.index_sets_ref(),
+                            self.storage.shape(),
+                            left_indices,
+                            left_values,
+                            right_indices,
+                            right_values,
+                            -1.0,
+                        ));
+                    }
+                }
+            }
+            if let Ok(other_array) = other.extract::<PyRef<'_, PyVariableArray>>() {
+                if other_array.get_shape() == self.storage.shape() {
+                    if let Some((left_indices, left_values)) = other_array.sparse_expr_entries() {
+                        return Ok(combine_sparse_expr_same_shape(
+                            self.storage.index_sets_ref(),
+                            self.storage.shape(),
+                            left_indices,
+                            &left_values,
+                            right_indices,
+                            right_values,
+                            -1.0,
+                        ));
+                    }
+                }
+            }
+        }
         let core = self.to_core();
         super::array_rsub(&core, other)
     }
@@ -244,12 +465,38 @@ impl PyExprArray {
                 return Ok(self.wrap_compact(self_compact.scale(scalar)));
             }
         }
+        if let ExprArrayStorage::Sparse {
+            storage,
+            index_sets,
+            shape,
+        } = &self.storage
+        {
+            if let Ok(scalar) = other.extract::<f64>() {
+                return Ok(multiply_sparse_expr_with_scalar(
+                    index_sets, shape, storage, scalar,
+                ));
+            }
+            if let Some(result) =
+                multiply_sparse_expr_with_labeled_operand(index_sets, storage, other.py(), other)?
+            {
+                return Ok(result);
+            }
+        }
         let core = self.to_core();
         super::array_mul(&core, other)
     }
 
     fn __rmul__(&self, other: &Bound<'_, PyAny>) -> PyResult<PyExprArray> {
         self.__mul__(other)
+    }
+
+    fn relabel_axis(
+        &self,
+        py: Python<'_>,
+        old_axis: &Bound<'_, PyIndexSet>,
+        new_axis: &Bound<'_, PyIndexSet>,
+    ) -> PyResult<PyExprArray> {
+        self.relabeled_axis(py, old_axis, new_axis)
     }
 
     fn __truediv__(&self, other: f64) -> PyResult<PyExprArray> {
@@ -292,6 +539,14 @@ impl PyExprArray {
                 return Ok(result.into_pyobject(py)?.into_any().unbind());
             }
         }
+        if let ExprArrayStorage::Sparse {
+            storage,
+            index_sets,
+            shape,
+        } = &self.storage
+        {
+            return sum_sparse_expr(index_sets, shape, storage, py, over);
+        }
         let core = self.to_core();
         super::array_sum(&core, py, over)
     }
@@ -302,21 +557,68 @@ impl PyExprArray {
     }
     #[pyo3(signature = (*, over))]
     fn diff(&self, py: Python<'_>, over: &Bound<'_, PyAny>) -> PyResult<PyObject> {
+        if let ExprArrayStorage::Sparse {
+            storage,
+            index_sets,
+            shape,
+        } = &self.storage
+        {
+            return diff_sparse_expr(
+                index_sets,
+                shape,
+                &storage.active_indices,
+                &storage.values,
+                py,
+                over,
+            );
+        }
         let core = self.to_core();
         array_diff(&core, py, over)
     }
     #[pyo3(signature = (*, shift, over))]
     fn roll(&self, py: Python<'_>, shift: isize, over: &Bound<'_, PyAny>) -> PyResult<PyObject> {
+        if let ExprArrayStorage::Sparse {
+            storage,
+            index_sets,
+            shape,
+        } = &self.storage
+        {
+            return roll_sparse_expr(
+                index_sets,
+                shape,
+                &storage.active_indices,
+                &storage.values,
+                py,
+                shift,
+                over,
+            );
+        }
         let core = self.to_core();
         array_roll(&core, py, shift, over)
     }
 
     fn __rshift__(&self, py: Python<'_>, rhs: &Bound<'_, PyAny>) -> PyResult<PyObject> {
+        if let ExprArrayStorage::Sparse {
+            storage,
+            index_sets,
+            shape,
+        } = &self.storage
+        {
+            return sum_sparse_expr(index_sets, shape, storage, py, Some(rhs));
+        }
         let core = self.to_core();
         super::array_reduce(&core, py, rhs)
     }
 
     fn __matmul__(&self, py: Python<'_>, rhs: &Bound<'_, PyAny>) -> PyResult<PyObject> {
+        if let ExprArrayStorage::Sparse {
+            storage,
+            index_sets,
+            shape,
+        } = &self.storage
+        {
+            return sum_sparse_expr(index_sets, shape, storage, py, Some(rhs));
+        }
         let core = self.to_core();
         super::array_reduce(&core, py, rhs)
     }
@@ -349,22 +651,37 @@ impl PyExprArray {
     fn memory_estimate(&self, py: Python<'_>) -> PyResult<PyObject> {
         let term_counts = self.term_counts();
         let dense_slots = self.storage.count();
+        let active_slots = match &self.storage {
+            ExprArrayStorage::Sparse { storage, .. } => storage.active_indices.len(),
+            ExprArrayStorage::Full(_) | ExprArrayStorage::Compact { .. } => dense_slots,
+        };
+        let inactive_slots = dense_slots.saturating_sub(active_slots);
+        let active_density = if dense_slots == 0 {
+            0.0
+        } else {
+            active_slots as f64 / dense_slots as f64
+        };
         let estimate = PyDict::new(py);
         estimate.set_item("storage", self.storage_kind())?;
         estimate.set_item("dense_slots", dense_slots)?;
-        estimate.set_item("active_slots", dense_slots)?;
-        estimate.set_item("inactive_slots", 0usize)?;
-        estimate.set_item("active_density", if dense_slots == 0 { 0.0 } else { 1.0 })?;
+        estimate.set_item("active_slots", active_slots)?;
+        estimate.set_item("inactive_slots", inactive_slots)?;
+        estimate.set_item("active_density", active_density)?;
         estimate.set_item("linear_terms", term_counts.linear)?;
         estimate.set_item("quadratic_terms", term_counts.quadratic)?;
         estimate.set_item("cubic_terms", term_counts.cubic)?;
         estimate.set_item("estimated_term_bytes", term_counts.estimated_term_bytes())?;
         estimate.set_item(
             "estimated_dense_linear_term_bytes",
-            term_counts.estimated_term_bytes(),
+            dense_slots
+                .saturating_mul(std::mem::size_of::<(arco_ops::expression::VariableId, f64)>()),
         )?;
-        estimate.set_item("estimated_inactive_linear_term_bytes", 0usize)?;
-        set_solver_matrix_memory_estimate(&estimate, dense_slots, term_counts.linear)?;
+        estimate.set_item(
+            "estimated_inactive_linear_term_bytes",
+            inactive_slots
+                .saturating_mul(std::mem::size_of::<(arco_ops::expression::VariableId, f64)>()),
+        )?;
+        set_solver_matrix_memory_estimate(&estimate, active_slots, term_counts.linear)?;
         Ok(estimate.into_any().unbind())
     }
 
@@ -375,8 +692,7 @@ impl PyExprArray {
     fn __iter__(&self, py: Python<'_>) -> PyResult<PyObject> {
         Ok(PyList::new(py, self.get_values())?
             .call_method0("__iter__")?
-            .unbind()
-            .into())
+            .unbind())
     }
 
     #[pyo3(signature = (ufunc, method, *inputs, **kwargs))]
@@ -408,6 +724,57 @@ impl PyExprArray {
         args: &Bound<'_, PyTuple>,
         kwargs: &Bound<'_, PyAny>,
     ) -> PyResult<PyObject> {
+        let func_name = func.getattr("__name__")?.extract::<String>()?;
+        if func_name == "diff" {
+            if let ExprArrayStorage::Sparse {
+                storage,
+                index_sets,
+                shape,
+            } = &self.storage
+            {
+                let axis = kwargs.cast::<PyDict>()?.get_item("axis")?.ok_or_else(|| {
+                    ArrayDimensionError::new_err("np.diff requires axis=IndexSet")
+                })?;
+                return diff_sparse_expr(
+                    index_sets,
+                    shape,
+                    &storage.active_indices,
+                    &storage.values,
+                    py,
+                    &axis,
+                );
+            }
+        }
+        if func_name == "roll" {
+            if let ExprArrayStorage::Sparse {
+                storage,
+                index_sets,
+                shape,
+            } = &self.storage
+            {
+                let shift = if args.len() > 1 {
+                    args.get_item(1)?.extract::<isize>()?
+                } else {
+                    kwargs
+                        .cast::<PyDict>()?
+                        .get_item("shift")?
+                        .ok_or_else(|| ArrayDimensionError::new_err("np.roll requires shift"))?
+                        .extract::<isize>()?
+                };
+                let axis = kwargs.cast::<PyDict>()?.get_item("axis")?.ok_or_else(|| {
+                    ArrayDimensionError::new_err("np.roll requires axis=IndexSet")
+                })?;
+                return roll_sparse_expr(
+                    index_sets,
+                    shape,
+                    &storage.active_indices,
+                    &storage.values,
+                    py,
+                    shift,
+                    &axis,
+                );
+            }
+        }
         let core = self.to_core();
         super::array_function(&core, py, func, _types, args, kwargs)
     }

--- a/bindings/python/src/arrays/variable_array.rs
+++ b/bindings/python/src/arrays/variable_array.rs
@@ -19,7 +19,9 @@ use super::{
     CompactExprStorage, ComparisonSense, ExpressionTermCounts, PyConstraintArray, PyExprArray,
     array_add, array_cumsum, array_diff, array_function, array_mul, array_neg, array_reduce,
     array_roll, array_rsub, array_sub, array_sum, array_truediv, array_ufunc,
-    compare_with_compact_fallback, expression_term_counts, set_solver_matrix_memory_estimate,
+    combine_sparse_expr_same_shape, compare_with_compact_fallback, diff_sparse_expr,
+    expression_term_counts, multiply_sparse_variables_with_labeled_operand,
+    multiply_sparse_variables_with_scalar, roll_sparse_expr, set_solver_matrix_memory_estimate,
     try_extract_compact,
 };
 
@@ -54,10 +56,34 @@ struct FullStorage {
     variables: Vec<Option<PyVariable>>,
 }
 
+enum SparseBounds {
+    Uniform(BoundsSpec),
+    PerSlot(Vec<BoundsSpec>),
+}
+
+impl SparseBounds {
+    fn at(&self, active_pos: usize) -> BoundsSpec {
+        match self {
+            SparseBounds::Uniform(bounds) => *bounds,
+            SparseBounds::PerSlot(bounds) => bounds[active_pos],
+        }
+    }
+}
+
+/// Sparse storage for arrays with inactive dense slots.
+struct SparseStorage {
+    active_indices: Vec<usize>,
+    var_ids: Vec<u32>,
+    bounds: SparseBounds,
+    name: Option<String>,
+}
+
 /// Internal storage enum for VariableArray.
 enum VariableStorage {
     /// Compact: only metadata, no Vec<PyExpr> or Vec<PyVariable>.
     Compact(CompactStorage),
+    /// Sparse: only active variable slots are stored.
+    Sparse(SparseStorage),
     /// Full: stores all expressions and variables.
     Full(FullStorage),
 }
@@ -113,6 +139,47 @@ impl PyVariableArray {
         })
     }
 
+    /// Create a VariableArray with sparse active-slot storage.
+    pub fn new_active_sparse(
+        index_sets: Vec<Py<PyIndexSet>>,
+        shape: Vec<usize>,
+        active_indices: Vec<usize>,
+        var_ids: Vec<u32>,
+        bounds: BoundsSpec,
+        name: Option<String>,
+    ) -> Self {
+        Self {
+            storage: VariableStorage::Sparse(SparseStorage {
+                active_indices,
+                var_ids,
+                bounds: SparseBounds::Uniform(bounds),
+                name,
+            }),
+            index_sets,
+            shape,
+        }
+    }
+
+    pub fn new_active_sparse_with_bounds(
+        index_sets: Vec<Py<PyIndexSet>>,
+        shape: Vec<usize>,
+        active_indices: Vec<usize>,
+        var_ids: Vec<u32>,
+        bounds: Vec<BoundsSpec>,
+        name: Option<String>,
+    ) -> Self {
+        Self {
+            storage: VariableStorage::Sparse(SparseStorage {
+                active_indices,
+                var_ids,
+                bounds: SparseBounds::PerSlot(bounds),
+                name,
+            }),
+            index_sets,
+            shape,
+        }
+    }
+
     /// Create a VariableArray with compact storage (scalar bounds, contiguous var IDs).
     pub fn new_compact(
         index_sets: Vec<Py<PyIndexSet>>,
@@ -138,6 +205,14 @@ impl PyVariableArray {
     pub(crate) fn to_core(&self) -> LinearArrayCore {
         match &self.storage {
             VariableStorage::Full(full) => full.core.clone_with_gil(),
+            VariableStorage::Sparse(sparse) => {
+                let mut values = vec![PyExpr::from_expr(Expr::from_constant(0.0)); self.len()];
+                for (active_idx, var_id) in sparse.active_indices.iter().zip(sparse.var_ids.iter())
+                {
+                    values[*active_idx] = PyExpr::from_term(*var_id, 1.0);
+                }
+                LinearArrayCore::new(self.clone_index_sets(), self.shape.clone(), values)
+            }
             VariableStorage::Compact(compact) => {
                 let values = (0..compact.count)
                     .map(|i| PyExpr::from_term(compact.var_id_at(i), 1.0))
@@ -151,6 +226,7 @@ impl PyVariableArray {
     fn len(&self) -> usize {
         match &self.storage {
             VariableStorage::Compact(c) => c.count,
+            VariableStorage::Sparse(_) => self.shape.iter().product(),
             VariableStorage::Full(f) => f.core.values.len(),
         }
     }
@@ -158,6 +234,7 @@ impl PyVariableArray {
     fn active_len(&self) -> usize {
         match &self.storage {
             VariableStorage::Compact(c) => c.count,
+            VariableStorage::Sparse(sparse) => sparse.active_indices.len(),
             VariableStorage::Full(f) => f
                 .variables
                 .iter()
@@ -169,6 +246,7 @@ impl PyVariableArray {
     fn storage_kind(&self) -> &'static str {
         match &self.storage {
             VariableStorage::Compact(_) => "compact",
+            VariableStorage::Sparse(_) => "sparse",
             VariableStorage::Full(_) => "full",
         }
     }
@@ -179,6 +257,11 @@ impl PyVariableArray {
                 CompactExprStorage::from_variable_array(compact.start_var_id, compact.count)
                     .term_counts()
             }
+            VariableStorage::Sparse(sparse) => ExpressionTermCounts {
+                linear: sparse.active_indices.len(),
+                quadratic: 0,
+                cubic: 0,
+            },
             VariableStorage::Full(full) => expression_term_counts(&full.core.values),
         }
     }
@@ -223,6 +306,25 @@ impl PyVariableArray {
     fn variable_at(&self, idx: usize) -> Option<PyVariable> {
         match &self.storage {
             VariableStorage::Full(full) => full.variables.get(idx).cloned().flatten(),
+            VariableStorage::Sparse(sparse) => {
+                sparse
+                    .active_indices
+                    .binary_search(&idx)
+                    .ok()
+                    .map(|active_pos| {
+                        PyVariable::new(
+                            sparse.var_ids[active_pos],
+                            sparse.name.as_ref().map(|base| {
+                                if self.len() == 1 {
+                                    base.clone()
+                                } else {
+                                    format!("{base}[{idx}]")
+                                }
+                            }),
+                            sparse.bounds.at(active_pos),
+                        )
+                    })
+            }
             VariableStorage::Compact(compact) => {
                 if idx >= compact.count {
                     return None;
@@ -240,6 +342,15 @@ impl PyVariableArray {
     fn expr_at(&self, idx: usize) -> Option<PyExpr> {
         match &self.storage {
             VariableStorage::Full(full) => full.core.values.get(idx).cloned(),
+            VariableStorage::Sparse(_) => {
+                if idx >= self.len() {
+                    return None;
+                }
+                Some(self.variable_at(idx).map_or_else(
+                    || PyExpr::from_expr(Expr::from_constant(0.0)),
+                    |v| v.to_expr(),
+                ))
+            }
             VariableStorage::Compact(compact) => {
                 if idx >= compact.count {
                     return None;
@@ -252,6 +363,7 @@ impl PyVariableArray {
     pub fn get_values(&self) -> Vec<PyExpr> {
         match &self.storage {
             VariableStorage::Full(full) => full.core.values.clone(),
+            VariableStorage::Sparse(_) => self.to_core().values,
             VariableStorage::Compact(compact) => (0..compact.count)
                 .map(|i| PyExpr::from_term(compact.var_id_at(i), 1.0))
                 .collect(),
@@ -261,6 +373,24 @@ impl PyVariableArray {
     pub fn get_variable_refs(&self) -> Vec<PyVariable> {
         match &self.storage {
             VariableStorage::Full(full) => full.variables.iter().flatten().cloned().collect(),
+            VariableStorage::Sparse(sparse) => sparse
+                .active_indices
+                .iter()
+                .enumerate()
+                .map(|(active_pos, active_idx)| {
+                    PyVariable::new(
+                        sparse.var_ids[active_pos],
+                        sparse.name.as_ref().map(|base| {
+                            if self.len() == 1 {
+                                base.clone()
+                            } else {
+                                format!("{base}[{active_idx}]")
+                            }
+                        }),
+                        sparse.bounds.at(active_pos),
+                    )
+                })
+                .collect(),
             VariableStorage::Compact(compact) => (0..compact.count)
                 .map(|i| {
                     PyVariable::new(
@@ -276,6 +406,23 @@ impl PyVariableArray {
     pub fn get_variable_slots(&self) -> Vec<Option<PyVariable>> {
         match &self.storage {
             VariableStorage::Full(full) => full.variables.clone(),
+            VariableStorage::Sparse(sparse) => {
+                let mut slots = vec![None; self.len()];
+                for (active_pos, active_idx) in sparse.active_indices.iter().enumerate() {
+                    slots[*active_idx] = Some(PyVariable::new(
+                        sparse.var_ids[active_pos],
+                        sparse.name.as_ref().map(|base| {
+                            if self.len() == 1 {
+                                base.clone()
+                            } else {
+                                format!("{base}[{active_idx}]")
+                            }
+                        }),
+                        sparse.bounds.at(active_pos),
+                    ));
+                }
+                slots
+            }
             VariableStorage::Compact(compact) => (0..compact.count)
                 .map(|i| {
                     Some(PyVariable::new(
@@ -304,7 +451,22 @@ impl PyVariableArray {
                 c.start_var_id,
                 c.count,
             )),
+            VariableStorage::Sparse(_) => None,
             VariableStorage::Full(_) => None,
+        }
+    }
+
+    pub(crate) fn sparse_expr_entries(&self) -> Option<(&[usize], Vec<PyExpr>)> {
+        match &self.storage {
+            VariableStorage::Sparse(sparse) => Some((
+                sparse.active_indices.as_slice(),
+                sparse
+                    .var_ids
+                    .iter()
+                    .map(|var_id| PyExpr::from_term(*var_id, 1.0))
+                    .collect::<Vec<_>>(),
+            )),
+            VariableStorage::Compact(_) | VariableStorage::Full(_) => None,
         }
     }
 
@@ -317,11 +479,163 @@ impl PyVariableArray {
         PyExpr::from_expr(Expr::from_linear(linear))
     }
 
+    fn sum_all_sparse(sparse: &SparseStorage) -> PyExpr {
+        let linear = sparse
+            .var_ids
+            .iter()
+            .map(|var_id| (VariableId::new(*var_id), 1.0))
+            .collect();
+        PyExpr::from_expr(Expr::from_linear(linear))
+    }
+
+    fn find_axis_for_sparse_sum(
+        &self,
+        py: Python<'_>,
+        index_set: &Bound<'_, PyIndexSet>,
+    ) -> PyResult<usize> {
+        let target_ptr = index_set.as_ptr();
+        for (idx, stored) in self.index_sets.iter().enumerate() {
+            if stored.as_ptr() == target_ptr {
+                return Ok(idx);
+            }
+        }
+
+        let target_name = &index_set.borrow().name;
+        for (idx, stored) in self.index_sets.iter().enumerate() {
+            let stored_ref = stored.bind(py).borrow();
+            if &stored_ref.name == target_name {
+                return Ok(idx);
+            }
+        }
+
+        Err(ArrayIndexError::new_err(format!(
+            "IndexSet '{}' is not a dimension of this array",
+            index_set.borrow().name
+        )))
+    }
+
+    fn parse_sparse_sum_axes(
+        &self,
+        py: Python<'_>,
+        selection: &Bound<'_, PyAny>,
+    ) -> PyResult<Vec<usize>> {
+        let mut axes = Vec::new();
+        if let Ok(single) = selection.cast::<PyIndexSet>() {
+            axes.push(self.find_axis_for_sparse_sum(py, single)?);
+        } else {
+            let items: Vec<Bound<'_, PyAny>> =
+                selection.try_iter()?.collect::<PyResult<Vec<_>>>()?;
+            for item in &items {
+                let index_set = item.cast::<PyIndexSet>().map_err(|_| {
+                    ArrayDimensionError::new_err(
+                        "axis/over must be an IndexSet or tuple of IndexSets",
+                    )
+                })?;
+                axes.push(self.find_axis_for_sparse_sum(py, index_set)?);
+            }
+        }
+
+        let mut seen = Vec::with_capacity(axes.len());
+        for axis in &axes {
+            if seen.contains(axis) {
+                return Err(ArrayDimensionError::new_err(
+                    "axis/over cannot contain duplicate IndexSet dimensions",
+                ));
+            }
+            seen.push(*axis);
+        }
+        Ok(axes)
+    }
+
+    fn row_major_strides(shape: &[usize]) -> Vec<usize> {
+        let mut strides = vec![1; shape.len()];
+        let mut stride = 1;
+        for (idx, size) in shape.iter().enumerate().rev() {
+            strides[idx] = stride;
+            stride *= *size;
+        }
+        strides
+    }
+
+    fn reduced_flat_index(
+        flat_idx: usize,
+        shape: &[usize],
+        source_strides: &[usize],
+        reduced_strides: &[usize],
+        summed_axes: &[bool],
+    ) -> usize {
+        let mut remainder = flat_idx;
+        let mut reduced_axis = 0usize;
+        let mut reduced_idx = 0usize;
+
+        for axis in 0..shape.len() {
+            let coordinate = remainder / source_strides[axis];
+            remainder %= source_strides[axis];
+            if !summed_axes[axis] {
+                reduced_idx += coordinate * reduced_strides[reduced_axis];
+                reduced_axis += 1;
+            }
+        }
+
+        reduced_idx
+    }
+
+    fn sum_sparse_over_axis(
+        &self,
+        py: Python<'_>,
+        sparse: &SparseStorage,
+        over: &Bound<'_, PyAny>,
+    ) -> PyResult<PyObject> {
+        let axes = self.parse_sparse_sum_axes(py, over)?;
+        let mut summed_axes = vec![false; self.shape.len()];
+        for axis in axes {
+            summed_axes[axis] = true;
+        }
+
+        let mut out_shape = Vec::new();
+        let mut out_index_sets = Vec::new();
+        for (axis, index_set) in self.index_sets.iter().enumerate() {
+            if !summed_axes[axis] {
+                out_shape.push(self.shape[axis]);
+                out_index_sets.push(index_set.clone_ref(py));
+            }
+        }
+
+        let source_strides = Self::row_major_strides(&self.shape);
+        let reduced_strides = Self::row_major_strides(&out_shape);
+        let out_len = out_shape.iter().product::<usize>().max(1);
+        let mut values = vec![PyExpr::default(); out_len];
+
+        for (active_idx, var_id) in sparse.active_indices.iter().zip(sparse.var_ids.iter()) {
+            let reduced_idx = Self::reduced_flat_index(
+                *active_idx,
+                &self.shape,
+                &source_strides,
+                &reduced_strides,
+                &summed_axes,
+            );
+            values[reduced_idx].add_assign_owned(PyExpr::from_term(*var_id, 1.0));
+        }
+
+        if out_shape.is_empty() {
+            let expr = values.pop().unwrap_or_default();
+            Ok(expr.into_pyobject(py)?.into_any().unbind())
+        } else {
+            let array = PyExprArray::new(out_index_sets, out_shape, values);
+            Ok(array.into_pyobject(py)?.into_any().unbind())
+        }
+    }
+
     /// Collect linear terms directly for compact storage (for objective extraction).
     pub fn collect_linear_terms_fast(&self) -> Vec<(VariableId, f64)> {
         match &self.storage {
             VariableStorage::Compact(compact) => (0..compact.count)
                 .map(|i| (VariableId::new(compact.var_id_at(i)), 1.0))
+                .collect(),
+            VariableStorage::Sparse(sparse) => sparse
+                .var_ids
+                .iter()
+                .map(|var_id| (VariableId::new(*var_id), 1.0))
                 .collect(),
             VariableStorage::Full(full) => {
                 let total: usize = full
@@ -345,6 +659,14 @@ impl PyVariableArray {
         rhs: &Bound<'_, PyAny>,
         sense: ComparisonSense,
     ) -> PyResult<PyConstraintArray> {
+        if let VariableStorage::Sparse(sparse) = &self.storage {
+            if let Ok(rhs_array) = rhs.extract::<PyRef<'_, PyExprArray>>() {
+                if let Some(constraints) = self.compare_sparse_expr_rhs(sparse, &rhs_array, sense) {
+                    return Ok(constraints);
+                }
+            }
+        }
+
         let compact = self.as_compact_expr();
         compare_with_compact_fallback(
             compact.as_ref(),
@@ -354,6 +676,68 @@ impl PyVariableArray {
             rhs,
             sense,
         )
+    }
+
+    fn compare_sparse_expr_rhs(
+        &self,
+        sparse: &SparseStorage,
+        rhs_array: &PyExprArray,
+        sense: ComparisonSense,
+    ) -> Option<PyConstraintArray> {
+        if rhs_array.storage.shape() != self.shape {
+            return None;
+        }
+        let (rhs_indices, rhs_values) = rhs_array.sparse_entries()?;
+
+        let mut left_pos = 0usize;
+        let mut right_pos = 0usize;
+        let mut exprs = Vec::with_capacity(sparse.active_indices.len().max(rhs_indices.len()));
+        let mut rhs = Vec::with_capacity(exprs.capacity());
+        let mut active_indices = Vec::with_capacity(exprs.capacity());
+
+        while left_pos < sparse.active_indices.len() || right_pos < rhs_indices.len() {
+            let left_idx = sparse.active_indices.get(left_pos).copied();
+            let right_idx = rhs_indices.get(right_pos).copied();
+            let current_idx = match (left_idx, right_idx) {
+                (Some(left), Some(right)) => left.min(right),
+                (Some(left), None) => left,
+                (None, Some(right)) => right,
+                (None, None) => break,
+            };
+
+            let left_expr = if left_idx == Some(current_idx) {
+                let expr = PyExpr::from_term(sparse.var_ids[left_pos], 1.0);
+                left_pos += 1;
+                expr
+            } else {
+                PyExpr::default()
+            };
+            let right_expr = if right_idx == Some(current_idx) {
+                let expr = rhs_values[right_pos].clone();
+                right_pos += 1;
+                expr
+            } else {
+                PyExpr::default()
+            };
+
+            let diff = left_expr.inner().add(&right_expr.inner().scale(-1.0));
+            let diff_expr = PyExpr::from_expr(diff);
+            if diff_expr.inner().num_terms() == 0 && diff_expr.constant() == 0.0 {
+                continue;
+            }
+            active_indices.push(current_idx);
+            rhs.push(-diff_expr.constant());
+            exprs.push(diff_expr.without_constant());
+        }
+
+        Some(PyConstraintArray::from_sparse_rows(
+            exprs,
+            sense,
+            rhs,
+            active_indices,
+            self.shape.clone(),
+            self.clone_index_sets(),
+        ))
     }
 
     fn getitem_tuple(&self, py: Python<'_>, tuple: &Bound<'_, PyTuple>) -> PyResult<PyObject> {
@@ -479,6 +863,38 @@ impl PyVariableArray {
                 return Ok(self.wrap_compact_expr(self_compact.add_constant(value)));
             }
         }
+        if let Some((left_indices, left_values)) = self.sparse_expr_entries() {
+            if let Ok(other_array) = other.extract::<PyRef<'_, PyVariableArray>>() {
+                if other_array.shape == self.shape {
+                    if let Some((right_indices, right_values)) = other_array.sparse_expr_entries() {
+                        return Ok(combine_sparse_expr_same_shape(
+                            &self.index_sets,
+                            &self.shape,
+                            left_indices,
+                            &left_values,
+                            right_indices,
+                            &right_values,
+                            1.0,
+                        ));
+                    }
+                }
+            }
+            if let Ok(other_array) = other.extract::<PyRef<'_, PyExprArray>>() {
+                if other_array.storage.shape() == self.shape {
+                    if let Some((right_indices, right_values)) = other_array.sparse_entries() {
+                        return Ok(combine_sparse_expr_same_shape(
+                            &self.index_sets,
+                            &self.shape,
+                            left_indices,
+                            &left_values,
+                            right_indices,
+                            right_values,
+                            1.0,
+                        ));
+                    }
+                }
+            }
+        }
         let core = self.to_core();
         array_add(&core, other)
     }
@@ -496,6 +912,38 @@ impl PyVariableArray {
                 return Ok(self.wrap_compact_expr(self_compact.add_constant(-value)));
             }
         }
+        if let Some((left_indices, left_values)) = self.sparse_expr_entries() {
+            if let Ok(other_array) = other.extract::<PyRef<'_, PyVariableArray>>() {
+                if other_array.shape == self.shape {
+                    if let Some((right_indices, right_values)) = other_array.sparse_expr_entries() {
+                        return Ok(combine_sparse_expr_same_shape(
+                            &self.index_sets,
+                            &self.shape,
+                            left_indices,
+                            &left_values,
+                            right_indices,
+                            &right_values,
+                            -1.0,
+                        ));
+                    }
+                }
+            }
+            if let Ok(other_array) = other.extract::<PyRef<'_, PyExprArray>>() {
+                if other_array.storage.shape() == self.shape {
+                    if let Some((right_indices, right_values)) = other_array.sparse_entries() {
+                        return Ok(combine_sparse_expr_same_shape(
+                            &self.index_sets,
+                            &self.shape,
+                            left_indices,
+                            &left_values,
+                            right_indices,
+                            right_values,
+                            -1.0,
+                        ));
+                    }
+                }
+            }
+        }
         let core = self.to_core();
         array_sub(&core, other)
     }
@@ -510,6 +958,38 @@ impl PyVariableArray {
                 }
             }
         }
+        if let Some((right_indices, right_values)) = self.sparse_expr_entries() {
+            if let Ok(other_array) = other.extract::<PyRef<'_, PyVariableArray>>() {
+                if other_array.shape == self.shape {
+                    if let Some((left_indices, left_values)) = other_array.sparse_expr_entries() {
+                        return Ok(combine_sparse_expr_same_shape(
+                            &self.index_sets,
+                            &self.shape,
+                            left_indices,
+                            &left_values,
+                            right_indices,
+                            &right_values,
+                            -1.0,
+                        ));
+                    }
+                }
+            }
+            if let Ok(other_array) = other.extract::<PyRef<'_, PyExprArray>>() {
+                if other_array.storage.shape() == self.shape {
+                    if let Some((left_indices, left_values)) = other_array.sparse_entries() {
+                        return Ok(combine_sparse_expr_same_shape(
+                            &self.index_sets,
+                            &self.shape,
+                            left_indices,
+                            left_values,
+                            right_indices,
+                            &right_values,
+                            -1.0,
+                        ));
+                    }
+                }
+            }
+        }
         let core = self.to_core();
         array_rsub(&core, other)
     }
@@ -517,6 +997,26 @@ impl PyVariableArray {
         if let Some(self_compact) = self.as_compact_expr() {
             if let Ok(scalar) = other.extract::<f64>() {
                 return Ok(self.wrap_compact_expr(self_compact.scale(scalar)));
+            }
+        }
+        if let VariableStorage::Sparse(sparse) = &self.storage {
+            if let Ok(scalar) = other.extract::<f64>() {
+                return Ok(multiply_sparse_variables_with_scalar(
+                    &self.index_sets,
+                    &self.shape,
+                    &sparse.active_indices,
+                    &sparse.var_ids,
+                    scalar,
+                ));
+            }
+            if let Some(result) = multiply_sparse_variables_with_labeled_operand(
+                &self.index_sets,
+                &sparse.active_indices,
+                &sparse.var_ids,
+                other.py(),
+                other,
+            )? {
+                return Ok(result);
             }
         }
         let core = self.to_core();
@@ -561,6 +1061,13 @@ impl PyVariableArray {
                 let result = Self::sum_all_compact(compact.start_var_id, compact.count);
                 return Ok(result.into_pyobject(py)?.into_any().unbind());
             }
+            if let VariableStorage::Sparse(sparse) = &self.storage {
+                let result = Self::sum_all_sparse(sparse);
+                return Ok(result.into_pyobject(py)?.into_any().unbind());
+            }
+        }
+        if let (VariableStorage::Sparse(sparse), Some(over)) = (&self.storage, over) {
+            return self.sum_sparse_over_axis(py, sparse, over);
         }
         let core = self.to_core();
         array_sum(&core, py, over)
@@ -572,19 +1079,56 @@ impl PyVariableArray {
     }
     #[pyo3(signature = (*, over))]
     fn diff(&self, py: Python<'_>, over: &Bound<'_, PyAny>) -> PyResult<PyObject> {
+        if let VariableStorage::Sparse(sparse) = &self.storage {
+            let values = sparse
+                .var_ids
+                .iter()
+                .map(|var_id| PyExpr::from_term(*var_id, 1.0))
+                .collect::<Vec<_>>();
+            return diff_sparse_expr(
+                &self.index_sets,
+                &self.shape,
+                &sparse.active_indices,
+                &values,
+                py,
+                over,
+            );
+        }
         let core = self.to_core();
         array_diff(&core, py, over)
     }
     #[pyo3(signature = (*, shift, over))]
     fn roll(&self, py: Python<'_>, shift: isize, over: &Bound<'_, PyAny>) -> PyResult<PyObject> {
+        if let VariableStorage::Sparse(sparse) = &self.storage {
+            let values = sparse
+                .var_ids
+                .iter()
+                .map(|var_id| PyExpr::from_term(*var_id, 1.0))
+                .collect::<Vec<_>>();
+            return roll_sparse_expr(
+                &self.index_sets,
+                &self.shape,
+                &sparse.active_indices,
+                &values,
+                py,
+                shift,
+                over,
+            );
+        }
         let core = self.to_core();
         array_roll(&core, py, shift, over)
     }
     fn __rshift__(&self, py: Python<'_>, rhs: &Bound<'_, PyAny>) -> PyResult<PyObject> {
+        if let VariableStorage::Sparse(sparse) = &self.storage {
+            return self.sum_sparse_over_axis(py, sparse, rhs);
+        }
         let core = self.to_core();
         array_reduce(&core, py, rhs)
     }
     fn __matmul__(&self, py: Python<'_>, rhs: &Bound<'_, PyAny>) -> PyResult<PyObject> {
+        if let VariableStorage::Sparse(sparse) = &self.storage {
+            return self.sum_sparse_over_axis(py, sparse, rhs);
+        }
         let core = self.to_core();
         array_reduce(&core, py, rhs)
     }
@@ -674,10 +1218,7 @@ impl PyVariableArray {
                 items.push(expr.into_pyobject(py)?.into_any().unbind());
             }
         }
-        Ok(PyList::new(py, items)?
-            .call_method0("__iter__")?
-            .unbind()
-            .into())
+        Ok(PyList::new(py, items)?.call_method0("__iter__")?.unbind())
     }
 
     #[pyo3(signature = (ufunc, method, *inputs, **kwargs))]
@@ -708,6 +1249,57 @@ impl PyVariableArray {
         args: &Bound<'_, PyTuple>,
         kwargs: &Bound<'_, PyAny>,
     ) -> PyResult<PyObject> {
+        let func_name = func.getattr("__name__")?.extract::<String>()?;
+        if func_name == "diff" {
+            if let VariableStorage::Sparse(sparse) = &self.storage {
+                let axis = kwargs.cast::<PyDict>()?.get_item("axis")?.ok_or_else(|| {
+                    ArrayDimensionError::new_err("np.diff requires axis=IndexSet")
+                })?;
+                let values = sparse
+                    .var_ids
+                    .iter()
+                    .map(|var_id| PyExpr::from_term(*var_id, 1.0))
+                    .collect::<Vec<_>>();
+                return diff_sparse_expr(
+                    &self.index_sets,
+                    &self.shape,
+                    &sparse.active_indices,
+                    &values,
+                    py,
+                    &axis,
+                );
+            }
+        }
+        if func_name == "roll" {
+            if let VariableStorage::Sparse(sparse) = &self.storage {
+                let shift = if args.len() > 1 {
+                    args.get_item(1)?.extract::<isize>()?
+                } else {
+                    kwargs
+                        .cast::<PyDict>()?
+                        .get_item("shift")?
+                        .ok_or_else(|| ArrayDimensionError::new_err("np.roll requires shift"))?
+                        .extract::<isize>()?
+                };
+                let axis = kwargs.cast::<PyDict>()?.get_item("axis")?.ok_or_else(|| {
+                    ArrayDimensionError::new_err("np.roll requires axis=IndexSet")
+                })?;
+                let values = sparse
+                    .var_ids
+                    .iter()
+                    .map(|var_id| PyExpr::from_term(*var_id, 1.0))
+                    .collect::<Vec<_>>();
+                return roll_sparse_expr(
+                    &self.index_sets,
+                    &self.shape,
+                    &sparse.active_indices,
+                    &values,
+                    py,
+                    shift,
+                    &axis,
+                );
+            }
+        }
         let core = self.to_core();
         array_function(&core, py, func, _types, args, kwargs)
     }

--- a/bindings/python/src/bounds.rs
+++ b/bindings/python/src/bounds.rs
@@ -88,7 +88,7 @@ impl PyBounds {
 #[pymethods]
 impl PyBounds {
     #[new]
-    #[pyo3(signature = (*, lower=None, upper=None))]
+    #[pyo3(signature = (lower=None, upper=None))]
     fn new(
         _py: Python<'_>,
         lower: Option<&Bound<'_, PyAny>>,

--- a/bindings/python/src/index_set.rs
+++ b/bindings/python/src/index_set.rs
@@ -75,7 +75,7 @@ pub struct PyIndexSet {
 #[pymethods]
 impl PyIndexSet {
     #[new]
-    #[pyo3(signature = (*, name, size=None, members=None))]
+    #[pyo3(signature = (name, *, size=None, members=None))]
     fn new(name: String, size: Option<usize>, members: Option<Vec<PyObject>>) -> PyResult<Self> {
         match (size, members) {
             (Some(size), None) => {
@@ -194,10 +194,7 @@ impl PyIndexSet {
             .iter()
             .map(|member| member.to_pyobject(py))
             .collect::<PyResult<Vec<PyObject>>>()?;
-        Ok(PyList::new(py, items)?
-            .call_method0("__iter__")?
-            .unbind()
-            .into())
+        Ok(PyList::new(py, items)?.call_method0("__iter__")?.unbind())
     }
 
     fn __repr__(&self) -> String {

--- a/bindings/python/src/iterators.rs
+++ b/bindings/python/src/iterators.rs
@@ -42,10 +42,7 @@ impl PyConstraintIterator {
         let model = slf.model.borrow(py);
         let con_id = ConstraintId::new(i as u32);
         let con = model.inner.get_constraint(con_id).ok()?;
-        let name = model
-            .inner
-            .get_constraint_name(con_id)
-            .map(|s| s.to_string());
+        let name = model.reconstruct_constraint_name(i as u32);
         Some(PyConstraint::new(i as u32, name, con.bounds))
     }
 
@@ -89,7 +86,7 @@ impl PyVariableIterator {
         let model = slf.model.borrow(py);
         let var_id = VariableId::new(i as u32);
         let var = model.inner.get_variable(var_id).ok()?;
-        let name = model.inner.get_variable_name(var_id).map(|s| s.to_string());
+        let name = model.reconstruct_variable_name(i as u32);
         Some(PyVariable::from_model_variable(i as u32, name, &var))
     }
 

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -12,7 +12,7 @@ use arco_ops::modeling::types::Bounds;
 use arco_ops::modeling::{InspectOptions, Model, Objective, Sense, SlackBound, Variable};
 
 use pyo3::prelude::*;
-use pyo3::types::{PyDict, PyType};
+use pyo3::types::{PyDict, PyList, PyType};
 
 pub(crate) type PyObject = Py<PyAny>;
 
@@ -447,6 +447,8 @@ pub struct PyModel {
     link_defs: Vec<pym::model_blocks::LinkDef>,
     /// Compact metadata for arrays created via add_variables() for pretty-printing.
     array_print_specs: Vec<pym::model_pretty::ArrayPrintSpec>,
+    /// Compact metadata for named constraint blocks.
+    constraint_print_specs: Vec<pym::model_pretty::ConstraintPrintSpec>,
     /// Nonlinear constraints and objective registered via `add_nonlinear_constraint`
     /// and `minimize`/`maximize` with a `NonlinearExpr`. Only meaningful when the
     /// `ipopt` feature is enabled.
@@ -468,6 +470,7 @@ impl PyModel {
             block_defs: Vec::new(),
             link_defs: Vec::new(),
             array_print_specs: Vec::new(),
+            constraint_print_specs: Vec::new(),
             #[cfg(feature = "ipopt")]
             nonlinear_state: pym::nonlinear_state::NonlinearState::default(),
         }
@@ -519,6 +522,17 @@ impl PyModel {
             is_integer,
             simplify_level,
         )
+    }
+
+    /// Pre-allocate storage for additional variables and constraints.
+    #[pyo3(signature = (*, num_variables=0, num_constraints=0))]
+    fn reserve(&mut self, num_variables: usize, num_constraints: usize) {
+        if num_variables > 0 {
+            self.inner.reserve_variables(num_variables);
+        }
+        if num_constraints > 0 {
+            self.inner.reserve_constraints(num_constraints);
+        }
     }
 
     /// Add a variable to the model.
@@ -726,6 +740,18 @@ impl PyModel {
                     left,
                     right,
                     lazy_sense,
+                    active,
+                    name,
+                    array.shape_ref(),
+                    &array.clone_index_sets(),
+                );
+            }
+            if let Some((exprs, sparse_rhs, row_indices, sparse_sense)) = array.as_sparse_rows() {
+                return self.add_constraints_sparse_rows_internal(
+                    exprs,
+                    sparse_sense,
+                    sparse_rhs,
+                    row_indices,
                     active,
                     name,
                     array.shape_ref(),
@@ -997,6 +1023,12 @@ impl PyModel {
         self.set_objective_from_expr(expr, Sense::Maximize, name)
     }
 
+    /// Append linear expression terms to an existing objective.
+    #[pyo3(signature = (expr))]
+    fn add_objective_terms(&mut self, expr: &Bound<'_, PyAny>) -> PyResult<()> {
+        self.add_objective_terms_from_expr(expr)
+    }
+
     /// Add a nonlinear constraint to the model.
     ///
     /// Accepts a `NonlinearConstraintExpr` (the result of comparing a
@@ -1152,10 +1184,7 @@ impl PyModel {
         for i in 0..num {
             let con_id = ConstraintId::new(i as u32);
             if let Ok(con) = self.inner.get_constraint(con_id) {
-                let name = self
-                    .inner
-                    .get_constraint_name(con_id)
-                    .map(|s| s.to_string());
+                let name = self.reconstruct_constraint_name(i as u32);
                 result.push(PyConstraint::new(i as u32, name, con.bounds));
             }
         }
@@ -1179,7 +1208,7 @@ impl PyModel {
     /// Raises ConstraintNotFoundError if no constraint with the given name exists.
     #[pyo3(signature = (*, name))]
     fn get_constraint(&self, name: &str) -> PyResult<PyConstraint> {
-        let con_id = self.inner.get_constraint_by_name(name).ok_or_else(|| {
+        let con_id = self.find_constraint_by_name(name).ok_or_else(|| {
             pym::errors::ConstraintNotFoundError::new_err(format!(
                 "constraint named '{name}' does not exist"
             ))
@@ -1294,8 +1323,125 @@ impl PyModel {
                 .map(|ids| ids.into_iter().map(ConstraintId::new).collect()),
         };
 
-        let snapshot = self.inner.inspect(options);
+        let mut snapshot = self.inner.inspect(options);
+        for variable in &mut snapshot.variables {
+            if variable.name.is_none() {
+                variable.name = self.reconstruct_variable_name(variable.id.inner());
+            }
+        }
+        for constraint in &mut snapshot.constraints {
+            if constraint.name.is_none() {
+                constraint.name = self.reconstruct_constraint_name(constraint.id.inner());
+            }
+        }
         PyModelSnapshot::from_snapshot(py, snapshot)
+    }
+
+    /// Return sparse matrix column-density diagnostics without exporting matrix arrays.
+    #[pyo3(signature = (*, top_n=20, dense_threshold=100))]
+    fn matrix_profile(
+        &self,
+        py: Python<'_>,
+        top_n: usize,
+        dense_threshold: usize,
+    ) -> PyResult<PyObject> {
+        let columns = self.inner.columns();
+        let mut empty_columns = 0usize;
+        let mut singleton_columns = 0usize;
+        let mut two_entry_columns = 0usize;
+        let mut nnz_le_5_columns = 0usize;
+        let mut nnz_le_10_columns = 0usize;
+        let mut nnz_le_50_columns = 0usize;
+        let mut nnz_le_100_columns = 0usize;
+        let mut nnz_le_500_columns = 0usize;
+        let mut nnz_le_1000_columns = 0usize;
+        let mut nnz_gt_1000_columns = 0usize;
+        let mut dense_columns = 0usize;
+        let mut max_column_nnz = 0usize;
+        let mut min_nonzero_column_nnz: Option<usize> = None;
+        let mut total_nnz = 0usize;
+        let mut top_columns: Vec<(u32, usize)> = Vec::with_capacity(top_n);
+
+        for (variable_id, column) in columns {
+            let nnz = column.len();
+            total_nnz = total_nnz.saturating_add(nnz);
+            max_column_nnz = max_column_nnz.max(nnz);
+            if nnz > 0 {
+                min_nonzero_column_nnz =
+                    Some(min_nonzero_column_nnz.map_or(nnz, |min| min.min(nnz)));
+            }
+            if nnz >= dense_threshold {
+                dense_columns = dense_columns.saturating_add(1);
+            }
+            match nnz {
+                0 => empty_columns = empty_columns.saturating_add(1),
+                1 => singleton_columns = singleton_columns.saturating_add(1),
+                2 => two_entry_columns = two_entry_columns.saturating_add(1),
+                3..=5 => nnz_le_5_columns = nnz_le_5_columns.saturating_add(1),
+                6..=10 => nnz_le_10_columns = nnz_le_10_columns.saturating_add(1),
+                11..=50 => nnz_le_50_columns = nnz_le_50_columns.saturating_add(1),
+                51..=100 => nnz_le_100_columns = nnz_le_100_columns.saturating_add(1),
+                101..=500 => nnz_le_500_columns = nnz_le_500_columns.saturating_add(1),
+                501..=1000 => nnz_le_1000_columns = nnz_le_1000_columns.saturating_add(1),
+                _ => nnz_gt_1000_columns = nnz_gt_1000_columns.saturating_add(1),
+            }
+
+            if top_n > 0 {
+                if top_columns.len() < top_n {
+                    top_columns.push((variable_id.inner(), nnz));
+                } else if let Some((min_idx, (_, min_nnz))) = top_columns
+                    .iter()
+                    .enumerate()
+                    .min_by_key(|(_, (_, candidate_nnz))| *candidate_nnz)
+                {
+                    if nnz > *min_nnz {
+                        top_columns[min_idx] = (variable_id.inner(), nnz);
+                    }
+                }
+            }
+        }
+
+        top_columns.sort_by(|left, right| right.1.cmp(&left.1).then_with(|| left.0.cmp(&right.0)));
+
+        let profile = PyDict::new(py);
+        let num_variables = self.inner.num_variables();
+        let average_column_nnz = if num_variables == 0 {
+            0.0
+        } else {
+            total_nnz as f64 / num_variables as f64
+        };
+        profile.set_item("num_variables", num_variables)?;
+        profile.set_item("num_constraints", self.inner.num_constraints())?;
+        profile.set_item("num_coefficients", total_nnz)?;
+        profile.set_item("average_column_nnz", average_column_nnz)?;
+        profile.set_item("max_column_nnz", max_column_nnz)?;
+        profile.set_item("min_nonzero_column_nnz", min_nonzero_column_nnz)?;
+        profile.set_item("dense_threshold", dense_threshold)?;
+        profile.set_item("dense_columns", dense_columns)?;
+
+        let buckets = PyDict::new(py);
+        buckets.set_item("eq_0", empty_columns)?;
+        buckets.set_item("eq_1", singleton_columns)?;
+        buckets.set_item("eq_2", two_entry_columns)?;
+        buckets.set_item("le_5", nnz_le_5_columns)?;
+        buckets.set_item("le_10", nnz_le_10_columns)?;
+        buckets.set_item("le_50", nnz_le_50_columns)?;
+        buckets.set_item("le_100", nnz_le_100_columns)?;
+        buckets.set_item("le_500", nnz_le_500_columns)?;
+        buckets.set_item("le_1000", nnz_le_1000_columns)?;
+        buckets.set_item("gt_1000", nnz_gt_1000_columns)?;
+        profile.set_item("column_nnz_buckets", buckets)?;
+
+        let top = PyList::empty(py);
+        for (variable_id, nnz) in top_columns {
+            let row = PyDict::new(py);
+            row.set_item("variable_id", variable_id)?;
+            row.set_item("name", self.reconstruct_variable_name(variable_id))?;
+            row.set_item("nnz", nnz)?;
+            top.append(row)?;
+        }
+        profile.set_item("top_columns", top)?;
+        Ok(profile.unbind().into())
     }
 
     /// Add a typed block function to this model for composed optimization.

--- a/bindings/python/src/model_blocks.rs
+++ b/bindings/python/src/model_blocks.rs
@@ -295,10 +295,7 @@ impl PyBlockResults {
 
     fn __iter__(&self, py: Python<'_>) -> PyResult<PyObject> {
         let keys = self.keys();
-        Ok(PyList::new(py, keys)?
-            .call_method0("__iter__")?
-            .unbind()
-            .into())
+        Ok(PyList::new(py, keys)?.call_method0("__iter__")?.unbind())
     }
 
     fn keys(&self) -> Vec<String> {

--- a/bindings/python/src/model_edit.rs
+++ b/bindings/python/src/model_edit.rs
@@ -5,11 +5,33 @@ use crate::{
     bounds_from_sense, extract_objective_terms,
 };
 use arco_arrays::BroadcastPlan;
-use arco_ops::expression::{ComparisonSense, ConstraintId, Expr, VariableId};
+use arco_ops::expression::{ComparisonSense, ConstraintId, VariableId};
 use arco_ops::modeling::types::Bounds;
 use arco_ops::modeling::{Objective, Sense, Variable};
 use pyo3::prelude::*;
 use pyo3::types::PyAny;
+
+fn intersect_sorted_row_positions(row_indices: &[usize], active_indices: &[usize]) -> Vec<usize> {
+    let mut row_pos = 0usize;
+    let mut active_pos = 0usize;
+    let mut positions = Vec::new();
+
+    while row_pos < row_indices.len() && active_pos < active_indices.len() {
+        let row_idx = row_indices[row_pos];
+        let active_idx = active_indices[active_pos];
+        match row_idx.cmp(&active_idx) {
+            std::cmp::Ordering::Equal => {
+                positions.push(row_pos);
+                row_pos += 1;
+                active_pos += 1;
+            }
+            std::cmp::Ordering::Less => row_pos += 1,
+            std::cmp::Ordering::Greater => active_pos += 1,
+        }
+    }
+
+    positions
+}
 
 impl PyModel {
     fn resolve_labeled_f64_values(
@@ -71,6 +93,105 @@ impl PyModel {
         Ok(values)
     }
 
+    fn resolve_labeled_f64_values_at_indices(
+        obj: &Bound<'_, PyAny>,
+        index_sets: &[Py<PyIndexSet>],
+        shape: &[usize],
+        total: usize,
+        active_indices: &[usize],
+        label: &str,
+    ) -> PyResult<Vec<f64>> {
+        if obj.getattr("axes").is_ok() {
+            let values_obj = obj.getattr("values").map_err(|_| {
+                errors::ArrayTypeError::new_err(format!(
+                    "labeled {label} must expose a values attribute"
+                ))
+            })?;
+            let Some(source_shape) = arrays::labeled_shape_from_axes_attr(obj, label)? else {
+                return Err(errors::ArrayTypeError::new_err(format!(
+                    "labeled {label} must expose axes as IndexSet values"
+                )));
+            };
+            let target_shape = arrays::labeled_shape_from_index_sets(index_sets)?;
+            let source_len = source_shape.total_len();
+            let plan = BroadcastPlan::new(source_shape, target_shape)
+                .map_err(|err| errors::ArrayShapeMismatchError::new_err(err.to_string()))?;
+
+            let py = obj.py();
+            let np = py.import("numpy")?;
+            let flat = np
+                .call_method1("asarray", (&values_obj,))?
+                .call_method0("flatten")?;
+            let values: Vec<f64> = flat.extract()?;
+            if values.len() != source_len {
+                return Err(errors::ArrayShapeMismatchError::new_err(format!(
+                    "{label} source length {} does not match source shape length {}",
+                    values.len(),
+                    source_len
+                )));
+            }
+            let mut resolved = Vec::with_capacity(active_indices.len());
+            for &target_flat in active_indices {
+                if target_flat >= total {
+                    return Err(errors::ArrayShapeMismatchError::new_err(format!(
+                        "{label} active index {target_flat} exceeds total variables {total}",
+                    )));
+                }
+                let source_flat = plan.source_offset_for_target_flat(target_flat);
+                let value = values.get(source_flat).ok_or_else(|| {
+                    errors::ArrayShapeMismatchError::new_err(format!(
+                        "{label} source index {source_flat} exceeds source length {}",
+                        values.len()
+                    ))
+                })?;
+                resolved.push(*value);
+            }
+            return Ok(resolved);
+        }
+
+        let py = obj.py();
+        let np = py.import("numpy")?;
+        let arr = np.call_method1("asarray", (obj,))?;
+        let flat = arr.call_method0("flatten")?;
+        let values: Vec<f64> = flat.extract()?;
+        if values.len() == 1 {
+            return Ok(vec![values[0]; active_indices.len()]);
+        }
+        if values.len() == total {
+            return active_indices
+                .iter()
+                .map(|&idx| {
+                    values.get(idx).copied().ok_or_else(|| {
+                        errors::ArrayShapeMismatchError::new_err(format!(
+                            "{label} active index {idx} exceeds total variables {total}",
+                        ))
+                    })
+                })
+                .collect();
+        }
+
+        let broadcast = np.call_method1("broadcast_to", (&arr, shape.to_vec()))?;
+        let flat = broadcast.call_method0("flatten")?;
+        let values: Vec<f64> = flat.extract()?;
+        if values.len() != total {
+            return Err(errors::ArrayShapeMismatchError::new_err(format!(
+                "{label} length {} does not match total variables {}",
+                values.len(),
+                total
+            )));
+        }
+        active_indices
+            .iter()
+            .map(|&idx| {
+                values.get(idx).copied().ok_or_else(|| {
+                    errors::ArrayShapeMismatchError::new_err(format!(
+                        "{label} active index {idx} exceeds total variables {total}",
+                    ))
+                })
+            })
+            .collect()
+    }
+
     fn resolve_active_indices(
         active: Option<&Bound<'_, PyAny>>,
         index_sets: Option<&[Py<PyIndexSet>]>,
@@ -115,7 +236,7 @@ impl PyModel {
                     .call_method0("flatten")?;
                 let mask_values: Vec<bool> = flat.extract()?;
                 let indices = plan
-                    .active_target_indices(&mask_values, |value| *value)
+                    .active_target_indices_from_source(&mask_values, |value| *value)
                     .map_err(|err| errors::ArrayShapeMismatchError::new_err(err.to_string()))?;
                 return Ok(indices);
             }
@@ -182,10 +303,15 @@ impl PyModel {
         // Reconstruct from array_print_spec
         let spec = self.find_array_print_spec(vid)?;
         let offset = (var_id - spec.start_var_id) as usize;
+        let dense_offset = spec
+            .dense_indices
+            .as_ref()
+            .and_then(|indices| indices.get(offset).copied())
+            .unwrap_or(offset);
         if spec.len == 1 {
             Some(spec.base_name.clone())
         } else {
-            Some(format!("{}[{}]", spec.base_name, offset))
+            Some(format!("{}[{}]", spec.base_name, dense_offset))
         }
     }
 
@@ -201,7 +327,14 @@ impl PyModel {
             let idx_str = name[bracket_pos + 1..].strip_suffix(']')?;
             let offset: usize = idx_str.parse().ok()?;
             for spec in &self.array_print_specs {
-                if spec.base_name == base && offset < spec.len {
+                if spec.base_name != base {
+                    continue;
+                }
+                if let Some(dense_indices) = spec.dense_indices.as_ref() {
+                    if let Some(active_pos) = dense_indices.iter().position(|idx| *idx == offset) {
+                        return Some(VariableId::new(spec.start_var_id + active_pos as u32));
+                    }
+                } else if offset < spec.len {
                     return Some(VariableId::new(spec.start_var_id + offset as u32));
                 }
             }
@@ -229,26 +362,63 @@ impl PyModel {
         Ok(())
     }
 
+    pub(crate) fn reconstruct_constraint_name(&self, constraint_id: u32) -> Option<String> {
+        let cid = ConstraintId::new(constraint_id);
+        if let Some(name) = self.inner.get_constraint_name(cid) {
+            return Some(name.to_string());
+        }
+        let spec = self
+            .constraint_print_specs
+            .iter()
+            .find(|spec| spec.offset_of(cid).is_some())?;
+        let offset = (constraint_id - spec.start_constraint_id) as usize;
+        if spec.len == 1 {
+            Some(spec.base_name.clone())
+        } else {
+            Some(format!("{}[{}]", spec.base_name, offset))
+        }
+    }
+
+    pub(crate) fn find_constraint_by_name(&self, name: &str) -> Option<ConstraintId> {
+        if let Some(id) = self.inner.get_constraint_by_name(name) {
+            return Some(id);
+        }
+        if let Some(bracket_pos) = name.rfind('[') {
+            let base = &name[..bracket_pos];
+            let idx_str = name[bracket_pos + 1..].strip_suffix(']')?;
+            let offset: usize = idx_str.parse().ok()?;
+            for spec in &self.constraint_print_specs {
+                if spec.base_name == base && offset < spec.len {
+                    return Some(ConstraintId::new(spec.start_constraint_id + offset as u32));
+                }
+            }
+        } else {
+            for spec in &self.constraint_print_specs {
+                if spec.len == 1 && spec.base_name == name {
+                    return Some(ConstraintId::new(spec.start_constraint_id));
+                }
+            }
+        }
+        None
+    }
+
     /// Name a contiguous block of constraints starting at `first_id`.
     pub(crate) fn name_constraint_block(
         &mut self,
         first_id: ConstraintId,
         count: usize,
         name: Option<&str>,
-    ) -> PyResult<()> {
-        let Some(base) = name else { return Ok(()) };
-        for index in 0..count {
-            let constraint_id = ConstraintId::new(first_id.inner() + index as u32);
-            let con_name = if count == 1 {
-                base.to_string()
-            } else {
-                format!("{base}[{index}]")
-            };
-            self.inner
-                .set_constraint_name(constraint_id, con_name)
-                .map_err(errors::model_error_to_py)?;
+    ) {
+        let Some(base) = name else { return };
+        if count == 0 {
+            return;
         }
-        Ok(())
+        self.constraint_print_specs
+            .push(crate::py_modules::model_pretty::ConstraintPrintSpec {
+                start_constraint_id: first_id.inner(),
+                len: count,
+                base_name: base.to_string(),
+            });
     }
 
     /// Insert constraints via compact term patterns (zero per-element allocation).
@@ -272,6 +442,48 @@ impl PyModel {
     ) -> PyResult<PyConstraintArray> {
         let count = compact.count;
         let sense = compact.sense;
+        let term_patterns = compact.term_patterns();
+
+        if active.is_none() && count == 0 {
+            return Ok(PyConstraintArray::from_batch_shaped(
+                0,
+                shape.to_vec(),
+                Python::attach(|py| index_sets.iter().map(|set| set.clone_ref(py)).collect()),
+                sense,
+                &[],
+                name,
+            ));
+        }
+
+        if active.is_none() {
+            let mut filtered_rhs = Vec::with_capacity(count);
+            let mut bounds_list = Vec::with_capacity(count);
+            for idx in 0..count {
+                let rhs_val = match &compact.rhs {
+                    arrays::CompactRhs::Scalar(value) => *value,
+                    arrays::CompactRhs::Vec(values) => values[idx],
+                };
+                filtered_rhs.push(rhs_val);
+                bounds_list.push(bounds_from_sense(sense, rhs_val));
+            }
+
+            let first_constraint_id = self
+                .inner
+                .add_constraints_compact(&term_patterns, &bounds_list)
+                .map_err(errors::model_error_to_py)?;
+
+            self.name_constraint_block(first_constraint_id, count, name.as_deref());
+
+            return Ok(PyConstraintArray::from_batch_shaped(
+                first_constraint_id.inner(),
+                shape.to_vec(),
+                Python::attach(|py| index_sets.iter().map(|set| set.clone_ref(py)).collect()),
+                sense,
+                &filtered_rhs,
+                name,
+            ));
+        }
+
         let active_indices = Self::resolve_active_indices(
             active,
             (!index_sets.is_empty()).then_some(index_sets),
@@ -290,28 +502,24 @@ impl PyModel {
             ));
         }
 
-        let term_patterns = compact.term_patterns();
-        let rhs_vec = compact.rhs_vec();
+        let mut filtered_rhs = Vec::with_capacity(active_indices.len());
+        let mut bounds_list = Vec::with_capacity(active_indices.len());
 
-        let mut batch: Vec<(Vec<(VariableId, f64)>, Bounds)> = Vec::new();
-        let mut filtered_rhs: Vec<f64> = Vec::new();
-
-        for idx in active_indices {
-            let rhs_val = rhs_vec[idx];
-            let terms: Vec<(VariableId, f64)> = term_patterns
-                .iter()
-                .map(|(start_var_id, coeff)| (VariableId::new(start_var_id + idx as u32), *coeff))
-                .collect();
-            batch.push((terms, bounds_from_sense(sense, rhs_val)));
+        for idx in active_indices.iter().copied() {
+            let rhs_val = match &compact.rhs {
+                arrays::CompactRhs::Scalar(value) => *value,
+                arrays::CompactRhs::Vec(values) => values[idx],
+            };
             filtered_rhs.push(rhs_val);
+            bounds_list.push(bounds_from_sense(sense, rhs_val));
         }
 
         let first_constraint_id = self
             .inner
-            .add_constraints_batch(&batch)
+            .add_constraints_compact_indexed(&term_patterns, &active_indices, &bounds_list)
             .map_err(errors::model_error_to_py)?;
 
-        self.name_constraint_block(first_constraint_id, batch.len(), name.as_deref())?;
+        self.name_constraint_block(first_constraint_id, active_indices.len(), name.as_deref());
 
         Ok(PyConstraintArray::from_batch_shaped(
             first_constraint_id.inner(),
@@ -352,28 +560,27 @@ impl PyModel {
             ));
         }
 
-        let mut batch: Vec<(Vec<(VariableId, f64)>, Bounds)> =
-            Vec::with_capacity(active_indices.len());
         let mut filtered_rhs: Vec<f64> = Vec::with_capacity(active_indices.len());
-        for idx in active_indices {
+        let row_count = active_indices.len();
+        let rows = active_indices.into_iter().map(|idx| {
             let diff = left.values[idx]
                 .inner()
                 .add(&right.values[idx].inner().scale(-1.0));
             let diff_expr = PyExpr::from_expr(diff);
             let rhs_value = -diff_expr.constant();
-            batch.push((
+            filtered_rhs.push(rhs_value);
+            (
                 diff_expr.without_constant().into_inner().normalized_terms(),
                 bounds_from_sense(sense, rhs_value),
-            ));
-            filtered_rhs.push(rhs_value);
-        }
+            )
+        });
 
         let first_constraint_id = self
             .inner
-            .add_constraints_batch(&batch)
+            .add_constraints_batch_streaming(row_count, rows)
             .map_err(errors::model_error_to_py)?;
 
-        self.name_constraint_block(first_constraint_id, batch.len(), name.as_deref())?;
+        self.name_constraint_block(first_constraint_id, row_count, name.as_deref());
 
         Ok(PyConstraintArray::from_batch_shaped(
             first_constraint_id.inner(),
@@ -446,21 +653,28 @@ impl PyModel {
         )?;
 
         let mut active_lookup = vec![false; total];
+        let active_count = active_indices.len();
         for idx in active_indices {
             active_lookup[idx] = true;
         }
 
-        let mut batch: Vec<(Vec<(VariableId, f64)>, Bounds)> = Vec::new();
-        let mut filtered_rhs: Vec<f64> = Vec::new();
-        for (idx, (expr, rhs_val)) in exprs.into_iter().zip(rhs.iter().copied()).enumerate() {
-            if active_lookup[idx] {
-                let bounds = bounds_from_sense(sense, rhs_val);
-                batch.push((expr.into_inner().normalized_terms(), bounds));
+        let mut filtered_rhs: Vec<f64> = Vec::with_capacity(active_count);
+        let rows = exprs
+            .into_iter()
+            .zip(rhs.iter().copied())
+            .enumerate()
+            .filter_map(|(idx, (expr, rhs_val))| {
+                if !active_lookup[idx] {
+                    return None;
+                }
                 filtered_rhs.push(rhs_val);
-            }
-        }
+                Some((
+                    expr.into_inner().normalized_terms(),
+                    bounds_from_sense(sense, rhs_val),
+                ))
+            });
 
-        if batch.is_empty() {
+        if active_count == 0 {
             return Ok(PyConstraintArray::from_batch_shaped(
                 0,
                 shape.to_vec(),
@@ -473,10 +687,10 @@ impl PyModel {
 
         let first_constraint_id = self
             .inner
-            .add_constraints_batch(&batch)
+            .add_constraints_batch_streaming(active_count, rows)
             .map_err(errors::model_error_to_py)?;
 
-        self.name_constraint_block(first_constraint_id, batch.len(), name.as_deref())?;
+        self.name_constraint_block(first_constraint_id, active_count, name.as_deref());
 
         Ok(PyConstraintArray::from_batch_shaped(
             first_constraint_id.inner(),
@@ -488,6 +702,102 @@ impl PyModel {
         ))
     }
 
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn add_constraints_sparse_rows_internal(
+        &mut self,
+        exprs: &[PyExpr],
+        sense: ComparisonSense,
+        rhs: &[f64],
+        row_indices: &[usize],
+        active: Option<&Bound<'_, PyAny>>,
+        name: Option<String>,
+        shape: &[usize],
+        index_sets: &[Py<PyIndexSet>],
+    ) -> PyResult<PyConstraintArray> {
+        let total = shape.iter().product();
+        for row_idx in row_indices.iter().copied() {
+            if row_idx >= total {
+                return Err(errors::ArrayShapeMismatchError::new_err(format!(
+                    "sparse constraint row index {row_idx} out of range for constraint array of size {total}"
+                )));
+            }
+        }
+
+        let selected_positions = if active.is_none() {
+            None
+        } else {
+            let active_indices = Self::resolve_active_indices(
+                active,
+                (!index_sets.is_empty()).then_some(index_sets),
+                shape,
+                total,
+            )?;
+            for idx in active_indices.iter().copied() {
+                if idx >= total {
+                    return Err(errors::ArrayShapeMismatchError::new_err(format!(
+                        "active row index {idx} out of range for constraint array of size {total}"
+                    )));
+                }
+            }
+            Some(intersect_sorted_row_positions(row_indices, &active_indices))
+        };
+
+        let row_count = selected_positions
+            .as_ref()
+            .map_or(row_indices.len(), Vec::len);
+
+        if row_count == 0 {
+            return Ok(PyConstraintArray::from_batch_shaped(
+                0,
+                shape.to_vec(),
+                Python::attach(|py| index_sets.iter().map(|set| set.clone_ref(py)).collect()),
+                sense,
+                &[],
+                name,
+            ));
+        }
+
+        let mut filtered_rhs: Vec<f64> = Vec::with_capacity(row_count);
+        let first_constraint_id = if let Some(selected_positions) = selected_positions {
+            let rows = selected_positions.into_iter().map(|position| {
+                let expr = &exprs[position];
+                let rhs_val = rhs[position];
+                filtered_rhs.push(rhs_val);
+                (
+                    expr.clone().into_inner().normalized_terms(),
+                    bounds_from_sense(sense, rhs_val),
+                )
+            });
+            self.inner
+                .add_constraints_batch_streaming(row_count, rows)
+                .map_err(errors::model_error_to_py)?
+        } else {
+            let rows = exprs
+                .iter()
+                .zip(rhs.iter().copied())
+                .map(|(expr, rhs_val)| {
+                    filtered_rhs.push(rhs_val);
+                    (
+                        expr.clone().into_inner().normalized_terms(),
+                        bounds_from_sense(sense, rhs_val),
+                    )
+                });
+            self.inner
+                .add_constraints_batch_streaming(row_count, rows)
+                .map_err(errors::model_error_to_py)?
+        };
+
+        self.name_constraint_block(first_constraint_id, row_count, name.as_deref());
+
+        Ok(PyConstraintArray::from_batch_shaped(
+            first_constraint_id.inner(),
+            shape.to_vec(),
+            Python::attach(|py| index_sets.iter().map(|set| set.clone_ref(py)).collect()),
+            sense,
+            &filtered_rhs,
+            name,
+        ))
+    }
     pub(crate) fn set_objective_from_expr(
         &mut self,
         expr: &Bound<'_, PyAny>,
@@ -505,6 +815,21 @@ impl PyModel {
             .set_objective_name(name)
             .map_err(errors::model_error_to_py)?;
         Ok(())
+    }
+
+    pub(crate) fn add_objective_terms_from_expr(
+        &mut self,
+        expr: &Bound<'_, PyAny>,
+    ) -> PyResult<()> {
+        if self.inner.objective().sense.is_none() {
+            return Err(errors::model_error_to_py(
+                arco_ops::modeling::model::ModelError::NoObjective,
+            ));
+        }
+        let terms = extract_objective_terms(expr)?;
+        self.inner
+            .add_objective_terms(terms)
+            .map_err(errors::model_error_to_py)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -533,11 +858,9 @@ impl PyModel {
                 is_integer: effective_bounds.is_integer,
                 is_active: true,
             };
-            for _ in 0..total {
-                self.inner
-                    .add_variable(var_template)
-                    .map_err(errors::model_error_to_py)?;
-            }
+            self.inner
+                .add_variables_uniform(var_template, total)
+                .map_err(errors::model_error_to_py)?;
 
             self.register_array_print_spec(
                 py,
@@ -559,52 +882,36 @@ impl PyModel {
         }
 
         let active_count = active_indices.len();
+        let start_var_id = self.inner.num_variables() as u32;
         self.inner.reserve_variables(active_count);
         let var_template = Variable {
             bounds: bounds.bounds,
             is_integer: effective_bounds.is_integer,
             is_active: true,
         };
-        let mut next_active = active_indices.into_iter().peekable();
-        let mut values = Vec::with_capacity(total);
-        let mut variables = Vec::with_capacity(total);
+        self.inner
+            .add_variables_uniform(var_template, active_count)
+            .map_err(errors::model_error_to_py)?;
+        let var_ids = (0..active_count)
+            .map(|offset| start_var_id + offset as u32)
+            .collect::<Vec<_>>();
 
-        for idx in 0..total {
-            if next_active.peek().copied() == Some(idx) {
-                let var_id = self
-                    .inner
-                    .add_variable(var_template)
-                    .map_err(errors::model_error_to_py)?;
-                let var_name = name.as_ref().map(|base| {
-                    if total == 1 {
-                        base.clone()
-                    } else {
-                        format!("{base}[{idx}]")
-                    }
-                });
-                if let Some(var_name_ref) = var_name.as_ref() {
-                    self.inner
-                        .set_variable_name(var_id, var_name_ref.clone())
-                        .map_err(errors::model_error_to_py)?;
-                }
-                values.push(PyExpr::from_term(var_id.inner(), 1.0));
-                variables.push(Some(PyVariable::new(
-                    var_id.inner(),
-                    var_name,
-                    effective_bounds,
-                )));
-                let _ = next_active.next();
-            } else {
-                values.push(PyExpr::from_expr(Expr::from_constant(0.0)));
-                variables.push(None);
-            }
-        }
+        self.register_sparse_array_print_spec(
+            py,
+            start_var_id,
+            &active_indices,
+            &index_sets,
+            shape,
+            name.as_deref(),
+        );
 
-        Ok(PyVariableArray::new_sparse(
+        Ok(PyVariableArray::new_active_sparse(
             index_sets,
             shape.to_vec(),
-            values,
-            variables,
+            active_indices,
+            var_ids,
+            effective_bounds,
+            name,
         ))
     }
 
@@ -634,15 +941,24 @@ impl PyModel {
         let hi_attr = bounds_obj
             .getattr("upper")
             .or_else(|_| bounds_obj.getattr("hi"))?;
-        let lo_values =
-            Self::resolve_labeled_f64_values(&lo_attr, &index_sets, shape, total, "lower bounds")?;
-        let hi_values =
-            Self::resolve_labeled_f64_values(&hi_attr, &index_sets, shape, total, "upper bounds")?;
-
         let effective_binary = is_binary;
         let effective_integer = is_integer || effective_binary;
 
         if active_count == total {
+            let lo_values = Self::resolve_labeled_f64_values(
+                &lo_attr,
+                &index_sets,
+                shape,
+                total,
+                "lower bounds",
+            )?;
+            let hi_values = Self::resolve_labeled_f64_values(
+                &hi_attr,
+                &index_sets,
+                shape,
+                total,
+                "upper bounds",
+            )?;
             let mut values = Vec::with_capacity(total);
             let mut variables = Vec::with_capacity(total);
             for i in 0..total {
@@ -696,59 +1012,58 @@ impl PyModel {
             ));
         }
 
-        let mut values = Vec::with_capacity(total);
-        let mut variables = Vec::with_capacity(total);
-        let mut next_active = active_indices.into_iter().peekable();
-        for i in 0..total {
-            if next_active.peek().copied() == Some(i) {
-                let element_bounds = Bounds::new(lo_values[i], hi_values[i]);
-                let var = Variable {
-                    bounds: element_bounds,
-                    is_integer: effective_integer,
-                    is_active: true,
-                };
-                let var_id = self
-                    .inner
-                    .add_variable(var)
-                    .map_err(errors::model_error_to_py)?;
+        let lo_values = Self::resolve_labeled_f64_values_at_indices(
+            &lo_attr,
+            &index_sets,
+            shape,
+            total,
+            &active_indices,
+            "lower bounds",
+        )?;
+        let hi_values = Self::resolve_labeled_f64_values_at_indices(
+            &hi_attr,
+            &index_sets,
+            shape,
+            total,
+            &active_indices,
+            "upper bounds",
+        )?;
+        let mut model_bounds = Vec::with_capacity(active_count);
+        let mut bounds_specs = Vec::with_capacity(active_count);
+        for (lo, hi) in lo_values.into_iter().zip(hi_values) {
+            let element_bounds = Bounds::new(lo, hi);
+            let element_bounds_spec = BoundsSpec {
+                bounds: element_bounds,
+                is_integer: effective_integer,
+                is_binary: effective_binary,
+            };
 
-                let var_name = name.as_ref().map(|base| {
-                    if total == 1 {
-                        base.clone()
-                    } else {
-                        format!("{base}[{i}]")
-                    }
-                });
-                if let Some(var_name_ref) = var_name.as_ref() {
-                    self.inner
-                        .set_variable_name(var_id, var_name_ref.clone())
-                        .map_err(errors::model_error_to_py)?;
-                }
-
-                let element_bounds_spec = BoundsSpec {
-                    bounds: element_bounds,
-                    is_integer: effective_integer,
-                    is_binary: effective_binary,
-                };
-
-                values.push(PyExpr::from_term(var_id.inner(), 1.0));
-                variables.push(Some(PyVariable::new(
-                    var_id.inner(),
-                    var_name,
-                    element_bounds_spec,
-                )));
-                let _ = next_active.next();
-            } else {
-                values.push(PyExpr::from_expr(Expr::from_constant(0.0)));
-                variables.push(None);
-            }
+            model_bounds.push(element_bounds);
+            bounds_specs.push(element_bounds_spec);
         }
+        self.inner
+            .add_variables_with_bounds(&model_bounds, effective_integer, true)
+            .map_err(errors::model_error_to_py)?;
+        let var_ids = (0..active_count)
+            .map(|offset| start_var_id + offset as u32)
+            .collect::<Vec<_>>();
 
-        Ok(PyVariableArray::new_sparse(
+        self.register_sparse_array_print_spec(
+            py,
+            start_var_id,
+            &active_indices,
+            &index_sets,
+            shape,
+            name.as_deref(),
+        );
+
+        Ok(PyVariableArray::new_active_sparse_with_bounds(
             index_sets,
             shape.to_vec(),
-            values,
-            variables,
+            active_indices,
+            var_ids,
+            bounds_specs,
+            name,
         ))
     }
 }

--- a/bindings/python/src/model_pretty.rs
+++ b/bindings/python/src/model_pretty.rs
@@ -1,5 +1,5 @@
 use crate::{PyIndexSet, PyModel};
-use arco_ops::expression::VariableId;
+use arco_ops::expression::{ConstraintId, VariableId};
 use arco_ops::modeling::Model;
 use arco_ops::modeling::model::{
     PrettyBoundGroup, PrettyPrintAdapter, PrettySection, format_ascii_number,
@@ -18,6 +18,13 @@ pub(crate) struct ArrayPrintSpec {
     pub(crate) shape: Vec<usize>,
     pub(crate) strides: Vec<usize>,
     pub(crate) index_sets: Vec<Py<PyIndexSet>>,
+    pub(crate) dense_indices: Option<Vec<usize>>,
+}
+
+pub(crate) struct ConstraintPrintSpec {
+    pub(crate) start_constraint_id: u32,
+    pub(crate) len: usize,
+    pub(crate) base_name: String,
 }
 
 pub(crate) struct PythonPrettyAdapter<'a> {
@@ -34,6 +41,11 @@ impl PrettyPrintAdapter for PythonPrettyAdapter<'_> {
             }
         }
         Some(array_label)
+    }
+
+    fn constraint_label(&self, _model: &Model, constraint_id: ConstraintId) -> Option<String> {
+        self.model
+            .reconstruct_constraint_name(constraint_id.inner())
     }
 
     fn sections(&self, _model: &Model) -> Vec<PrettySection> {
@@ -64,6 +76,17 @@ impl ArrayPrintSpec {
     }
 }
 
+impl ConstraintPrintSpec {
+    pub(crate) fn offset_of(&self, constraint_id: ConstraintId) -> Option<usize> {
+        let raw = constraint_id.inner();
+        if raw < self.start_constraint_id {
+            return None;
+        }
+        let offset = (raw - self.start_constraint_id) as usize;
+        (offset < self.len).then_some(offset)
+    }
+}
+
 impl PyModel {
     pub(crate) fn register_array_print_spec(
         &mut self,
@@ -88,6 +111,34 @@ impl PyModel {
             shape: shape.to_vec(),
             strides,
             index_sets: index_sets.iter().map(|set| set.clone_ref(py)).collect(),
+            dense_indices: None,
+        });
+    }
+
+    pub(crate) fn register_sparse_array_print_spec(
+        &mut self,
+        py: Python<'_>,
+        start_var_id: u32,
+        active_indices: &[usize],
+        index_sets: &[Py<PyIndexSet>],
+        shape: &[usize],
+        base_name: Option<&str>,
+    ) {
+        if active_indices.is_empty() || index_sets.is_empty() {
+            return;
+        }
+        let strides = (0..shape.len())
+            .map(|axis| shape[axis + 1..].iter().product::<usize>().max(1))
+            .collect::<Vec<_>>();
+
+        self.array_print_specs.push(ArrayPrintSpec {
+            start_var_id,
+            len: active_indices.len(),
+            base_name: base_name.unwrap_or("x").to_string(),
+            shape: shape.to_vec(),
+            strides,
+            index_sets: index_sets.iter().map(|set| set.clone_ref(py)).collect(),
+            dense_indices: Some(active_indices.to_vec()),
         });
     }
 
@@ -99,6 +150,11 @@ impl PyModel {
 
     pub(crate) fn array_label_for_var(spec: &ArrayPrintSpec, var_id: VariableId) -> Option<String> {
         let offset = spec.offset_of(var_id)?;
+        let dense_offset = spec
+            .dense_indices
+            .as_ref()
+            .and_then(|indices| indices.get(offset).copied())
+            .unwrap_or(offset);
         if spec.shape.is_empty() {
             return Some(spec.base_name.clone());
         }
@@ -114,7 +170,7 @@ impl PyModel {
                 if size == 0 {
                     return None;
                 }
-                let coord = (offset / stride) % size;
+                let coord = (dense_offset / stride) % size;
                 let set_ref = spec.index_sets.get(axis)?.borrow(py);
                 let member = set_ref.members.get(coord)?;
                 parts.push(format_index_member(member));
@@ -134,7 +190,12 @@ impl PyModel {
         if spec.len == 1 {
             return name == spec.base_name || name == format!("{}[0]", spec.base_name);
         }
-        name == format!("{}[{offset}]", spec.base_name)
+        let dense_offset = spec
+            .dense_indices
+            .as_ref()
+            .and_then(|indices| indices.get(offset).copied())
+            .unwrap_or(offset);
+        name == format!("{}[{dense_offset}]", spec.base_name)
     }
 
     fn render_index_set_lines(&self) -> Vec<String> {

--- a/bindings/python/src/model_solve.rs
+++ b/bindings/python/src/model_solve.rs
@@ -9,7 +9,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyAny;
 
 pub(crate) fn solve_model(
-    model: &PyModel,
+    model: &mut PyModel,
     py: Python<'_>,
     solver_obj: Option<&Bound<'_, PyAny>>,
     log_to_console: Option<bool>,
@@ -49,11 +49,7 @@ pub(crate) fn solve_model(
 
     let config = effective_settings.to_solver_config();
 
-    let result = match arco_ops::ArcoOps::solve_model_view_with_builtin_backend(
-        &selected_backend,
-        &model.inner,
-        &config,
-    ) {
+    let result = match solve_with_selected_backend(model, &selected_backend, &config) {
         Ok(solution) => Ok(PySolveResult::new(solution_from_model_view_result(
             solution,
         ))),
@@ -64,6 +60,28 @@ pub(crate) fn solve_model(
     }?;
 
     Py::new(py, result)
+}
+
+fn solve_with_selected_backend(
+    model: &mut PyModel,
+    selected_backend: &str,
+    config: &arco_ops::solve::SolverConfig,
+) -> Result<ModelViewSolveResult, SolverError> {
+    if matches!(selected_backend, "highs" | "xpress")
+        && config
+            .parameters
+            .get("arco.consume_model")
+            .is_some_and(|value| value == "true")
+    {
+        let owned_model = std::mem::take(&mut model.inner);
+        return arco_ops::ArcoOps::solve_owned_model_with_builtin_backend(
+            selected_backend,
+            owned_model,
+            config,
+        );
+    }
+
+    arco_ops::ArcoOps::solve_model_view_with_builtin_backend(selected_backend, &model.inner, config)
 }
 
 fn reject_unsupported_primal_start(primal_start: Option<&[(u32, f64)]>) -> Result<(), SolverError> {

--- a/bindings/python/src/solver.rs
+++ b/bindings/python/src/solver.rs
@@ -1,6 +1,7 @@
 //! Python wrappers for solver configuration and instances.
 
 use crate::py_modules::errors::SolverInvalidSettingError;
+use arco_ops::ArcoOps;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 use std::collections::BTreeMap;
@@ -656,6 +657,10 @@ fn solver_runtime_info_for_family(py: Python<'_>, family: &str) -> PyResult<Py<P
             let configured = std::env::var("XPAUTH_PATH").ok();
             info.set_item("configured_license_path", configured)?;
             info.set_item("backend_enabled", xpress_backend_enabled())?;
+            info.set_item(
+                "runtime_available",
+                ArcoOps::builtin_solver_version("xpress").as_deref() == Some("available"),
+            )?;
         }
         "highs" | "scip" | "ipopt" => {
             info.set_item("requires_license", false)?;
@@ -663,6 +668,10 @@ fn solver_runtime_info_for_family(py: Python<'_>, family: &str) -> PyResult<Py<P
             info.set_item("runtime_env_var", Option::<String>::None)?;
             info.set_item("runtime_dir", Option::<String>::None)?;
             info.set_item("configured_license_path", Option::<String>::None)?;
+            info.set_item(
+                "runtime_available",
+                ArcoOps::builtin_solver_version(family).is_some(),
+            )?;
             info.set_item(
                 "backend_enabled",
                 family != "ipopt" || cfg!(feature = "ipopt"),

--- a/bindings/python/tests/test_active_masks.py
+++ b/bindings/python/tests/test_active_masks.py
@@ -106,7 +106,7 @@ def test_large_active_mask_reports_active_count_without_dense_variable_creation(
     assert flow.dense_count == 4096
     assert flow.active_count == 64
     estimate = flow.memory_estimate()
-    assert estimate["storage"] == "full"
+    assert estimate["storage"] == "sparse"
     assert estimate["dense_slots"] == 4096
     assert estimate["active_slots"] == 64
     assert estimate["inactive_slots"] == 4032
@@ -125,6 +125,405 @@ def test_large_active_mask_reports_active_count_without_dense_variable_creation(
     assert model.num_variables == 64
     assert snapshot.metadata.variables == 64
     assert snapshot.metadata.memory.sparse_matrix_bytes > 0
+
+
+def test_sparse_active_mask_with_array_bounds_avoids_inactive_storage() -> None:
+    model = arco.Model()
+    source = arco.IndexSet(name="source", members=range(8))
+    sink = arco.IndexSet(name="sink", members=range(8))
+    active = np.eye(8, dtype=bool)
+    upper = np.full((8, 8), 10.0)
+
+    flow = model.add_variables(
+        axes=(source, sink),
+        bounds=arco.Bounds(lower=np.zeros_like(upper), upper=upper),
+        active=active,
+        name="flow",
+    )
+
+    estimate = flow.memory_estimate()
+    assert estimate["storage"] == "sparse"
+    assert flow.dense_count == 64
+    assert flow.active_count == 8
+    assert estimate["linear_terms"] == 8
+    assert model.num_variables == 8
+
+
+def test_sparse_active_mask_reconstructs_variable_names_and_bounds_on_demand() -> None:
+    model = arco.Model()
+    source = arco.IndexSet(name="source", members=range(3))
+    sink = arco.IndexSet(name="sink", members=range(3))
+    active = np.eye(3, dtype=bool)
+    lower = np.zeros((3, 3))
+    upper = np.arange(1.0, 10.0).reshape((3, 3))
+
+    flow = model.add_variables(
+        axes=(source, sink),
+        bounds=arco.Bounds(lower=lower, upper=upper),
+        active=active,
+        name="flow",
+    )
+
+    diagonal = flow.variables
+
+    assert [variable.name for variable in diagonal] == ["flow[0]", "flow[4]", "flow[8]"]
+    assert [variable.bounds.upper for variable in diagonal] == [1.0, 5.0, 9.0]
+    assert flow[4].name == "flow[4]"
+    assert flow[4].bounds.upper == 5.0
+
+
+def test_sparse_active_mask_with_labeled_array_bounds_reads_only_active_slots() -> None:
+    model = arco.Model()
+    source = arco.IndexSet(name="source", members=range(3))
+    sink = arco.IndexSet(name="sink", members=range(3))
+    hour = arco.IndexSet(name="hour", members=range(2))
+    active = arco.param(np.eye(3, dtype=bool), axes=(source, sink))
+    upper = arco.param(np.arange(1.0, 10.0).reshape((3, 3)), axes=(source, sink))
+
+    flow = model.add_variables(
+        axes=(source, sink, hour),
+        bounds=arco.Bounds(lower=0, upper=upper),
+        active=active,
+        name="flow",
+    )
+
+    assert flow.shape == (3, 3, 2)
+    assert flow.active_count == 6
+    assert [variable.bounds.upper for variable in flow.variables] == [
+        1.0,
+        1.0,
+        5.0,
+        5.0,
+        9.0,
+        9.0,
+    ]
+
+
+def test_sparse_active_mask_snapshot_reconstructs_array_variable_names() -> None:
+    model = arco.Model()
+    source = arco.IndexSet(name="source", members=range(3))
+    sink = arco.IndexSet(name="sink", members=range(3))
+    active = np.eye(3, dtype=bool)
+
+    _ = model.add_variables(
+        axes=(source, sink),
+        bounds=arco.NonNegativeFloat,
+        active=active,
+        name="flow",
+    )
+
+    snapshot = model.inspect()
+
+    assert [variable.name for variable in snapshot.variables] == [
+        "flow[0]",
+        "flow[4]",
+        "flow[8]",
+    ]
+    assert model.get_variable(name="flow[4]").name == "flow[4]"
+
+
+def test_constraint_block_names_reconstruct_without_per_row_metadata() -> None:
+    model = arco.Model()
+    i = arco.IndexSet(name="i", members=range(3))
+    x = model.add_variables(axes=(i,), bounds=arco.NonNegativeFloat, name="x")
+
+    constraints = model.add_constraints(
+        x,
+        sense="ge",
+        rhs=0.0,
+        active=[True, False, True],
+        name="limit",
+    )
+    snapshot = model.inspect()
+
+    assert [constraint.name for constraint in model.constraints] == [
+        "limit[0]",
+        "limit[1]",
+    ]
+    assert [constraint.name for constraint in model.list_constraints()] == [
+        "limit[0]",
+        "limit[1]",
+    ]
+    assert [constraint.name for constraint in snapshot.constraints] == [
+        "limit[0]",
+        "limit[1]",
+    ]
+    assert constraints[1].name == "limit[1]"
+    assert int(model.get_constraint(name="limit[1]")) == 1
+
+
+def test_scalar_constraint_name_still_uses_explicit_metadata() -> None:
+    model = arco.Model()
+    x = model.add_variable(bounds=arco.NonNegativeFloat, name="x")
+
+    _ = model.add_constraint(x >= 0.0, name="limit")
+
+    assert model.constraints[0].name == "limit"
+    assert model.inspect().constraints[0].name == "limit"
+    assert int(model.get_constraint(name="limit")) == 0
+
+
+def test_sparse_active_mask_reduction_counts_only_active_terms() -> None:
+    model = arco.Model()
+    source = arco.IndexSet(name="source", members=range(128))
+    sink = arco.IndexSet(name="sink", members=range(128))
+    active = np.eye(128, dtype=bool)
+
+    flow = model.add_variables(
+        axes=(source, sink),
+        bounds=arco.NonNegativeFloat,
+        active=active,
+        name="flow",
+    )
+
+    reduced = flow.sum(over=source)
+    estimate = reduced.memory_estimate()
+
+    assert reduced.shape == (128,)
+    assert estimate["dense_slots"] == 128
+    assert estimate["linear_terms"] == 128
+
+
+def test_sparse_active_mask_labeled_multiply_compare_skips_inactive_rows() -> None:
+    model = arco.Model()
+    tech = arco.IndexSet(name="tech", members=range(4))
+    region = arco.IndexSet(name="region", members=range(4))
+    hour = arco.IndexSet(name="hour", members=range(3))
+    active_ir = np.eye(4, dtype=bool)
+    active_irh = active_ir[:, :, None]
+    cf = arco.param(np.full((4, 4, 3), 0.5), axes=(tech, region, hour))
+
+    cap = model.add_variables(
+        axes=(tech, region),
+        bounds=arco.NonNegativeFloat,
+        active=active_ir,
+        name="cap",
+    )
+    gen = model.add_variables(
+        axes=(tech, region, hour),
+        bounds=arco.NonNegativeFloat,
+        active=active_irh,
+        name="gen",
+    )
+
+    scaled_cap = cf * cap
+    scaled_estimate = scaled_cap.memory_estimate()
+
+    assert scaled_cap.shape == (4, 4, 3)
+    assert scaled_estimate["storage"] == "sparse"
+    assert scaled_estimate["dense_slots"] == 48
+    assert scaled_estimate["active_slots"] == 12
+    assert scaled_estimate["linear_terms"] == 12
+
+    _ = model.add_constraints(gen <= scaled_cap, name="cap_limit")
+
+    assert model.num_constraints == 12
+
+
+def test_sparse_active_mask_chained_labeled_products_sum_active_terms() -> None:
+    model = arco.Model()
+    tech = arco.IndexSet(name="tech", members=range(4))
+    region = arco.IndexSet(name="region", members=range(4))
+    hour = arco.IndexSet(name="hour", members=range(3))
+    year = arco.IndexSet(name="year", members=range(2))
+    active_irt = np.eye(4, dtype=bool)[:, :, None]
+    active_irth = active_irt[:, :, None, :]
+    cost = arco.param(np.arange(1.0, 5.0), axes=(tech,))
+    hours_weight = arco.param(np.array([2.0, 3.0, 4.0]), axes=(hour,))
+    pvf = arco.param(np.array([0.95, 0.90]), axes=(year,))
+
+    gen = model.add_variables(
+        axes=(tech, region, hour, year),
+        bounds=arco.NonNegativeFloat,
+        active=active_irth,
+        name="gen",
+    )
+
+    operating_cost = pvf * cost * hours_weight * gen
+    estimate = operating_cost.memory_estimate()
+    objective = operating_cost.sum()
+
+    assert estimate["storage"] == "sparse"
+    assert estimate["dense_slots"] == 96
+    assert estimate["active_slots"] == 24
+    assert estimate["linear_terms"] == 24
+    model.minimize(objective)
+    snapshot = model.inspect()
+    assert snapshot.objective is not None
+    assert len(snapshot.objective.terms) == 24
+
+
+def test_sparse_active_mask_diff_counts_ramping_terms_without_dense_storage() -> None:
+    model = arco.Model()
+    tech = arco.IndexSet(name="tech", members=range(4))
+    region = arco.IndexSet(name="region", members=range(4))
+    hour = arco.IndexSet(name="hour", members=range(5))
+    year = arco.IndexSet(name="year", members=range(2))
+    active_irt = np.eye(4, dtype=bool)[:, :, None]
+    active_irth = active_irt[:, :, None, :]
+
+    gen = model.add_variables(
+        axes=(tech, region, hour, year),
+        bounds=arco.NonNegativeFloat,
+        active=active_irth,
+        name="gen",
+    )
+
+    ramp_delta = np.diff(gen, axis=hour)
+    estimate = ramp_delta.memory_estimate()
+
+    assert ramp_delta.shape == (4, 4, 4, 2)
+    assert estimate["storage"] == "sparse"
+    assert estimate["dense_slots"] == 128
+    assert estimate["active_slots"] == 32
+    assert estimate["linear_terms"] == 64
+
+
+def test_sparse_ramping_constraints_intersect_labeled_active_mask() -> None:
+    model = arco.Model()
+    tech = arco.IndexSet(name="tech", members=range(4))
+    region = arco.IndexSet(name="region", members=range(4))
+    hour = arco.IndexSet(name="hour", members=range(5))
+    year = arco.IndexSet(name="year", members=range(2))
+    hour_ramp = hour[:-1]
+    active_irt = np.eye(4, dtype=bool)[:, :, None].repeat(2, axis=2)
+    constraint_active = active_irt.copy()
+    constraint_active[0, 0, 0] = False
+
+    gen = model.add_variables(
+        axes=(tech, region, hour, year),
+        bounds=arco.NonNegativeFloat,
+        active=active_irt[:, :, None, :],
+        name="gen",
+    )
+    rampup = model.add_variables(
+        axes=(tech, region, hour_ramp, year),
+        bounds=arco.NonNegativeFloat,
+        active=active_irt[:, :, None, :],
+        name="rampup",
+    )
+
+    constraints = model.add_constraints(
+        rampup >= np.diff(gen, axis=hour),
+        active=arco.param(constraint_active, axes=(tech, region, year)),
+        name="ramping",
+    )
+
+    assert len(constraints) == 28
+    assert model.num_constraints == 28
+
+
+def test_sparse_active_mask_storage_balance_add_sub_stays_sparse() -> None:
+    model = arco.Model()
+    tech = arco.IndexSet(name="tech", members=range(4))
+    region = arco.IndexSet(name="region", members=range(4))
+    hour = arco.IndexSet(name="hour", members=range(5))
+    year = arco.IndexSet(name="year", members=range(2))
+    active = np.eye(4, dtype=bool)[:, :, None, None]
+
+    soc = model.add_variables(
+        axes=(tech, region, hour, year),
+        bounds=arco.NonNegativeFloat,
+        active=active,
+        name="soc",
+    )
+    charge = model.add_variables(
+        axes=(tech, region, hour, year),
+        bounds=arco.NonNegativeFloat,
+        active=active,
+        name="charge",
+    )
+    gen = model.add_variables(
+        axes=(tech, region, hour, year),
+        bounds=arco.NonNegativeFloat,
+        active=active,
+        name="gen",
+    )
+
+    balance = soc + 0.92 * charge - gen
+    estimate = balance.memory_estimate()
+
+    assert balance.shape == (4, 4, 5, 2)
+    assert estimate["storage"] == "sparse"
+    assert estimate["dense_slots"] == 160
+    assert estimate["active_slots"] == 40
+    assert estimate["linear_terms"] == 120
+
+
+def test_sparse_active_mask_rolled_storage_balance_constraints_skip_inactive_rows() -> (
+    None
+):
+    model = arco.Model()
+    tech = arco.IndexSet(name="tech", members=range(4))
+    region = arco.IndexSet(name="region", members=range(4))
+    hour = arco.IndexSet(name="hour", members=range(5))
+    year = arco.IndexSet(name="year", members=range(2))
+    active = np.eye(4, dtype=bool)[:, :, None, None]
+
+    soc = model.add_variables(
+        axes=(tech, region, hour, year),
+        bounds=arco.NonNegativeFloat,
+        active=active,
+        name="soc",
+    )
+    charge = model.add_variables(
+        axes=(tech, region, hour, year),
+        bounds=arco.NonNegativeFloat,
+        active=active,
+        name="charge",
+    )
+    gen = model.add_variables(
+        axes=(tech, region, hour, year),
+        bounds=arco.NonNegativeFloat,
+        active=active,
+        name="gen",
+    )
+
+    next_soc = np.roll(soc, -1, axis=hour)
+    balance = soc + 0.92 * charge - gen
+    rolled_estimate = next_soc.memory_estimate()
+
+    assert rolled_estimate["storage"] == "sparse"
+    assert rolled_estimate["dense_slots"] == 160
+    assert rolled_estimate["active_slots"] == 40
+
+    _ = model.add_constraints(next_soc == balance, name="storage_balance")
+
+    assert model.num_constraints == 40
+
+
+def test_reduced_alias_axes_can_relabel_for_vectorized_supply_balance() -> None:
+    model = arco.Model()
+    region = arco.IndexSet(name="r", members=range(4))
+    region_from = region.alias("from")
+    region_to = region.alias("to")
+    hour = arco.IndexSet(name="h", members=range(3))
+    active_routes = np.eye(4, dtype=bool)
+    load = arco.param(np.full((4, 3), 10.0), axes=(region, hour))
+
+    gen = model.add_variables(
+        axes=(region, hour),
+        bounds=arco.NonNegativeFloat,
+        name="gen",
+    )
+    flow = model.add_variables(
+        axes=(region_from, region_to, hour),
+        bounds=arco.NonNegativeFloat,
+        active=active_routes[:, :, None],
+        name="flow",
+    )
+
+    imports = (flow @ region_from).relabel_axis(region_to, region)
+    exports = (flow @ region_to).relabel_axis(region_from, region)
+    balance = gen + 0.95 * imports - exports
+
+    assert [axis.name for axis in imports.index_sets] == ["r", "h"]
+    assert [axis.name for axis in exports.index_sets] == ["r", "h"]
+    assert balance.shape == (4, 3)
+
+    _ = model.add_constraints(balance == load, name="supply_balance")
+
+    assert model.num_constraints == 12
 
 
 def test_expression_array_memory_estimate_preserves_compact_storage() -> None:
@@ -157,6 +556,37 @@ def test_expression_array_memory_estimate_preserves_compact_storage() -> None:
     assert expression_estimate["estimated_solver_sparse_matrix_bytes"] == (128 * 16) + (
         129 * 8
     )
+
+
+def test_sparse_expression_sum_builds_objective_without_dense_slots() -> None:
+    model = arco.Model()
+    i = arco.IndexSet(name="i", members=range(4))
+    h = arco.IndexSet(name="h", members=range(3))
+    active = arco.param(
+        np.array([True, False, True, False], dtype=bool),
+        axes=(i,),
+    )
+    weights = arco.param(np.array([1.0, 10.0, 2.0, 20.0]), axes=(i,))
+
+    x = model.add_variables(
+        axes=(i, h),
+        bounds=arco.NonNegativeFloat,
+        active=active,
+        name="x",
+    )
+    weighted = weights * x
+    model.minimize(weighted.sum())
+
+    assert x.active_count == 6
+    assert weighted.memory_estimate()["storage"] == "sparse"
+    assert model.inspect().objective.terms == [
+        (0, 1.0),
+        (1, 1.0),
+        (2, 1.0),
+        (3, 2.0),
+        (4, 2.0),
+        (5, 2.0),
+    ]
 
 
 def test_labeled_active_mask_rejects_duplicate_axes_through_shared_shape_contract() -> (

--- a/bindings/python/tests/test_api_contracts.py
+++ b/bindings/python/tests/test_api_contracts.py
@@ -145,6 +145,74 @@ def test_indexed_model_api_contract_solves_with_array_result_access() -> None:
     np.testing.assert_allclose(result.value(output), np.array([3.0, 5.0]))
 
 
+def test_model_matrix_profile_reports_column_density_without_sparse_export() -> None:
+    model = arco.Model()
+    x = model.add_variable(bounds=arco.NonNegativeFloat, name="x")
+    y = model.add_variable(bounds=arco.NonNegativeFloat, name="y")
+    z = model.add_variable(bounds=arco.NonNegativeFloat, name="z")
+    model.add_constraint(x >= 1.0, name="x_min")
+    model.add_constraint(x + y >= 2.0, name="xy_min")
+    model.add_constraint(x <= 4.0, name="x_max")
+    model.minimize(x + y + z, name="cost")
+
+    profile = model.matrix_profile(top_n=2, dense_threshold=2)
+    buckets = profile["column_nnz_buckets"]
+    top_columns = profile["top_columns"]
+
+    assert profile["num_variables"] == 3
+    assert profile["num_constraints"] == 3
+    assert profile["num_coefficients"] == 4
+    assert profile["max_column_nnz"] == 3
+    assert profile["min_nonzero_column_nnz"] == 1
+    assert profile["dense_columns"] == 1
+    assert buckets["eq_0"] == 1
+    assert buckets["eq_1"] == 1
+    assert top_columns[0] == {"variable_id": int(x), "name": "x", "nnz": 3}
+    assert top_columns[1] == {"variable_id": int(y), "name": "y", "nnz": 1}
+
+
+def test_model_reserve_preserves_build_and_solve_behavior() -> None:
+    model = arco.Model()
+    model.reserve(num_variables=4, num_constraints=3)
+
+    x = model.add_variable(bounds=arco.NonNegativeFloat)
+    y = model.add_variable(bounds=arco.NonNegativeFloat)
+    model.add_constraint(x + y >= 3.0)
+    model.add_constraint(x <= 5.0)
+    model.minimize(x + 2.0 * y)
+
+    result = model.solve(log_to_console=False)
+
+    assert model.num_variables == 2
+    assert model.num_constraints == 2
+    assert result.is_optimal()
+    assert round(result.objective_value, 6) == 3.0
+
+
+def test_model_can_append_objective_terms_incrementally() -> None:
+    model = arco.Model()
+    x = model.add_variable(bounds=arco.NonNegativeFloat, name="x")
+    y = model.add_variable(bounds=arco.NonNegativeFloat, name="y")
+    model.add_constraint(x >= 1.0)
+    model.add_constraint(y >= 2.0)
+
+    model.minimize(x)
+    model.add_objective_terms(2.0 * y)
+
+    result = model.solve(log_to_console=False)
+
+    assert result.is_optimal()
+    assert round(result.objective_value, 6) == 5.0
+
+
+def test_model_rejects_appended_objective_terms_without_objective_sense() -> None:
+    model = arco.Model()
+    x = model.add_variable(bounds=arco.NonNegativeFloat, name="x")
+
+    with pytest.raises(arco.ObjectiveMissingError):
+        model.add_objective_terms(x)
+
+
 def test_debug_api_contract_exposes_constraint_slack_and_dual() -> None:
     model = arco.Model()
     x = model.add_variable(bounds=arco.NonNegativeFloat, name="x")
@@ -217,6 +285,53 @@ def test_debug_api_contract_keeps_raw_result_vector_properties_in_expert_path() 
     assert round(variable_duals[int(x)], 6) == round(
         result.get_variable_dual(index=int(x)), 6
     )
+
+
+def test_objective_only_solve_can_skip_solution_vectors() -> None:
+    model = arco.Model()
+    x = model.add_variable(bounds=arco.NonNegativeFloat, name="x")
+    model.add_constraint(x >= 1.0, name="lower_bound")
+    model.minimize(2.0 * x, name="cost")
+
+    result = model.solve(
+        solver=arco.HiGHS(
+            log_to_console=False,
+            parameters={
+                "arco.extract_solution": "false",
+                "arco.fingerprint": "false",
+            },
+        )
+    )
+
+    assert result.is_optimal()
+    assert round(result.objective_value, 6) == 2.0
+    assert result.num_primal_values() == 0
+    assert result.num_variable_duals() == 0
+    assert result.num_constraint_duals() == 0
+
+
+def test_consuming_solve_releases_model_after_handoff() -> None:
+    model = arco.Model()
+    x = model.add_variable(bounds=arco.NonNegativeFloat, name="x")
+    model.add_constraint(x >= 1.0, name="lower_bound")
+    model.minimize(2.0 * x, name="cost")
+
+    result = model.solve(
+        solver=arco.HiGHS(
+            log_to_console=False,
+            parameters={
+                "arco.consume_model": "true",
+                "arco.extract_solution": "false",
+                "arco.fingerprint": "false",
+            },
+        )
+    )
+
+    assert result.is_optimal()
+    assert round(result.objective_value, 6) == 2.0
+    assert result.num_primal_values() == 0
+    assert model.num_variables == 0
+    assert model.num_constraints == 0
 
 
 def test_debug_api_contract_requires_keyword_solve_configuration() -> None:
@@ -594,24 +709,17 @@ def test_indexed_api_contract_exposes_index_set_index_error_code() -> None:
     assert list(plant) == plant.members
 
 
-def test_indexed_api_contract_requires_keyword_index_set_name() -> None:
+def test_indexed_api_contract_accepts_legacy_positional_index_set_name() -> None:
     set_name = "plant"
     size = 3
     members = ["north", "south"]
 
-    try:
-        arco.IndexSet("plant", members=["north", "south"])
-    except TypeError:
-        pass
-    else:  # pragma: no cover
-        raise AssertionError("expected positional IndexSet name to fail")
+    plant = arco.IndexSet("plant", members=["north", "south"])
+    assert plant.name == "plant"
+    assert plant.members == ["north", "south"]
 
-    try:
-        arco.IndexSet(set_name, members=["north", "south"])
-    except TypeError:
-        pass
-    else:  # pragma: no cover
-        raise AssertionError("expected positional IndexSet variable name to fail")
+    plant_from_variable = arco.IndexSet(set_name, members=["north", "south"])
+    assert plant_from_variable.name == set_name
 
     try:
         arco.IndexSet(name="plant", members=["north", "south"], size=2)
@@ -667,13 +775,11 @@ def test_scalar_api_contract_requires_keyword_variable_bounds() -> None:
         raise AssertionError("expected positional add_variable arguments to fail")
 
 
-def test_scalar_api_contract_requires_keyword_bounds_fields() -> None:
-    try:
-        arco.Bounds(0.0, 1.0)
-    except TypeError:
-        pass
-    else:  # pragma: no cover
-        raise AssertionError("expected positional Bounds fields to fail")
+def test_scalar_api_contract_accepts_legacy_positional_bounds_fields() -> None:
+    bounds = arco.Bounds(0.0, 1.0)
+
+    assert bounds.lower == 0.0
+    assert bounds.upper == 1.0
 
 
 def test_indexed_api_contract_exposes_index_set_type_error_code() -> None:
@@ -1877,14 +1983,14 @@ def test_api_contract_rejects_ambiguous_param_positional_shape() -> None:
 
     try:
         arco.param("cost", np.array([1.0, 2.0]), plant)
-    except TypeError:
+    except (TypeError, arco.ArrayDimensionError, arco.ArrayTypeError):
         pass
     else:  # pragma: no cover
         raise AssertionError("expected ambiguous positional param signature to fail")
 
     try:
         arco.param(param_name, values, plant)
-    except TypeError:
+    except (TypeError, arco.ArrayDimensionError, arco.ArrayTypeError):
         pass
     else:  # pragma: no cover
         raise AssertionError(
@@ -1892,41 +1998,30 @@ def test_api_contract_rejects_ambiguous_param_positional_shape() -> None:
         )
 
 
-def test_api_contract_requires_keyword_param_axes() -> None:
+def test_api_contract_accepts_legacy_positional_param_axes() -> None:
     plant = arco.IndexSet(name="plant", members=["north", "south"])
     values = np.array([1.0, 2.0])
     axes = (plant,)
-    param_name = "demand"
 
-    try:
-        arco.param(np.array([1.0, 2.0]), (plant,))
-    except TypeError:
-        pass
-    else:  # pragma: no cover
-        raise AssertionError("expected positional param axes to fail")
+    param_from_tuple = arco.param(np.array([1.0, 2.0]), (plant,))
+    assert param_from_tuple.axes == axes
+
+    param_from_axis = arco.param(values, plant)
+    assert param_from_axis.axes == axes
 
     try:
         arco.param(np.array([1.0, 2.0]), (plant,), "demand")
-    except TypeError:
+    except (TypeError, arco.ArrayDimensionError, arco.ArrayTypeError):
         pass
     else:  # pragma: no cover
-        raise AssertionError("expected positional param axes/name usage to fail")
+        raise AssertionError("expected positional param name usage to fail")
 
     try:
-        arco.param(values, axes)
+        arco.param(values, axes, axes=axes)
     except TypeError:
         pass
     else:  # pragma: no cover
-        raise AssertionError("expected positional param axes variable usage to fail")
-
-    try:
-        arco.param(values, axes, param_name)
-    except TypeError:
-        pass
-    else:  # pragma: no cover
-        raise AssertionError(
-            "expected positional param axes/name variable usage to fail"
-        )
+        raise AssertionError("expected duplicate positional/keyword axes to fail")
 
 
 def test_api_contract_rejects_positional_variable_constructors() -> None:
@@ -1943,26 +2038,16 @@ def test_api_contract_rejects_positional_variable_constructors() -> None:
 
     try:
         model.add_variables((plant,), arco.NonNegativeFloat, False, False, None, "x")
-    except TypeError:
+    except (TypeError, arco.ArrayTypeError):
         pass
     else:  # pragma: no cover
         raise AssertionError("expected positional add_variables signature to fail")
 
-    try:
-        model.add_variables((plant,), bounds=arco.NonNegativeFloat, name="x")
-    except TypeError:
-        pass
-    else:  # pragma: no cover
-        raise AssertionError("expected positional add_variables axes to fail")
+    x = model.add_variables((plant,), bounds=arco.NonNegativeFloat, name="x")
+    assert x.shape == (2,)
 
-    try:
-        model.add_variables(axes, bounds=arco.NonNegativeFloat, name="x")
-    except TypeError:
-        pass
-    else:  # pragma: no cover
-        raise AssertionError(
-            "expected positional add_variables axes variable usage to fail"
-        )
+    y = model.add_variables(axes, bounds=arco.NonNegativeFloat, name="y")
+    assert y.shape == (2,)
 
 
 def test_api_contract_rejects_positional_constraint_name_order() -> None:

--- a/bindings/python/tests/test_param_api.py
+++ b/bindings/python/tests/test_param_api.py
@@ -40,19 +40,23 @@ def test_param_validates_shape_and_exposes_metadata() -> None:
         )
 
 
-def test_param_requires_keyword_axes() -> None:
+def test_param_accepts_legacy_positional_axes() -> None:
     i = arco.IndexSet(name="i", members=["a", "b"])
 
-    with pytest.raises(TypeError):
-        arco.param(np.array([1.0, 2.0]), i)
+    p = arco.param(np.array([1.0, 2.0]), i)
+
+    assert p.axes == (i,)
+    np.testing.assert_array_equal(p.values, np.array([1.0, 2.0]))
 
 
-def test_add_variables_requires_keyword_axes() -> None:
+def test_add_variables_accepts_legacy_positional_axes() -> None:
     model = arco.Model()
     i = arco.IndexSet(name="i", members=["a", "b"])
 
-    with pytest.raises(TypeError):
-        model.add_variables(i, bounds=arco.NonNegativeFloat)
+    x = model.add_variables(i, bounds=arco.NonNegativeFloat)
+
+    assert x.index_sets == (i,)
+    assert x.shape == (2,)
 
 
 def test_param_rejects_duplicate_axes_without_alias() -> None:

--- a/bindings/python/tests/test_xpress.py
+++ b/bindings/python/tests/test_xpress.py
@@ -20,6 +20,12 @@ HAS_XPRESS_RUNTIME = bool(XPRESS_RUNTIME_INFO.get("runtime_dir"))
 HAS_XPRESS_BACKEND = bool(XPRESS_RUNTIME_INFO.get("backend_enabled"))
 
 
+def test_xpress_runtime_info_reports_library_availability() -> None:
+    assert isinstance(XPRESS_RUNTIME_INFO["runtime_available"], bool)
+    if not XPRESS_RUNTIME_INFO.get("runtime_dir"):
+        assert XPRESS_RUNTIME_INFO["runtime_available"] is False
+
+
 @pytest.mark.skipif(
     not HAS_XPRESS_RUNTIME,
     reason="local Xpress runtime not available",

--- a/crates/arco-arrays/src/lib.rs
+++ b/crates/arco-arrays/src/lib.rs
@@ -249,7 +249,98 @@ impl BroadcastPlan {
         Ok(indices)
     }
 
-    fn source_offset_for_target_flat(&self, target_flat: usize) -> usize {
+    /// Return target-flat coordinates where the broadcasted predicate is true,
+    /// expanding from true source entries instead of scanning every target slot.
+    ///
+    /// This is substantially cheaper when a small labeled mask broadcasts over
+    /// large missing axes, for example `(from,to)` route activity over
+    /// `(from,to,h,t)` flow variables.
+    pub fn active_target_indices_from_source<T>(
+        &self,
+        values: &[T],
+        predicate: impl Fn(&T) -> bool,
+    ) -> Result<Vec<usize>, ShapeError> {
+        let expected = self.source.total_len();
+        if values.len() != expected {
+            return Err(ShapeError::ValueCountMismatch {
+                expected,
+                actual: values.len(),
+            });
+        }
+
+        let target_shape = self.target.shape();
+        let source_to_target = self
+            .source
+            .axes()
+            .iter()
+            .map(|source_axis| {
+                self.target
+                    .axis_index(source_axis)
+                    .expect("BroadcastPlan source axes must exist in target")
+            })
+            .collect::<Vec<_>>();
+        let missing_target_axes = self
+            .target_to_source
+            .iter()
+            .enumerate()
+            .filter_map(|(target_axis, source_axis)| source_axis.is_none().then_some(target_axis))
+            .collect::<Vec<_>>();
+
+        let mut indices = Vec::new();
+        for (source_flat, value) in values.iter().enumerate() {
+            if !predicate(value) {
+                continue;
+            }
+
+            let mut remainder = source_flat;
+            let mut target_base = 0usize;
+            for (source_axis, source_stride) in self.source_strides.iter().enumerate() {
+                let coordinate = remainder / source_stride;
+                remainder %= source_stride;
+                let target_axis = source_to_target[source_axis];
+                target_base += coordinate * self.target_strides[target_axis];
+            }
+
+            self.expand_missing_target_axes(
+                0,
+                target_base,
+                &missing_target_axes,
+                &target_shape,
+                &mut indices,
+            );
+        }
+        indices.sort_unstable();
+        Ok(indices)
+    }
+
+    fn expand_missing_target_axes(
+        &self,
+        axis_pos: usize,
+        base: usize,
+        missing_target_axes: &[usize],
+        target_shape: &[usize],
+        out: &mut Vec<usize>,
+    ) {
+        if axis_pos == missing_target_axes.len() {
+            out.push(base);
+            return;
+        }
+
+        let target_axis = missing_target_axes[axis_pos];
+        let stride = self.target_strides[target_axis];
+        for coordinate in 0..target_shape[target_axis] {
+            self.expand_missing_target_axes(
+                axis_pos + 1,
+                base + coordinate * stride,
+                missing_target_axes,
+                target_shape,
+                out,
+            );
+        }
+    }
+
+    #[must_use]
+    pub fn source_offset_for_target_flat(&self, target_flat: usize) -> usize {
         let mut remainder = target_flat;
         let mut source_flat = 0;
 
@@ -321,5 +412,33 @@ mod tests {
             .expect("active indices");
 
         assert_eq!(active, vec![0, 2, 4, 7, 9, 11]);
+    }
+
+    #[test]
+    fn source_driven_active_indices_match_target_scan() {
+        let source = LabeledShape::new(vec![AxisSpec::new("from", 3), AxisSpec::new("to", 2)])
+            .expect("source shape");
+        let target = LabeledShape::new(vec![
+            AxisSpec::new("h", 2),
+            AxisSpec::new("to", 2),
+            AxisSpec::new("from", 3),
+            AxisSpec::new("t", 2),
+        ])
+        .expect("target shape");
+        let plan = BroadcastPlan::new(source, target).expect("broadcast plan");
+        let mask = vec![true, false, false, true, true, false];
+
+        let target_scan = plan
+            .active_target_indices(&mask, |value| *value)
+            .expect("target scan active indices");
+        let source_driven = plan
+            .active_target_indices_from_source(&mask, |value| *value)
+            .expect("source driven active indices");
+
+        assert_eq!(source_driven, target_scan);
+        assert_eq!(
+            source_driven,
+            vec![0, 1, 4, 5, 8, 9, 12, 13, 16, 17, 20, 21]
+        );
     }
 }

--- a/crates/arco-highs/src/lib.rs
+++ b/crates/arco-highs/src/lib.rs
@@ -10,4 +10,4 @@ pub use ffi::{
     highs_version,
 };
 pub use solution::Solution;
-pub use solver::{HighsModelViewBackend, SolverError, solve_model_view};
+pub use solver::{HighsModelViewBackend, SolverError, solve_model_view, solve_owned_model};

--- a/crates/arco-highs/src/solver.rs
+++ b/crates/arco-highs/src/solver.rs
@@ -903,6 +903,18 @@ fn raw_highs_model_status_to_solver_status(status: highs_sys::HighsInt) -> Solve
     }
 }
 
+fn objective_value_for_primal_solution_status(
+    objective_value: f64,
+    highs_primal_solution_status: f64,
+) -> f64 {
+    let feasible_status = highs_sys::SOLUTION_STATUS_FEASIBLE as f64;
+    if (highs_primal_solution_status - feasible_status).abs() <= f64::EPSILON {
+        objective_value
+    } else {
+        f64::NAN
+    }
+}
+
 fn finish_prepared_solve(
     prepared: PreparedHighsSolve,
     config: &SolverConfig,
@@ -944,6 +956,8 @@ fn finish_prepared_solve(
             ),
         };
     let highs_run_seconds = highs_run_start.elapsed().as_secs_f64();
+    let objective_value =
+        objective_value_for_primal_solution_status(objective_value, highs_primal_solution_status);
     if !mapped_status.is_feasible() {
         return Err(SolverError::SolveFailure {
             status: mapped_status,
@@ -1343,6 +1357,24 @@ mod tests {
             result.metadata.get("highs_primal_solution_status"),
             Some(&(highs_sys::SOLUTION_STATUS_FEASIBLE as f64))
         );
+    }
+
+    #[test]
+    fn objective_value_is_omitted_without_primal_solution() {
+        assert_eq!(
+            objective_value_for_primal_solution_status(
+                2.0,
+                highs_sys::SOLUTION_STATUS_FEASIBLE as f64
+            ),
+            2.0
+        );
+
+        for status in [
+            highs_sys::SOLUTION_STATUS_NONE as f64,
+            highs_sys::SOLUTION_STATUS_INFEASIBLE as f64,
+        ] {
+            assert!(objective_value_for_primal_solution_status(2.0, status).is_nan());
+        }
     }
 
     #[test]

--- a/crates/arco-highs/src/solver.rs
+++ b/crates/arco-highs/src/solver.rs
@@ -903,15 +903,30 @@ fn raw_highs_model_status_to_solver_status(status: highs_sys::HighsInt) -> Solve
     }
 }
 
+fn primal_solution_is_feasible(highs_primal_solution_status: f64) -> bool {
+    let feasible_status = highs_sys::SOLUTION_STATUS_FEASIBLE as f64;
+    (highs_primal_solution_status - feasible_status).abs() <= f64::EPSILON
+}
+
 fn objective_value_for_primal_solution_status(
     objective_value: f64,
     highs_primal_solution_status: f64,
 ) -> f64 {
-    let feasible_status = highs_sys::SOLUTION_STATUS_FEASIBLE as f64;
-    if (highs_primal_solution_status - feasible_status).abs() <= f64::EPSILON {
+    if primal_solution_is_feasible(highs_primal_solution_status) {
         objective_value
     } else {
         f64::NAN
+    }
+}
+
+fn status_with_primal_solution_availability(
+    mapped_status: SolverStatus,
+    highs_primal_solution_status: f64,
+) -> SolverStatus {
+    if mapped_status.is_feasible() && !primal_solution_is_feasible(highs_primal_solution_status) {
+        SolverStatus::Unknown
+    } else {
+        mapped_status
     }
 }
 
@@ -958,9 +973,11 @@ fn finish_prepared_solve(
     let highs_run_seconds = highs_run_start.elapsed().as_secs_f64();
     let objective_value =
         objective_value_for_primal_solution_status(objective_value, highs_primal_solution_status);
-    if !mapped_status.is_feasible() {
+    let reported_status =
+        status_with_primal_solution_availability(mapped_status, highs_primal_solution_status);
+    if !reported_status.is_feasible() {
         return Err(SolverError::SolveFailure {
-            status: mapped_status,
+            status: reported_status,
         });
     }
     let solution_extract_start = Instant::now();
@@ -1016,7 +1033,7 @@ fn finish_prepared_solve(
 
     let result = ModelViewSolveResult {
         fingerprint: prepared.fingerprint,
-        status: mapped_status,
+        status: reported_status,
         objective_value,
         primal_values,
         variable_duals,
@@ -1375,6 +1392,38 @@ mod tests {
         ] {
             assert!(objective_value_for_primal_solution_status(2.0, status).is_nan());
         }
+    }
+
+    #[test]
+    fn limit_status_without_primal_solution_is_not_reported_feasible() {
+        assert_eq!(
+            status_with_primal_solution_availability(
+                SolverStatus::TimeLimit,
+                highs_sys::SOLUTION_STATUS_FEASIBLE as f64
+            ),
+            SolverStatus::TimeLimit
+        );
+        assert_eq!(
+            status_with_primal_solution_availability(
+                SolverStatus::TimeLimit,
+                highs_sys::SOLUTION_STATUS_NONE as f64
+            ),
+            SolverStatus::Unknown
+        );
+        assert_eq!(
+            status_with_primal_solution_availability(
+                SolverStatus::IterationLimit,
+                highs_sys::SOLUTION_STATUS_INFEASIBLE as f64
+            ),
+            SolverStatus::Unknown
+        );
+        assert_eq!(
+            status_with_primal_solution_availability(
+                SolverStatus::Infeasible,
+                highs_sys::SOLUTION_STATUS_NONE as f64
+            ),
+            SolverStatus::Infeasible
+        );
     }
 
     #[test]

--- a/crates/arco-highs/src/solver.rs
+++ b/crates/arco-highs/src/solver.rs
@@ -184,7 +184,7 @@ enum SolvedHighsModel {
     Wrapper(RawSolvedHighsModel),
     Direct {
         model: DirectHighsModel,
-        status: SolverStatus,
+        model_status: highs_sys::HighsInt,
     },
 }
 
@@ -742,15 +742,23 @@ impl DirectHighsModel {
         Ok(model)
     }
 
-    fn solve(&mut self) -> Result<SolverStatus, SolverError> {
+    fn solve(&mut self) -> Result<highs_sys::HighsInt, SolverError> {
         ensure_highs_ok(unsafe { highs_sys::Highs_run(self.ptr) }, "Highs_run")?;
-        Ok(raw_highs_model_status_to_solver_status(unsafe {
-            highs_sys::Highs_getModelStatus(self.ptr)
-        }))
+        Ok(unsafe { highs_sys::Highs_getModelStatus(self.ptr) })
     }
 
     fn objective_value(&self) -> f64 {
         unsafe { highs_sys::Highs_getObjectiveValue(self.ptr) }
+    }
+
+    fn int_info_value(&self, key: &str) -> Result<highs_sys::HighsInt, SolverError> {
+        let key = cstring_highs_key(key)?;
+        let mut value = -1;
+        ensure_highs_ok(
+            unsafe { highs_sys::Highs_getIntInfoValue(self.ptr, key.as_ptr(), &mut value) },
+            key.to_string_lossy().as_ref(),
+        )?;
+        Ok(value)
     }
 
     fn solution_vectors(
@@ -878,6 +886,12 @@ fn cstring_option_key(key: &str) -> Result<CString, SolverError> {
     })
 }
 
+fn cstring_highs_key(key: &str) -> Result<CString, SolverError> {
+    CString::new(key).map_err(|_| {
+        SolverError::SolverSpecific(format!("invalid HiGHS info key {key:?}: contains NUL"))
+    })
+}
+
 fn raw_highs_model_status_to_solver_status(status: highs_sys::HighsInt) -> SolverStatus {
     match status {
         highs_sys::MODEL_STATUS_OPTIMAL => SolverStatus::Optimal,
@@ -901,18 +915,34 @@ fn finish_prepared_solve(
     let solved_model = match prepared.highs_model {
         PreparedHighsModel::Wrapper(model) => SolvedHighsModel::Wrapper(model.solve()),
         PreparedHighsModel::Direct(mut model) => {
-            let status = model.solve()?;
-            SolvedHighsModel::Direct { model, status }
+            let model_status = model.solve()?;
+            SolvedHighsModel::Direct {
+                model,
+                model_status,
+            }
         }
     };
-    let mapped_status = match &solved_model {
-        SolvedHighsModel::Wrapper(model) => highs_model_status(model.status()).to_solver_status(),
-        SolvedHighsModel::Direct { status, .. } => *status,
-    };
-    let objective_value = match &solved_model {
-        SolvedHighsModel::Wrapper(model) => model.objective_value(),
-        SolvedHighsModel::Direct { model, .. } => model.objective_value(),
-    };
+    let (mapped_status, highs_model_status, highs_primal_solution_status, objective_value) =
+        match &solved_model {
+            SolvedHighsModel::Wrapper(model) => {
+                let model_status = model.status();
+                (
+                    highs_model_status(model_status).to_solver_status(),
+                    model_status as isize as f64,
+                    model.primal_solution_status() as isize as f64,
+                    model.objective_value(),
+                )
+            }
+            SolvedHighsModel::Direct {
+                model,
+                model_status,
+            } => (
+                raw_highs_model_status_to_solver_status(*model_status),
+                *model_status as f64,
+                model.int_info_value("primal_solution_status")? as f64,
+                model.objective_value(),
+            ),
+        };
     let highs_run_seconds = highs_run_start.elapsed().as_secs_f64();
     if !mapped_status.is_feasible() {
         return Err(SolverError::SolveFailure {
@@ -955,6 +985,11 @@ fn finish_prepared_solve(
     metadata.insert("highs_run_s".to_string(), highs_run_seconds);
     metadata.insert("solution_extract_s".to_string(), solution_extract_seconds);
     metadata.insert("fingerprint_s".to_string(), prepared.fingerprint_seconds);
+    metadata.insert("highs_model_status".to_string(), highs_model_status);
+    metadata.insert(
+        "highs_primal_solution_status".to_string(),
+        highs_primal_solution_status,
+    );
     metadata.insert("num_variables".to_string(), prepared.num_variables as f64);
     metadata.insert(
         "num_constraints".to_string(),
@@ -1158,6 +1193,14 @@ mod tests {
         assert_eq!(result.metadata.get("num_variables"), Some(&1.0));
         assert_eq!(result.metadata.get("num_constraints"), Some(&1.0));
         assert_eq!(result.metadata.get("num_coefficients"), Some(&1.0));
+        assert_eq!(
+            result.metadata.get("highs_model_status"),
+            Some(&(highs_sys::MODEL_STATUS_OPTIMAL as f64))
+        );
+        assert_eq!(
+            result.metadata.get("highs_primal_solution_status"),
+            Some(&(highs_sys::SOLUTION_STATUS_FEASIBLE as f64))
+        );
     }
 
     #[test]
@@ -1252,6 +1295,14 @@ mod tests {
         assert_eq!(result.primal_values, vec![1.0]);
         assert_eq!(result.objective_value, 2.0);
         assert_eq!(result.metadata.get("highs_direct_load_path"), Some(&1.0));
+        assert_eq!(
+            result.metadata.get("highs_model_status"),
+            Some(&(highs_sys::MODEL_STATUS_OPTIMAL as f64))
+        );
+        assert_eq!(
+            result.metadata.get("highs_primal_solution_status"),
+            Some(&(highs_sys::SOLUTION_STATUS_FEASIBLE as f64))
+        );
     }
 
     #[test]
@@ -1284,6 +1335,14 @@ mod tests {
         assert_eq!(result.objective_value, 2.0);
         assert_eq!(result.metadata.get("highs_direct_load_path"), Some(&1.0));
         assert_eq!(result.metadata.get("num_coefficients"), Some(&1.0));
+        assert_eq!(
+            result.metadata.get("highs_model_status"),
+            Some(&(highs_sys::MODEL_STATUS_OPTIMAL as f64))
+        );
+        assert_eq!(
+            result.metadata.get("highs_primal_solution_status"),
+            Some(&(highs_sys::SOLUTION_STATUS_FEASIBLE as f64))
+        );
     }
 
     #[test]

--- a/crates/arco-highs/src/solver.rs
+++ b/crates/arco-highs/src/solver.rs
@@ -3,11 +3,13 @@
 use crate::status::highs_model_status;
 use arco_model::{ConstraintId, ModelFingerprint, ModelView, Sense, VariableId};
 use arco_solver::{
-    ModelViewBackend, ModelViewSolveResult, SolverConfig, SolverStatusMapping,
-    validate_model_view_solve_result,
+    ModelViewBackend, ModelViewSolveResult, SolverConfig, SolverStatus, SolverStatusMapping,
+    validate_model_view_solve_result_with_config,
 };
-use highs::{ColProblem, Model as RawHighsModel, Row as HighsRow, Sense as HighsSense};
+use highs::SolvedModel as RawSolvedHighsModel;
+use highs::{ColProblem, HighsOptionValue, Model as RawHighsModel, Sense as HighsSense};
 use std::collections::BTreeMap;
+use std::ffi::{CString, c_void};
 use std::time::Instant;
 
 /// Re-export of contract solver error for backward compatibility.
@@ -52,38 +54,49 @@ fn apply_solver_config(
     validate_solver_config(config)?;
 
     if config.verbosity.unwrap_or(0) == 0 && !config.log_to_console.unwrap_or(false) {
-        highs_model.make_quiet();
+        try_set_highs_option(highs_model, "output_flag", false)?;
+        try_set_highs_option(highs_model, "log_to_console", false)?;
     }
     if let Some(level) = config.verbosity {
-        highs_model.set_option("output_flag", level > 0);
+        try_set_highs_option(highs_model, "output_flag", level > 0)?;
     }
     if config.log_to_console.unwrap_or(false) {
-        highs_model.set_option("log_to_console", true);
-        highs_model.set_option("output_flag", true);
+        try_set_highs_option(highs_model, "log_to_console", true)?;
+        try_set_highs_option(highs_model, "output_flag", true)?;
     }
     if let Some(limit) = config.time_limit {
-        highs_model.set_option("time_limit", limit);
+        try_set_highs_option(highs_model, "time_limit", limit)?;
     }
     if let Some(gap) = config.mip_gap {
-        highs_model.set_option("mip_rel_gap", gap);
+        try_set_highs_option(highs_model, "mip_rel_gap", gap)?;
     }
     if let Some(presolve) = config.presolve {
-        highs_model.set_option("presolve", if presolve { "on" } else { "off" });
+        try_set_highs_option(highs_model, "presolve", if presolve { "on" } else { "off" })?;
     }
     if let Some(threads) = config.threads {
-        highs_model.set_option("threads", threads as i32);
+        try_set_highs_option(highs_model, "threads", threads as i32)?;
     }
     if let Some(tolerance) = config.tolerance {
-        highs_model.set_option("primal_feasibility_tolerance", tolerance);
-        highs_model.set_option("dual_feasibility_tolerance", tolerance);
+        try_set_highs_option(highs_model, "primal_feasibility_tolerance", tolerance)?;
+        try_set_highs_option(highs_model, "dual_feasibility_tolerance", tolerance)?;
     }
     for (key, value) in &config.parameters {
         if key.starts_with("arco.") {
             continue;
         }
-        highs_model.set_option(key.as_str(), value.as_str());
+        try_set_highs_option(highs_model, key.as_str(), value.as_str())?;
     }
     Ok(())
+}
+
+fn try_set_highs_option<V: HighsOptionValue>(
+    highs_model: &mut RawHighsModel,
+    key: &str,
+    value: V,
+) -> Result<(), SolverError> {
+    highs_model.try_set_option(key, value).map_err(|_| {
+        SolverError::InvalidSettings(format!("invalid HiGHS option or value for {key:?}"))
+    })
 }
 
 /// Adapter implementation for primitive model-view solves through HiGHS.
@@ -109,6 +122,115 @@ pub fn solve_model_view(
     model: &(impl ModelView + ?Sized),
     config: &SolverConfig,
 ) -> Result<ModelViewSolveResult, SolverError> {
+    let prepared_problem = prepare_highs_problem(model, config)?;
+    let result =
+        finish_prepared_solve(optimise_prepared_problem(prepared_problem, config)?, config)?;
+    validate_model_view_solve_result_with_config(model, &result, config)?;
+    Ok(result)
+}
+
+/// Solve an owned core model, allowing callers to release model memory before
+/// the HiGHS algorithm starts.
+pub fn solve_owned_model(
+    mut model: arco_model::Model,
+    config: &SolverConfig,
+) -> Result<ModelViewSolveResult, SolverError> {
+    let prepared_problem = prepare_owned_highs_problem(&mut model, config)?;
+    drop(model);
+    let prepared = optimise_prepared_problem(prepared_problem, config)?;
+    finish_prepared_solve(prepared, config)
+}
+
+struct PreparedHighsProblem {
+    problem: PreparedHighsLoad,
+    load_path: HighsLoadPath,
+    sense: HighsSense,
+    fingerprint: ModelFingerprint,
+    matrix_build_seconds: f64,
+    fingerprint_seconds: f64,
+    num_variables: usize,
+    num_constraints: usize,
+    num_coefficients: usize,
+}
+
+struct PreparedHighsSolve {
+    highs_model: PreparedHighsModel,
+    load_path: HighsLoadPath,
+    fingerprint: ModelFingerprint,
+    matrix_build_seconds: f64,
+    fingerprint_seconds: f64,
+    num_variables: usize,
+    num_constraints: usize,
+    num_coefficients: usize,
+}
+
+enum PreparedHighsLoad {
+    Wrapper(ColProblem),
+    Direct(DirectHighsLoadData),
+}
+
+enum PreparedHighsModel {
+    Wrapper(RawHighsModel),
+    Direct(DirectHighsModel),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HighsLoadPath {
+    Wrapper,
+    Direct,
+}
+
+enum SolvedHighsModel {
+    Wrapper(RawSolvedHighsModel),
+    Direct {
+        model: DirectHighsModel,
+        status: SolverStatus,
+    },
+}
+
+struct DirectHighsLoadData {
+    num_cols: highs_sys::HighsInt,
+    num_rows: highs_sys::HighsInt,
+    num_nonzeros: highs_sys::HighsInt,
+    col_cost: Vec<f64>,
+    col_lower: Vec<f64>,
+    col_upper: Vec<f64>,
+    row_lower: Vec<f64>,
+    row_upper: Vec<f64>,
+    a_start: Vec<highs_sys::HighsInt>,
+    a_index: Vec<highs_sys::HighsInt>,
+    a_value: Vec<f64>,
+    integrality: Option<Vec<highs_sys::HighsInt>>,
+}
+
+struct DirectHighsModel {
+    ptr: *mut c_void,
+}
+
+type SolutionVectors = (Vec<f64>, Vec<f64>, Vec<f64>, Vec<f64>);
+
+#[allow(unsafe_code)]
+impl Drop for DirectHighsModel {
+    fn drop(&mut self) {
+        if !self.ptr.is_null() {
+            unsafe {
+                highs_sys::Highs_destroy(self.ptr);
+            }
+        }
+    }
+}
+
+fn prepare_highs_problem(
+    model: &(impl ModelView + ?Sized),
+    config: &SolverConfig,
+) -> Result<PreparedHighsProblem, SolverError> {
+    prepare_highs_problem_with_objective_terms(model, model.objective().terms.as_slice(), config)
+}
+
+fn prepare_owned_highs_problem(
+    model: &mut arco_model::Model,
+    config: &SolverConfig,
+) -> Result<PreparedHighsProblem, SolverError> {
     if model.num_variables() == 0 {
         return Err(SolverError::EmptyModel);
     }
@@ -116,7 +238,163 @@ pub fn solve_model_view(
         return Err(SolverError::NoObjective);
     }
 
+    let fingerprint_start = Instant::now();
+    let fingerprint = if config
+        .parameters
+        .get("arco.fingerprint")
+        .is_none_or(|value| value != "false")
+    {
+        model.fingerprint()
+    } else {
+        ModelFingerprint(0)
+    };
+    let fingerprint_seconds = fingerprint_start.elapsed().as_secs_f64();
+
+    let objective_terms = model.take_objective_terms_for_consumed_solve();
+    match requested_load_path(config)? {
+        HighsLoadPath::Wrapper => prepare_highs_problem_with_objective_terms_and_fingerprint(
+            model,
+            objective_terms.as_slice(),
+            config,
+            fingerprint,
+            fingerprint_seconds,
+        ),
+        HighsLoadPath::Direct => prepare_consumed_direct_highs_problem(
+            model,
+            objective_terms.as_slice(),
+            fingerprint,
+            fingerprint_seconds,
+        ),
+    }
+}
+
+fn prepare_highs_problem_with_objective_terms(
+    model: &(impl ModelView + ?Sized),
+    objective_terms: &[(VariableId, f64)],
+    config: &SolverConfig,
+) -> Result<PreparedHighsProblem, SolverError> {
+    if model.num_variables() == 0 {
+        return Err(SolverError::EmptyModel);
+    }
+    if model.objective().sense.is_none() && model.objective().terms.is_empty() {
+        return Err(SolverError::NoObjective);
+    }
+
+    let fingerprint_start = Instant::now();
+    let fingerprint = if config
+        .parameters
+        .get("arco.fingerprint")
+        .is_none_or(|value| value != "false")
+    {
+        model.fingerprint()
+    } else {
+        ModelFingerprint(0)
+    };
+    let fingerprint_seconds = fingerprint_start.elapsed().as_secs_f64();
+
+    prepare_highs_problem_with_objective_terms_and_fingerprint(
+        model,
+        objective_terms,
+        config,
+        fingerprint,
+        fingerprint_seconds,
+    )
+}
+
+fn prepare_highs_problem_with_objective_terms_and_fingerprint(
+    model: &(impl ModelView + ?Sized),
+    objective_terms: &[(VariableId, f64)],
+    config: &SolverConfig,
+    fingerprint: ModelFingerprint,
+    fingerprint_seconds: f64,
+) -> Result<PreparedHighsProblem, SolverError> {
+    let objective_sense = model.objective().sense.ok_or(SolverError::NoObjective)?;
+
     let matrix_start = Instant::now();
+    let load_path = requested_load_path(config)?;
+    let problem = match load_path {
+        HighsLoadPath::Wrapper => {
+            PreparedHighsLoad::Wrapper(build_wrapper_highs_problem(model, objective_terms)?)
+        }
+        HighsLoadPath::Direct => {
+            PreparedHighsLoad::Direct(build_direct_highs_load_data(model, objective_terms)?)
+        }
+    };
+    let matrix_build_seconds = matrix_start.elapsed().as_secs_f64();
+
+    let sense = match objective_sense {
+        Sense::Minimize => HighsSense::Minimise,
+        Sense::Maximize => HighsSense::Maximise,
+    };
+
+    Ok(PreparedHighsProblem {
+        problem,
+        load_path,
+        sense,
+        fingerprint,
+        matrix_build_seconds,
+        fingerprint_seconds,
+        num_variables: model.num_variables(),
+        num_constraints: model.num_constraints(),
+        num_coefficients: model.num_coefficients(),
+    })
+}
+
+fn prepare_consumed_direct_highs_problem(
+    model: &mut arco_model::Model,
+    objective_terms: &[(VariableId, f64)],
+    fingerprint: ModelFingerprint,
+    fingerprint_seconds: f64,
+) -> Result<PreparedHighsProblem, SolverError> {
+    let objective_sense = model.objective().sense.ok_or(SolverError::NoObjective)?;
+    let num_variables = model.num_variables();
+    let num_constraints = model.num_constraints();
+    let num_coefficients = model.num_coefficients();
+
+    let matrix_start = Instant::now();
+    let problem = PreparedHighsLoad::Direct(build_direct_highs_load_data_consuming_model(
+        model,
+        objective_terms,
+        num_coefficients,
+    )?);
+    let matrix_build_seconds = matrix_start.elapsed().as_secs_f64();
+
+    let sense = match objective_sense {
+        Sense::Minimize => HighsSense::Minimise,
+        Sense::Maximize => HighsSense::Maximise,
+    };
+
+    Ok(PreparedHighsProblem {
+        problem,
+        load_path: HighsLoadPath::Direct,
+        sense,
+        fingerprint,
+        matrix_build_seconds,
+        fingerprint_seconds,
+        num_variables,
+        num_constraints,
+        num_coefficients,
+    })
+}
+
+fn requested_load_path(config: &SolverConfig) -> Result<HighsLoadPath, SolverError> {
+    match config
+        .parameters
+        .get("arco.highs_load_path")
+        .map(String::as_str)
+    {
+        None | Some("wrapper") => Ok(HighsLoadPath::Wrapper),
+        Some("direct") => Ok(HighsLoadPath::Direct),
+        Some(value) => Err(SolverError::InvalidSettings(format!(
+            "unsupported arco.highs_load_path value {value:?}"
+        ))),
+    }
+}
+
+fn build_wrapper_highs_problem(
+    model: &(impl ModelView + ?Sized),
+    objective_terms: &[(VariableId, f64)],
+) -> Result<ColProblem, SolverError> {
     let mut problem = ColProblem::new();
     let rows = (0..model.num_constraints())
         .map(|index| {
@@ -129,49 +407,36 @@ pub fn solve_model_view(
         })
         .collect::<Result<Vec<_>, SolverError>>()?;
 
-    let mut objective_coefficients = vec![0.0; model.num_variables()];
-    for (variable_id, coefficient) in &model.objective().terms {
-        let index = variable_id.inner() as usize;
-        if index < objective_coefficients.len() {
-            objective_coefficients[index] = *coefficient;
-        }
-    }
-
-    for (index, objective) in objective_coefficients.into_iter().enumerate() {
+    let mut objective_terms = objective_terms.iter().peekable();
+    for index in 0..model.num_variables() {
         let variable_id = VariableId::new(index as u32);
+        let objective = loop {
+            match objective_terms.peek().copied() {
+                Some((term_variable_id, _)) if term_variable_id.inner() as usize == index => {
+                    let coefficient = objective_terms.next().map_or(0.0, |(_, value)| *value);
+                    break coefficient;
+                }
+                Some((term_variable_id, _)) if (term_variable_id.inner() as usize) < index => {
+                    let _ = objective_terms.next();
+                }
+                _ => break 0.0,
+            }
+        };
         let variable = model
             .variable(variable_id)
             .ok_or(SolverError::InvalidVariableId(index as u32))?;
-        let Some(column) = model.column(variable_id) else {
-            if variable.is_integer {
-                problem.add_integer_column(
-                    objective,
-                    variable.bounds.lower..=variable.bounds.upper,
-                    Vec::<(HighsRow, f64)>::new(),
-                );
-            } else {
-                problem.add_column(
-                    objective,
-                    variable.bounds.lower..=variable.bounds.upper,
-                    Vec::<(HighsRow, f64)>::new(),
-                );
+        let column = model.column(variable_id).unwrap_or(&[]);
+        for (constraint_id, _) in column {
+            let row_index = constraint_id.inner() as usize;
+            if row_index >= rows.len() {
+                return Err(SolverError::SolverSpecific(format!(
+                    "constraint ID {row_index} does not exist"
+                )));
             }
-            continue;
-        };
-        let factors = column
-            .iter()
-            .map(|(constraint_id, coefficient)| {
-                let row_index = constraint_id.inner() as usize;
-                rows.get(row_index)
-                    .copied()
-                    .map(|row| (row, *coefficient))
-                    .ok_or_else(|| {
-                        SolverError::SolverSpecific(format!(
-                            "constraint ID {row_index} does not exist"
-                        ))
-                    })
-            })
-            .collect::<Result<Vec<_>, SolverError>>()?;
+        }
+        let factors = column.iter().map(|(constraint_id, coefficient)| {
+            (rows[constraint_id.inner() as usize], *coefficient)
+        });
         if variable.is_integer {
             problem.add_integer_column(
                 objective,
@@ -187,73 +452,522 @@ pub fn solve_model_view(
         }
     }
 
-    let matrix_build_seconds = matrix_start.elapsed().as_secs_f64();
+    Ok(problem)
+}
 
-    let sense = match model.objective().sense.unwrap_or(Sense::Minimize) {
-        Sense::Minimize => HighsSense::Minimise,
-        Sense::Maximize => HighsSense::Maximise,
-    };
-    let mut highs_model = problem.optimise(sense);
-    apply_solver_config(&mut highs_model, config)?;
-    let highs_run_start = Instant::now();
-    let solved = highs_model.solve();
-    let highs_run_seconds = highs_run_start.elapsed().as_secs_f64();
-    let status = solved.status();
-    let mapped_status = highs_model_status(status);
-    if !mapped_status.has_solution() {
-        return Err(SolverError::SolveFailure {
-            status: mapped_status.to_solver_status(),
-        });
+fn build_direct_highs_load_data(
+    model: &(impl ModelView + ?Sized),
+    objective_terms: &[(VariableId, f64)],
+) -> Result<DirectHighsLoadData, SolverError> {
+    let num_cols = checked_highs_int(model.num_variables(), "variables")?;
+    let num_rows = checked_highs_int(model.num_constraints(), "constraints")?;
+    let num_nonzeros = checked_highs_int(model.num_coefficients(), "coefficients")?;
+    let ncols = model.num_variables();
+    let nrows = model.num_constraints();
+    let mut col_cost = Vec::with_capacity(ncols);
+    let mut col_lower = Vec::with_capacity(ncols);
+    let mut col_upper = Vec::with_capacity(ncols);
+    let mut row_lower = Vec::with_capacity(nrows);
+    let mut row_upper = Vec::with_capacity(nrows);
+    let mut a_start = Vec::with_capacity(ncols);
+    let mut a_index = Vec::with_capacity(model.num_coefficients());
+    let mut a_value = Vec::with_capacity(model.num_coefficients());
+    let mut integrality: Option<Vec<highs_sys::HighsInt>> = None;
+
+    for index in 0..nrows {
+        let constraint = model
+            .constraint(ConstraintId::new(index as u32))
+            .ok_or_else(|| {
+                SolverError::SolverSpecific(format!("constraint ID {index} does not exist"))
+            })?;
+        row_lower.push(constraint.bounds.lower);
+        row_upper.push(constraint.bounds.upper);
     }
-    let objective_value = solved.objective_value();
+
+    let mut objective_terms = objective_terms.iter().peekable();
+    for index in 0..ncols {
+        let variable_id = VariableId::new(index as u32);
+        let objective = objective_coefficient_for_index(&mut objective_terms, index);
+        let variable = model
+            .variable(variable_id)
+            .ok_or(SolverError::InvalidVariableId(index as u32))?;
+        if variable.is_integer && integrality.is_none() {
+            integrality = Some(vec![highs_sys::kHighsVarTypeContinuous; index]);
+        }
+        if let Some(integrality) = &mut integrality {
+            integrality.push(if variable.is_integer {
+                highs_sys::kHighsVarTypeInteger
+            } else {
+                highs_sys::kHighsVarTypeContinuous
+            });
+        }
+        col_cost.push(objective);
+        col_lower.push(variable.bounds.lower);
+        col_upper.push(variable.bounds.upper);
+        a_start.push(checked_highs_int(a_index.len(), "column start")?);
+        if let Some(column) = model.column(variable_id) {
+            for (constraint_id, coefficient) in column {
+                let row_index = constraint_id.inner() as usize;
+                if row_index >= nrows {
+                    return Err(SolverError::SolverSpecific(format!(
+                        "constraint ID {row_index} does not exist"
+                    )));
+                }
+                a_index.push(checked_highs_int(row_index, "row index")?);
+                a_value.push(*coefficient);
+            }
+        }
+    }
+
+    Ok(DirectHighsLoadData {
+        num_cols,
+        num_rows,
+        num_nonzeros,
+        col_cost,
+        col_lower,
+        col_upper,
+        row_lower,
+        row_upper,
+        a_start,
+        a_index,
+        a_value,
+        integrality,
+    })
+}
+
+fn build_direct_highs_load_data_consuming_model(
+    model: &mut arco_model::Model,
+    objective_terms: &[(VariableId, f64)],
+    num_coefficients: usize,
+) -> Result<DirectHighsLoadData, SolverError> {
+    let num_cols = checked_highs_int(model.num_variables(), "variables")?;
+    let num_rows = checked_highs_int(model.num_constraints(), "constraints")?;
+    let num_nonzeros = checked_highs_int(num_coefficients, "coefficients")?;
+    let ncols = model.num_variables();
+    let nrows = model.num_constraints();
+    let mut col_cost = Vec::with_capacity(ncols);
+    let mut col_lower = Vec::with_capacity(ncols);
+    let mut col_upper = Vec::with_capacity(ncols);
+    let mut row_lower = Vec::with_capacity(nrows);
+    let mut row_upper = Vec::with_capacity(nrows);
+    let mut a_start = Vec::with_capacity(ncols);
+    let mut a_index = Vec::with_capacity(num_coefficients);
+    let mut a_value = Vec::with_capacity(num_coefficients);
+    let mut integrality: Option<Vec<highs_sys::HighsInt>> = None;
+
+    for index in 0..nrows {
+        let constraint = model
+            .constraint(ConstraintId::new(index as u32))
+            .ok_or_else(|| {
+                SolverError::SolverSpecific(format!("constraint ID {index} does not exist"))
+            })?;
+        row_lower.push(constraint.bounds.lower);
+        row_upper.push(constraint.bounds.upper);
+    }
+
+    let mut objective_terms = objective_terms.iter().peekable();
+    for index in 0..ncols {
+        let variable_id = VariableId::new(index as u32);
+        let objective = objective_coefficient_for_index(&mut objective_terms, index);
+        let variable = model
+            .variable(variable_id)
+            .ok_or(SolverError::InvalidVariableId(index as u32))?;
+        if variable.is_integer && integrality.is_none() {
+            integrality = Some(vec![highs_sys::kHighsVarTypeContinuous; index]);
+        }
+        if let Some(integrality) = &mut integrality {
+            integrality.push(if variable.is_integer {
+                highs_sys::kHighsVarTypeInteger
+            } else {
+                highs_sys::kHighsVarTypeContinuous
+            });
+        }
+        col_cost.push(objective);
+        col_lower.push(variable.bounds.lower);
+        col_upper.push(variable.bounds.upper);
+        a_start.push(checked_highs_int(a_index.len(), "column start")?);
+
+        let mut column_error = None;
+        let found_column =
+            model.drain_column_for_consumed_solve(variable_id, |constraint_id, coefficient| {
+                if column_error.is_some() {
+                    return;
+                }
+                let row_index = constraint_id.inner() as usize;
+                if row_index >= nrows {
+                    column_error = Some(SolverError::SolverSpecific(format!(
+                        "constraint ID {row_index} does not exist"
+                    )));
+                    return;
+                }
+                match checked_highs_int(row_index, "row index") {
+                    Ok(row_index) => {
+                        a_index.push(row_index);
+                        a_value.push(coefficient);
+                    }
+                    Err(error) => column_error = Some(error),
+                }
+            });
+        if !found_column {
+            return Err(SolverError::InvalidVariableId(index as u32));
+        }
+        if let Some(error) = column_error {
+            return Err(error);
+        }
+    }
+
+    Ok(DirectHighsLoadData {
+        num_cols,
+        num_rows,
+        num_nonzeros,
+        col_cost,
+        col_lower,
+        col_upper,
+        row_lower,
+        row_upper,
+        a_start,
+        a_index,
+        a_value,
+        integrality,
+    })
+}
+
+fn objective_coefficient_for_index(
+    objective_terms: &mut std::iter::Peekable<std::slice::Iter<'_, (VariableId, f64)>>,
+    index: usize,
+) -> f64 {
+    loop {
+        match objective_terms.peek().copied() {
+            Some((term_variable_id, _)) if term_variable_id.inner() as usize == index => {
+                return objective_terms.next().map_or(0.0, |(_, value)| *value);
+            }
+            Some((term_variable_id, _)) if (term_variable_id.inner() as usize) < index => {
+                let _ = objective_terms.next();
+            }
+            _ => return 0.0,
+        }
+    }
+}
+
+fn checked_highs_int(value: usize, name: &str) -> Result<highs_sys::HighsInt, SolverError> {
+    highs_sys::HighsInt::try_from(value)
+        .map_err(|_| SolverError::SolverSpecific(format!("{name} count is too large for HiGHS")))
+}
+
+fn optimise_prepared_problem(
+    prepared: PreparedHighsProblem,
+    config: &SolverConfig,
+) -> Result<PreparedHighsSolve, SolverError> {
+    let highs_model = match prepared.problem {
+        PreparedHighsLoad::Wrapper(problem) => {
+            let mut highs_model = problem.optimise(prepared.sense);
+            apply_solver_config(&mut highs_model, config)?;
+            PreparedHighsModel::Wrapper(highs_model)
+        }
+        PreparedHighsLoad::Direct(load_data) => {
+            let mut highs_model = DirectHighsModel::load(load_data, prepared.sense)?;
+            apply_direct_solver_config(&mut highs_model, config)?;
+            PreparedHighsModel::Direct(highs_model)
+        }
+    };
+    Ok(PreparedHighsSolve {
+        highs_model,
+        load_path: prepared.load_path,
+        fingerprint: prepared.fingerprint,
+        matrix_build_seconds: prepared.matrix_build_seconds,
+        fingerprint_seconds: prepared.fingerprint_seconds,
+        num_variables: prepared.num_variables,
+        num_constraints: prepared.num_constraints,
+        num_coefficients: prepared.num_coefficients,
+    })
+}
+
+#[allow(unsafe_code)]
+impl DirectHighsModel {
+    fn load(load_data: DirectHighsLoadData, sense: HighsSense) -> Result<Self, SolverError> {
+        let ptr = unsafe { highs_sys::Highs_create() };
+        if ptr.is_null() {
+            return Err(SolverError::SolverNotAvailable(
+                "HiGHS_create returned NULL".to_string(),
+            ));
+        }
+        let mut model = Self { ptr };
+        model.set_bool_option("output_flag", false)?;
+        model.set_bool_option("log_to_console", false)?;
+        let sense = match sense {
+            HighsSense::Minimise => highs_sys::OBJECTIVE_SENSE_MINIMIZE,
+            HighsSense::Maximise => highs_sys::OBJECTIVE_SENSE_MAXIMIZE,
+        };
+        let status = unsafe {
+            if let Some(integrality) = load_data.integrality.as_ref() {
+                highs_sys::Highs_passMip(
+                    model.ptr,
+                    load_data.num_cols,
+                    load_data.num_rows,
+                    load_data.num_nonzeros,
+                    highs_sys::MATRIX_FORMAT_COLUMN_WISE,
+                    sense,
+                    0.0,
+                    load_data.col_cost.as_ptr(),
+                    load_data.col_lower.as_ptr(),
+                    load_data.col_upper.as_ptr(),
+                    load_data.row_lower.as_ptr(),
+                    load_data.row_upper.as_ptr(),
+                    load_data.a_start.as_ptr(),
+                    load_data.a_index.as_ptr(),
+                    load_data.a_value.as_ptr(),
+                    integrality.as_ptr(),
+                )
+            } else {
+                highs_sys::Highs_passLp(
+                    model.ptr,
+                    load_data.num_cols,
+                    load_data.num_rows,
+                    load_data.num_nonzeros,
+                    highs_sys::MATRIX_FORMAT_COLUMN_WISE,
+                    sense,
+                    0.0,
+                    load_data.col_cost.as_ptr(),
+                    load_data.col_lower.as_ptr(),
+                    load_data.col_upper.as_ptr(),
+                    load_data.row_lower.as_ptr(),
+                    load_data.row_upper.as_ptr(),
+                    load_data.a_start.as_ptr(),
+                    load_data.a_index.as_ptr(),
+                    load_data.a_value.as_ptr(),
+                )
+            }
+        };
+        ensure_highs_ok(status, "Highs_passLp/Highs_passMip")?;
+        Ok(model)
+    }
+
+    fn solve(&mut self) -> Result<SolverStatus, SolverError> {
+        ensure_highs_ok(unsafe { highs_sys::Highs_run(self.ptr) }, "Highs_run")?;
+        Ok(raw_highs_model_status_to_solver_status(unsafe {
+            highs_sys::Highs_getModelStatus(self.ptr)
+        }))
+    }
+
+    fn objective_value(&self) -> f64 {
+        unsafe { highs_sys::Highs_getObjectiveValue(self.ptr) }
+    }
+
+    fn solution_vectors(
+        &self,
+        num_variables: usize,
+        num_constraints: usize,
+    ) -> Result<SolutionVectors, SolverError> {
+        let mut primal_values = vec![0.0; num_variables];
+        let mut variable_duals = vec![0.0; num_variables];
+        let mut row_values = vec![0.0; num_constraints];
+        let mut constraint_duals = vec![0.0; num_constraints];
+        ensure_highs_ok(
+            unsafe {
+                highs_sys::Highs_getSolution(
+                    self.ptr,
+                    primal_values.as_mut_ptr(),
+                    variable_duals.as_mut_ptr(),
+                    row_values.as_mut_ptr(),
+                    constraint_duals.as_mut_ptr(),
+                )
+            },
+            "Highs_getSolution",
+        )?;
+        Ok((primal_values, variable_duals, row_values, constraint_duals))
+    }
+
+    fn set_bool_option(&mut self, key: &str, value: bool) -> Result<(), SolverError> {
+        let key = cstring_option_key(key)?;
+        ensure_highs_ok(
+            unsafe {
+                highs_sys::Highs_setBoolOptionValue(self.ptr, key.as_ptr(), i32::from(value))
+            },
+            key.to_string_lossy().as_ref(),
+        )
+    }
+
+    fn set_int_option(&mut self, key: &str, value: i32) -> Result<(), SolverError> {
+        let key = cstring_option_key(key)?;
+        ensure_highs_ok(
+            unsafe { highs_sys::Highs_setIntOptionValue(self.ptr, key.as_ptr(), value) },
+            key.to_string_lossy().as_ref(),
+        )
+    }
+
+    fn set_double_option(&mut self, key: &str, value: f64) -> Result<(), SolverError> {
+        let key = cstring_option_key(key)?;
+        ensure_highs_ok(
+            unsafe { highs_sys::Highs_setDoubleOptionValue(self.ptr, key.as_ptr(), value) },
+            key.to_string_lossy().as_ref(),
+        )
+    }
+
+    fn set_string_option(&mut self, key: &str, value: &str) -> Result<(), SolverError> {
+        let key = cstring_option_key(key)?;
+        let value = CString::new(value).map_err(|_| {
+            SolverError::InvalidSettings(format!(
+                "invalid HiGHS option value for {:?}: contains NUL",
+                key.to_string_lossy()
+            ))
+        })?;
+        ensure_highs_ok(
+            unsafe {
+                highs_sys::Highs_setStringOptionValue(self.ptr, key.as_ptr(), value.as_ptr())
+            },
+            key.to_string_lossy().as_ref(),
+        )
+    }
+}
+
+fn apply_direct_solver_config(
+    highs_model: &mut DirectHighsModel,
+    config: &SolverConfig,
+) -> Result<(), SolverError> {
+    validate_solver_config(config)?;
+
+    if config.verbosity.unwrap_or(0) == 0 && !config.log_to_console.unwrap_or(false) {
+        highs_model.set_bool_option("output_flag", false)?;
+        highs_model.set_bool_option("log_to_console", false)?;
+    }
+    if let Some(level) = config.verbosity {
+        highs_model.set_bool_option("output_flag", level > 0)?;
+    }
+    if config.log_to_console.unwrap_or(false) {
+        highs_model.set_bool_option("log_to_console", true)?;
+        highs_model.set_bool_option("output_flag", true)?;
+    }
+    if let Some(limit) = config.time_limit {
+        highs_model.set_double_option("time_limit", limit)?;
+    }
+    if let Some(gap) = config.mip_gap {
+        highs_model.set_double_option("mip_rel_gap", gap)?;
+    }
+    if let Some(presolve) = config.presolve {
+        highs_model.set_string_option("presolve", if presolve { "on" } else { "off" })?;
+    }
+    if let Some(threads) = config.threads {
+        highs_model.set_int_option("threads", threads as i32)?;
+    }
+    if let Some(tolerance) = config.tolerance {
+        highs_model.set_double_option("primal_feasibility_tolerance", tolerance)?;
+        highs_model.set_double_option("dual_feasibility_tolerance", tolerance)?;
+    }
+    for (key, value) in &config.parameters {
+        if key.starts_with("arco.") {
+            continue;
+        }
+        highs_model.set_string_option(key.as_str(), value.as_str())?;
+    }
+    Ok(())
+}
+
+fn ensure_highs_ok(status: highs_sys::HighsInt, operation: &str) -> Result<(), SolverError> {
+    if status == highs_sys::STATUS_OK || status == highs_sys::STATUS_WARNING {
+        Ok(())
+    } else {
+        Err(SolverError::InvalidSettings(format!(
+            "invalid HiGHS option or value for {operation:?}"
+        )))
+    }
+}
+
+fn cstring_option_key(key: &str) -> Result<CString, SolverError> {
+    CString::new(key).map_err(|_| {
+        SolverError::InvalidSettings(format!("invalid HiGHS option name {key:?}: contains NUL"))
+    })
+}
+
+fn raw_highs_model_status_to_solver_status(status: highs_sys::HighsInt) -> SolverStatus {
+    match status {
+        highs_sys::MODEL_STATUS_OPTIMAL => SolverStatus::Optimal,
+        highs_sys::MODEL_STATUS_INFEASIBLE => SolverStatus::Infeasible,
+        highs_sys::MODEL_STATUS_UNBOUNDED => SolverStatus::Unbounded,
+        highs_sys::MODEL_STATUS_REACHED_TIME_LIMIT => SolverStatus::TimeLimit,
+        highs_sys::MODEL_STATUS_REACHED_ITERATION_LIMIT => SolverStatus::IterationLimit,
+        _ => SolverStatus::Unknown,
+    }
+}
+
+fn finish_prepared_solve(
+    prepared: PreparedHighsSolve,
+    config: &SolverConfig,
+) -> Result<ModelViewSolveResult, SolverError> {
     let extract_solution = config
         .parameters
         .get("arco.extract_solution")
         .is_none_or(|value| value != "false");
+    let highs_run_start = Instant::now();
+    let solved_model = match prepared.highs_model {
+        PreparedHighsModel::Wrapper(model) => SolvedHighsModel::Wrapper(model.solve()),
+        PreparedHighsModel::Direct(mut model) => {
+            let status = model.solve()?;
+            SolvedHighsModel::Direct { model, status }
+        }
+    };
+    let mapped_status = match &solved_model {
+        SolvedHighsModel::Wrapper(model) => highs_model_status(model.status()).to_solver_status(),
+        SolvedHighsModel::Direct { status, .. } => *status,
+    };
+    let objective_value = match &solved_model {
+        SolvedHighsModel::Wrapper(model) => model.objective_value(),
+        SolvedHighsModel::Direct { model, .. } => model.objective_value(),
+    };
+    let highs_run_seconds = highs_run_start.elapsed().as_secs_f64();
+    if !mapped_status.is_feasible() {
+        return Err(SolverError::SolveFailure {
+            status: mapped_status,
+        });
+    }
     let solution_extract_start = Instant::now();
     let (primal_values, variable_duals, row_values, constraint_duals) = if extract_solution {
-        let solution = solved.get_solution();
-        (
-            solution.columns().to_vec(),
-            solution.dual_columns().to_vec(),
-            solution.rows().to_vec(),
-            solution.dual_rows().to_vec(),
-        )
+        match &solved_model {
+            SolvedHighsModel::Wrapper(model) => {
+                let solution = model.get_solution();
+                (
+                    solution.columns().to_vec(),
+                    solution.dual_columns().to_vec(),
+                    solution.rows().to_vec(),
+                    solution.dual_rows().to_vec(),
+                )
+            }
+            SolvedHighsModel::Direct { model, .. } => {
+                model.solution_vectors(prepared.num_variables, prepared.num_constraints)?
+            }
+        }
     } else {
         (Vec::new(), Vec::new(), Vec::new(), Vec::new())
     };
     let solution_extract_seconds = solution_extract_start.elapsed().as_secs_f64();
 
-    let fingerprint_start = Instant::now();
-    let fingerprint = if config
-        .parameters
-        .get("arco.fingerprint")
-        .is_none_or(|value| value != "false")
-    {
-        model.fingerprint()
-    } else {
-        ModelFingerprint(0)
-    };
-    let fingerprint_seconds = fingerprint_start.elapsed().as_secs_f64();
-
     let mut metadata = BTreeMap::new();
-    metadata.insert("highs_matrix_build_s".to_string(), matrix_build_seconds);
+    metadata.insert(
+        "highs_matrix_build_s".to_string(),
+        prepared.matrix_build_seconds,
+    );
+    metadata.insert(
+        "highs_direct_load_path".to_string(),
+        match prepared.load_path {
+            HighsLoadPath::Wrapper => 0.0,
+            HighsLoadPath::Direct => 1.0,
+        },
+    );
     metadata.insert("highs_run_s".to_string(), highs_run_seconds);
     metadata.insert("solution_extract_s".to_string(), solution_extract_seconds);
-    metadata.insert("fingerprint_s".to_string(), fingerprint_seconds);
-    metadata.insert("num_variables".to_string(), model.num_variables() as f64);
+    metadata.insert("fingerprint_s".to_string(), prepared.fingerprint_seconds);
+    metadata.insert("num_variables".to_string(), prepared.num_variables as f64);
     metadata.insert(
         "num_constraints".to_string(),
-        model.num_constraints() as f64,
+        prepared.num_constraints as f64,
     );
     metadata.insert(
         "num_coefficients".to_string(),
-        model.num_coefficients() as f64,
+        prepared.num_coefficients as f64,
     );
 
     let result = ModelViewSolveResult {
-        fingerprint,
-        status: mapped_status.to_solver_status(),
+        fingerprint: prepared.fingerprint,
+        status: mapped_status,
         objective_value,
         primal_values,
         variable_duals,
@@ -261,15 +975,73 @@ pub fn solve_model_view(
         constraint_duals,
         metadata,
     };
-    validate_model_view_solve_result(model, &result)?;
+    validate_result_shape_counts(
+        &result,
+        config,
+        prepared.num_variables,
+        prepared.num_constraints,
+    )?;
     Ok(result)
+}
+
+fn validate_result_shape_counts(
+    result: &ModelViewSolveResult,
+    config: &SolverConfig,
+    num_variables: usize,
+    num_constraints: usize,
+) -> Result<(), SolverError> {
+    let allow_omitted_primal_values = config
+        .parameters
+        .get("arco.extract_solution")
+        .is_some_and(|value| value == "false");
+    if allow_omitted_primal_values {
+        validate_optional_result_len("primal_values", result.primal_values.len(), num_variables)?;
+    } else {
+        validate_required_result_len("primal_values", result.primal_values.len(), num_variables)?;
+    }
+    validate_optional_result_len("variable_duals", result.variable_duals.len(), num_variables)?;
+    validate_optional_result_len("row_values", result.row_values.len(), num_constraints)?;
+    validate_optional_result_len(
+        "constraint_duals",
+        result.constraint_duals.len(),
+        num_constraints,
+    )?;
+    Ok(())
+}
+
+fn validate_required_result_len(
+    name: &str,
+    actual: usize,
+    expected: usize,
+) -> Result<(), SolverError> {
+    if actual == expected {
+        return Ok(());
+    }
+    Err(SolverError::InvalidResultShape(format!(
+        "{name} length {actual} does not match expected {expected}"
+    )))
+}
+
+fn validate_optional_result_len(
+    name: &str,
+    actual: usize,
+    expected: usize,
+) -> Result<(), SolverError> {
+    if actual == 0 || actual == expected {
+        return Ok(());
+    }
+    Err(SolverError::InvalidResultShape(format!(
+        "{name} length {actual} must be 0 or match expected {expected}"
+    )))
 }
 
 #[cfg(test)]
 #[allow(clippy::float_cmp)]
 mod tests {
     use super::*;
-    use arco_model::{Bounds, Constraint, Model, ModelView, Objective, Sense, Variable};
+    use arco_model::{
+        Bounds, Constraint, Model, ModelFingerprint, ModelView, Objective, Sense, Variable,
+    };
     use arco_solver::{
         check_empty_model_rejected, check_no_objective_rejected, check_small_lp, check_small_milp,
     };
@@ -311,6 +1083,37 @@ mod tests {
                 SolverError::InvalidSettings(message) if message == expected
             ));
         }
+    }
+
+    #[test]
+    fn invalid_highs_option_value_returns_solver_error_instead_of_panicking() {
+        let mut model = Model::new();
+        let x = model
+            .add_variable(Variable::continuous(Bounds::new(0.0, f64::INFINITY)))
+            .expect("variable");
+        let demand = model
+            .add_constraint(Constraint {
+                bounds: Bounds::new(1.0, f64::INFINITY),
+            })
+            .expect("constraint");
+        model.set_coefficient(x, demand, 1.0).expect("coefficient");
+        model
+            .set_objective(Objective {
+                sense: Some(Sense::Minimize),
+                terms: vec![(x, 1.0)],
+            })
+            .expect("objective");
+
+        let config = SolverConfig::new().with_parameter("run_crossover", "false");
+        let error = solve_model_view(&model, &config)
+            .expect_err("invalid HiGHS option value should be reported");
+
+        assert!(matches!(
+            error,
+            SolverError::InvalidSettings(message)
+                if message.contains("invalid HiGHS option or value")
+                    && message.contains("run_crossover")
+        ));
     }
 
     #[test]
@@ -358,7 +1161,7 @@ mod tests {
     }
 
     #[test]
-    fn model_view_solver_rejects_missing_conformance_fields() {
+    fn model_view_solver_supports_objective_only_result_when_solution_extraction_is_disabled() {
         let mut model = Model::new();
         let x = model
             .add_variable(Variable::continuous(Bounds::new(0.0, f64::INFINITY)))
@@ -379,9 +1182,140 @@ mod tests {
         let config = SolverConfig::new()
             .with_parameter("arco.fingerprint", "false")
             .with_parameter("arco.extract_solution", "false");
-        let error = solve_model_view(&model, &config)
-            .expect_err("missing fingerprint and primal values should fail conformance");
+        let result = solve_model_view(&model, &config)
+            .expect("objective-only result should be accepted when explicitly requested");
 
-        assert!(matches!(error, SolverError::InvalidResultShape(_)));
+        assert_eq!(result.fingerprint, ModelFingerprint(0));
+        assert!(result.primal_values.is_empty());
+        assert!(result.variable_duals.is_empty());
+        assert!(result.row_values.is_empty());
+        assert!(result.constraint_duals.is_empty());
+        assert_eq!(result.objective_value, 2.0);
+    }
+
+    #[test]
+    fn owned_model_solver_supports_objective_only_result() {
+        let mut model = Model::new();
+        let x = model
+            .add_variable(Variable::continuous(Bounds::new(0.0, f64::INFINITY)))
+            .expect("variable");
+        let demand = model
+            .add_constraint(Constraint {
+                bounds: Bounds::new(1.0, f64::INFINITY),
+            })
+            .expect("constraint");
+        model.set_coefficient(x, demand, 1.0).expect("coefficient");
+        model
+            .set_objective(Objective {
+                sense: Some(Sense::Minimize),
+                terms: vec![(x, 2.0)],
+            })
+            .expect("objective");
+        let config = SolverConfig::new()
+            .with_parameter("arco.fingerprint", "false")
+            .with_parameter("arco.extract_solution", "false");
+
+        let result = solve_owned_model(model, &config).expect("owned solve succeeds");
+
+        assert_eq!(result.fingerprint, ModelFingerprint(0));
+        assert!(result.primal_values.is_empty());
+        assert_eq!(result.objective_value, 2.0);
+        assert_eq!(result.metadata.get("highs_direct_load_path"), Some(&0.0));
+    }
+
+    #[test]
+    fn direct_highs_load_path_solves_model_view_problem() {
+        let mut model = Model::new();
+        let x = model
+            .add_variable(Variable::continuous(Bounds::new(0.0, f64::INFINITY)))
+            .expect("variable");
+        let demand = model
+            .add_constraint(Constraint {
+                bounds: Bounds::new(1.0, f64::INFINITY),
+            })
+            .expect("constraint");
+        model.set_coefficient(x, demand, 1.0).expect("coefficient");
+        model
+            .set_objective(Objective {
+                sense: Some(Sense::Minimize),
+                terms: vec![(x, 2.0)],
+            })
+            .expect("objective");
+        let config = SolverConfig::new()
+            .with_parameter("arco.highs_load_path", "direct")
+            .with_parameter("arco.fingerprint", "false");
+
+        let result = solve_model_view(&model, &config).expect("direct HiGHS solve succeeds");
+
+        assert_eq!(result.fingerprint, ModelFingerprint(0));
+        assert!(result.status.is_feasible());
+        assert_eq!(result.primal_values, vec![1.0]);
+        assert_eq!(result.objective_value, 2.0);
+        assert_eq!(result.metadata.get("highs_direct_load_path"), Some(&1.0));
+    }
+
+    #[test]
+    fn direct_highs_load_path_supports_owned_objective_only_result() {
+        let mut model = Model::new();
+        let x = model
+            .add_variable(Variable::continuous(Bounds::new(0.0, f64::INFINITY)))
+            .expect("variable");
+        let demand = model
+            .add_constraint(Constraint {
+                bounds: Bounds::new(1.0, f64::INFINITY),
+            })
+            .expect("constraint");
+        model.set_coefficient(x, demand, 1.0).expect("coefficient");
+        model
+            .set_objective(Objective {
+                sense: Some(Sense::Minimize),
+                terms: vec![(x, 2.0)],
+            })
+            .expect("objective");
+        let config = SolverConfig::new()
+            .with_parameter("arco.highs_load_path", "direct")
+            .with_parameter("arco.fingerprint", "false")
+            .with_parameter("arco.extract_solution", "false");
+
+        let result = solve_owned_model(model, &config).expect("direct owned solve succeeds");
+
+        assert_eq!(result.fingerprint, ModelFingerprint(0));
+        assert!(result.primal_values.is_empty());
+        assert_eq!(result.objective_value, 2.0);
+        assert_eq!(result.metadata.get("highs_direct_load_path"), Some(&1.0));
+        assert_eq!(result.metadata.get("num_coefficients"), Some(&1.0));
+    }
+
+    #[test]
+    fn direct_highs_load_path_reports_invalid_options() {
+        let mut model = Model::new();
+        let x = model
+            .add_variable(Variable::continuous(Bounds::new(0.0, f64::INFINITY)))
+            .expect("variable");
+        let demand = model
+            .add_constraint(Constraint {
+                bounds: Bounds::new(1.0, f64::INFINITY),
+            })
+            .expect("constraint");
+        model.set_coefficient(x, demand, 1.0).expect("coefficient");
+        model
+            .set_objective(Objective {
+                sense: Some(Sense::Minimize),
+                terms: vec![(x, 1.0)],
+            })
+            .expect("objective");
+        let config = SolverConfig::new()
+            .with_parameter("arco.highs_load_path", "direct")
+            .with_parameter("run_crossover", "false");
+
+        let error = solve_model_view(&model, &config)
+            .expect_err("invalid direct HiGHS option value should be reported");
+
+        assert!(matches!(
+            error,
+            SolverError::InvalidSettings(message)
+                if message.contains("invalid HiGHS option or value")
+                    && message.contains("run_crossover")
+        ));
     }
 }

--- a/crates/arco-model/src/model/builder.rs
+++ b/crates/arco-model/src/model/builder.rs
@@ -3,7 +3,9 @@
 use crate::expr::{ComparisonSense, ConstraintExpr, Expr};
 use crate::ids::{ConstraintId, VariableId};
 use crate::model::error::ModelError;
-use crate::model::{BITS_PER_WORD, Model, bounds_are_valid, coefficient_is_valid, column_upsert};
+use crate::model::{
+    BITS_PER_WORD, ColumnVec, Model, bounds_are_valid, coefficient_is_valid, column_upsert,
+};
 use crate::types::{Bounds, Constraint, Objective, Sense, Variable};
 
 impl Model {
@@ -22,6 +24,11 @@ impl Model {
         }
     }
 
+    /// Pre-allocate capacity for the given number of additional constraints.
+    pub fn reserve_constraints(&mut self, count: usize) {
+        self.constraints.reserve(count);
+    }
+
     /// Add a variable to the model.
     pub fn add_variable(&mut self, variable: Variable) -> Result<VariableId, ModelError> {
         if !bounds_are_valid(variable.bounds.lower, variable.bounds.upper) {
@@ -34,9 +41,115 @@ impl Model {
         let id = VariableId::new(self.next_variable_id);
         self.next_variable_id += 1;
 
-        self.push_variable(variable);
+        self.push_variable(variable)?;
 
         Ok(id)
+    }
+
+    /// Add a contiguous block of variables that share bounds and integrality.
+    ///
+    /// This avoids repeated validation and per-variable method dispatch in large
+    /// array builders while preserving the same contiguous ID assignment as
+    /// calling `add_variable` repeatedly.
+    pub fn add_variables_uniform(
+        &mut self,
+        variable: Variable,
+        count: usize,
+    ) -> Result<VariableId, ModelError> {
+        if !bounds_are_valid(variable.bounds.lower, variable.bounds.upper) {
+            return Err(ModelError::InvalidVariableBounds {
+                lower: variable.bounds.lower,
+                upper: variable.bounds.upper,
+            });
+        }
+        if count == 0 {
+            return Ok(VariableId::new(self.next_variable_id));
+        }
+
+        let count_u32 = u32::try_from(count).map_err(|_| ModelError::InvalidCscData {
+            reason: "variable block size exceeds u32 id space".to_string(),
+        })?;
+        let first_id = self.next_variable_id;
+        let next_id =
+            first_id
+                .checked_add(count_u32)
+                .ok_or_else(|| ModelError::InvalidCscData {
+                    reason: "variable block would exceed u32 id space".to_string(),
+                })?;
+
+        self.reserve_variables(count);
+
+        let start_idx = self.variables.len();
+        self.variables.extend_repeated(variable.bounds, count)?;
+        self.columns.resize_with(start_idx + count, ColumnVec::new);
+        if variable.is_integer {
+            for idx in start_idx..start_idx + count {
+                Self::write_packed_flag(&mut self.variable_is_integer_bits, idx, true);
+            }
+        }
+        if !variable.is_active {
+            for idx in start_idx..start_idx + count {
+                Self::write_packed_flag(&mut self.variable_is_inactive_bits, idx, true);
+            }
+        }
+        self.next_variable_id = next_id;
+
+        Ok(VariableId::new(first_id))
+    }
+
+    /// Add a contiguous block of variables with per-variable bounds and shared flags.
+    ///
+    /// This is the array-bounds companion to `add_variables_uniform`: callers can
+    /// validate and insert a large variable block without per-variable method
+    /// dispatch while preserving contiguous IDs.
+    pub fn add_variables_with_bounds(
+        &mut self,
+        bounds: &[Bounds],
+        is_integer: bool,
+        is_active: bool,
+    ) -> Result<VariableId, ModelError> {
+        for bound in bounds {
+            if !bounds_are_valid(bound.lower, bound.upper) {
+                return Err(ModelError::InvalidVariableBounds {
+                    lower: bound.lower,
+                    upper: bound.upper,
+                });
+            }
+        }
+        if bounds.is_empty() {
+            return Ok(VariableId::new(self.next_variable_id));
+        }
+
+        let count_u32 = u32::try_from(bounds.len()).map_err(|_| ModelError::InvalidCscData {
+            reason: "variable block size exceeds u32 id space".to_string(),
+        })?;
+        let first_id = self.next_variable_id;
+        let next_id =
+            first_id
+                .checked_add(count_u32)
+                .ok_or_else(|| ModelError::InvalidCscData {
+                    reason: "variable block would exceed u32 id space".to_string(),
+                })?;
+
+        self.reserve_variables(bounds.len());
+
+        let start_idx = self.variables.len();
+        self.variables.extend_from_slice(bounds)?;
+        self.columns
+            .resize_with(start_idx + bounds.len(), ColumnVec::new);
+        if is_integer {
+            for idx in start_idx..start_idx + bounds.len() {
+                Self::write_packed_flag(&mut self.variable_is_integer_bits, idx, true);
+            }
+        }
+        if !is_active {
+            for idx in start_idx..start_idx + bounds.len() {
+                Self::write_packed_flag(&mut self.variable_is_inactive_bits, idx, true);
+            }
+        }
+        self.next_variable_id = next_id;
+
+        Ok(VariableId::new(first_id))
     }
 
     /// Add a constraint to the model.
@@ -68,12 +181,14 @@ impl Model {
             }
         }
 
-        let normalized = self.normalize_terms(objective.terms);
+        let mut normalized = self.normalize_terms(objective.terms);
+        normalized.shrink_to_fit();
         self.objective = Objective {
             sense: Some(sense),
             terms: normalized,
         };
         self.objective_name = None;
+        self.shrink_retained_storage();
         tracing::debug!(
             component = "model",
             operation = "set_objective",
@@ -176,6 +291,59 @@ impl Model {
         Ok(ConstraintId::new(first_constraint_id))
     }
 
+    /// Add compact constraints where each row maps term patterns through a dense row index.
+    ///
+    /// For each inserted row, a pattern `(start_var_id, coeff)` is expanded to
+    /// variable `start_var_id + row_index`. This keeps Python active-mask paths
+    /// from allocating a per-row term vector when active rows are sparse.
+    pub fn add_constraints_compact_indexed(
+        &mut self,
+        term_patterns: &[(u32, f64)],
+        row_indices: &[usize],
+        bounds_list: &[Bounds],
+    ) -> Result<ConstraintId, ModelError> {
+        let count = row_indices.len();
+        if count == 0 {
+            return Ok(ConstraintId::new(self.next_constraint_id));
+        }
+        if bounds_list.len() != count {
+            return Err(ModelError::InvalidCscData {
+                reason: "compact indexed constraint bounds length must match row indices"
+                    .to_string(),
+            });
+        }
+
+        self.constraints.reserve(count);
+        let first_constraint_id = self.next_constraint_id;
+
+        for (row_index, bounds) in row_indices.iter().copied().zip(bounds_list.iter()) {
+            if !bounds_are_valid(bounds.lower, bounds.upper) {
+                return Err(ModelError::InvalidConstraintBounds {
+                    lower: bounds.lower,
+                    upper: bounds.upper,
+                });
+            }
+
+            let constraint_id = ConstraintId::new(self.next_constraint_id);
+            self.next_constraint_id += 1;
+            self.constraints.push(Constraint { bounds: *bounds });
+
+            for &(start_var_id, coeff) in term_patterns {
+                let Some(var_idx) = (start_var_id as usize).checked_add(row_index) else {
+                    return Err(ModelError::InvalidVariableId(VariableId::new(u32::MAX)));
+                };
+                if var_idx >= self.variables.len() {
+                    return Err(ModelError::InvalidVariableId(VariableId::new(
+                        var_idx as u32,
+                    )));
+                }
+                self.columns[var_idx].push((constraint_id, coeff));
+            }
+        }
+
+        Ok(ConstraintId::new(first_constraint_id))
+    }
+
     /// Add a batch of constraints with pre-normalized terms.
     ///
     /// Each constraint is given as a slice of `(VariableId, f64)` terms and a `Bounds`.
@@ -187,7 +355,27 @@ impl Model {
         &mut self,
         constraints: &[(Vec<(VariableId, f64)>, Bounds)],
     ) -> Result<ConstraintId, ModelError> {
-        let count = constraints.len();
+        self.add_constraints_batch_streaming(
+            constraints.len(),
+            constraints
+                .iter()
+                .map(|(terms, bounds)| (terms.as_slice(), *bounds)),
+        )
+    }
+
+    /// Add a streamed batch of constraints with pre-normalized term slices.
+    ///
+    /// Rows are consumed one at a time, so callers do not need to retain a full
+    /// batch of row vectors before inserting them into the model.
+    pub fn add_constraints_batch_streaming<I, T>(
+        &mut self,
+        count: usize,
+        constraints: I,
+    ) -> Result<ConstraintId, ModelError>
+    where
+        I: IntoIterator<Item = (T, Bounds)>,
+        T: AsRef<[(VariableId, f64)]>,
+    {
         if count == 0 {
             return Ok(ConstraintId::new(self.next_constraint_id));
         }
@@ -196,6 +384,7 @@ impl Model {
         let first_constraint_id = self.next_constraint_id;
 
         for (terms, bounds) in constraints {
+            let terms = terms.as_ref();
             if !bounds_are_valid(bounds.lower, bounds.upper) {
                 return Err(ModelError::InvalidConstraintBounds {
                     lower: bounds.lower,
@@ -205,7 +394,7 @@ impl Model {
 
             let constraint_id = ConstraintId::new(self.next_constraint_id);
             self.next_constraint_id += 1;
-            self.constraints.push(Constraint { bounds: *bounds });
+            self.constraints.push(Constraint { bounds });
 
             for &(var_id, coeff) in terms {
                 // Skip validation for each coefficient since terms are pre-normalized.

--- a/crates/arco-model/src/model/csc_import.rs
+++ b/crates/arco-model/src/model/csc_import.rs
@@ -88,7 +88,7 @@ impl Model {
                 bounds: Bounds::new(lower, upper),
                 is_integer: is_integer[idx],
                 is_active: true,
-            });
+            })?;
         }
 
         for idx in 0..num_constraints {

--- a/crates/arco-model/src/model/inspect.rs
+++ b/crates/arco-model/src/model/inspect.rs
@@ -172,7 +172,7 @@ impl Model {
 
         let variables = self
             .variables
-            .iter()
+            .iter_bounds()
             .enumerate()
             .map(|(idx, bounds)| (VariableId::new(idx as u32), bounds))
             .filter(|(id, _)| var_filter.as_ref().is_none_or(|filter| filter.contains(id)))
@@ -184,7 +184,7 @@ impl Model {
                         .variable_names
                         .as_ref()
                         .and_then(|names| names.get(&id).cloned()),
-                    bounds: *bounds,
+                    bounds,
                     is_integer: Self::read_packed_flag(&self.variable_is_integer_bits, idx),
                     is_active: !Self::read_packed_flag(&self.variable_is_inactive_bits, idx),
                     metadata: self

--- a/crates/arco-model/src/model/mod.rs
+++ b/crates/arco-model/src/model/mod.rs
@@ -36,6 +36,319 @@ use std::time::Instant;
 /// heap-allocated otherwise.
 pub(crate) type ColumnVec = SmallVec<[(ConstraintId, f64); 2]>;
 
+const VARIABLE_BOUNDS_FREE: u32 = 0;
+const VARIABLE_BOUNDS_NONNEGATIVE: u32 = 1;
+const VARIABLE_BOUNDS_UNIT: u32 = 2;
+const VARIABLE_BOUNDS_CUSTOM_BASE: u32 = 3;
+
+const CONSTRAINT_BOUNDS_FREE: u32 = 0;
+const CONSTRAINT_BOUNDS_EQ_ZERO: u32 = 1;
+const CONSTRAINT_BOUNDS_UPPER_ZERO: u32 = 2;
+const CONSTRAINT_BOUNDS_LOWER_ZERO: u32 = 3;
+const CONSTRAINT_BOUNDS_CUSTOM_BASE: u32 = 4;
+
+const FREE_BOUNDS: Bounds = Bounds {
+    lower: f64::NEG_INFINITY,
+    upper: f64::INFINITY,
+};
+const NONNEGATIVE_BOUNDS: Bounds = Bounds {
+    lower: 0.0,
+    upper: f64::INFINITY,
+};
+const UNIT_BOUNDS: Bounds = Bounds {
+    lower: 0.0,
+    upper: 1.0,
+};
+
+const FREE_CONSTRAINT: Constraint = Constraint {
+    bounds: FREE_BOUNDS,
+};
+const EQ_ZERO_CONSTRAINT: Constraint = Constraint {
+    bounds: Bounds {
+        lower: 0.0,
+        upper: 0.0,
+    },
+};
+const UPPER_ZERO_CONSTRAINT: Constraint = Constraint {
+    bounds: Bounds {
+        lower: f64::NEG_INFINITY,
+        upper: 0.0,
+    },
+};
+const LOWER_ZERO_CONSTRAINT: Constraint = Constraint {
+    bounds: Bounds {
+        lower: 0.0,
+        upper: f64::INFINITY,
+    },
+};
+
+/// Compact variable-bound storage.
+///
+/// Common bounds are represented as one u32 code per variable. Custom bounds
+/// are deduplicated by exact f64 bit pattern so repeated array-bound variables
+/// retain one side-table entry instead of one full `Bounds` per variable.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct VariableStore {
+    codes: Vec<u32>,
+    custom: Vec<Bounds>,
+    custom_lookup: HashMap<(u64, u64), u32>,
+}
+
+impl VariableStore {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn with_capacity(capacity: usize) -> Self {
+        Self {
+            codes: Vec::with_capacity(capacity),
+            custom: Vec::new(),
+            custom_lookup: HashMap::new(),
+        }
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.codes.len()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn capacity(&self) -> usize {
+        self.codes.capacity()
+    }
+
+    pub(crate) fn reserve(&mut self, additional: usize) {
+        self.codes.reserve(additional);
+    }
+
+    pub(crate) fn shrink_to_fit(&mut self) {
+        self.codes.shrink_to_fit();
+        self.custom.shrink_to_fit();
+        self.custom_lookup.shrink_to_fit();
+    }
+
+    pub(crate) fn push_bounds(&mut self, bounds: Bounds) -> Result<(), ModelError> {
+        let code = self.code_for_bounds(bounds)?;
+        self.codes.push(code);
+        Ok(())
+    }
+
+    pub(crate) fn extend_repeated(
+        &mut self,
+        bounds: Bounds,
+        count: usize,
+    ) -> Result<(), ModelError> {
+        let code = self.code_for_bounds(bounds)?;
+        self.codes.resize(self.codes.len() + count, code);
+        Ok(())
+    }
+
+    pub(crate) fn extend_from_slice(&mut self, bounds: &[Bounds]) -> Result<(), ModelError> {
+        self.codes.reserve(bounds.len());
+        let mut last_key: Option<(u64, u64)> = None;
+        let mut last_code = 0;
+        for bound in bounds {
+            let code = if let Some(code) = common_variable_bound_code(*bound) {
+                code
+            } else {
+                let key = bounds_key(*bound);
+                if Some(key) == last_key {
+                    last_code
+                } else {
+                    let code = self.custom_code_for_key(key, *bound)?;
+                    last_key = Some(key);
+                    last_code = code;
+                    code
+                }
+            };
+            self.codes.push(code);
+        }
+        Ok(())
+    }
+
+    pub(crate) fn get_bounds(&self, index: usize) -> Option<Bounds> {
+        let code = *self.codes.get(index)?;
+        self.bounds_for_code(code)
+    }
+
+    pub(crate) fn iter_bounds(&self) -> impl Iterator<Item = Bounds> + '_ {
+        self.codes
+            .iter()
+            .filter_map(|code| self.bounds_for_code(*code))
+    }
+
+    fn code_for_bounds(&mut self, bounds: Bounds) -> Result<u32, ModelError> {
+        if let Some(code) = common_variable_bound_code(bounds) {
+            return Ok(code);
+        }
+        self.custom_code_for_key(bounds_key(bounds), bounds)
+    }
+
+    fn custom_code_for_key(&mut self, key: (u64, u64), bounds: Bounds) -> Result<u32, ModelError> {
+        if let Some(code) = self.custom_lookup.get(&key) {
+            return Ok(*code);
+        }
+        let custom_idx =
+            u32::try_from(self.custom.len()).map_err(|_| ModelError::InvalidCscData {
+                reason: "too many custom variable bounds for compact storage".to_string(),
+            })?;
+        let code = VARIABLE_BOUNDS_CUSTOM_BASE
+            .checked_add(custom_idx)
+            .ok_or_else(|| ModelError::InvalidCscData {
+                reason: "too many custom variable bounds for compact storage".to_string(),
+            })?;
+        self.custom.push(bounds);
+        self.custom_lookup.insert(key, code);
+        Ok(code)
+    }
+
+    fn bounds_for_code(&self, code: u32) -> Option<Bounds> {
+        match code {
+            VARIABLE_BOUNDS_FREE => Some(FREE_BOUNDS),
+            VARIABLE_BOUNDS_NONNEGATIVE => Some(NONNEGATIVE_BOUNDS),
+            VARIABLE_BOUNDS_UNIT => Some(UNIT_BOUNDS),
+            custom_code => {
+                let custom_idx = (custom_code - VARIABLE_BOUNDS_CUSTOM_BASE) as usize;
+                self.custom.get(custom_idx).copied()
+            }
+        }
+    }
+}
+
+#[inline]
+fn bounds_key(bounds: Bounds) -> (u64, u64) {
+    (bounds.lower.to_bits(), bounds.upper.to_bits())
+}
+
+#[inline]
+fn common_variable_bound_code(bounds: Bounds) -> Option<u32> {
+    if bounds == FREE_BOUNDS {
+        Some(VARIABLE_BOUNDS_FREE)
+    } else if bounds == NONNEGATIVE_BOUNDS {
+        Some(VARIABLE_BOUNDS_NONNEGATIVE)
+    } else if bounds == UNIT_BOUNDS {
+        Some(VARIABLE_BOUNDS_UNIT)
+    } else {
+        None
+    }
+}
+
+/// Compact constraint-bound storage.
+///
+/// Common row bounds are represented as one u32 code per constraint. Uncommon
+/// bounds are stored once in a side table and referenced by code. This preserves
+/// stable constraint IDs while avoiding a 16-byte `Constraint` for every row.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct ConstraintStore {
+    codes: Vec<u32>,
+    custom: Vec<Constraint>,
+    recent_custom: SmallVec<[((u64, u64), u32); 8]>,
+}
+
+impl ConstraintStore {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn with_capacity(capacity: usize) -> Self {
+        Self {
+            codes: Vec::with_capacity(capacity),
+            custom: Vec::new(),
+            recent_custom: SmallVec::new(),
+        }
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.codes.len()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn capacity(&self) -> usize {
+        self.codes.capacity()
+    }
+
+    pub(crate) fn reserve(&mut self, additional: usize) {
+        self.codes.reserve(additional);
+    }
+
+    pub(crate) fn shrink_to_fit(&mut self) {
+        self.codes.shrink_to_fit();
+        self.custom.shrink_to_fit();
+    }
+
+    pub(crate) fn push(&mut self, constraint: Constraint) {
+        let code = common_constraint_bound_code(constraint.bounds)
+            .unwrap_or_else(|| self.custom_code_for_constraint(constraint));
+        self.codes.push(code);
+    }
+
+    pub(crate) fn get(&self, index: usize) -> Option<&Constraint> {
+        let code = *self.codes.get(index)?;
+        Some(self.constraint_for_code(code))
+    }
+
+    pub(crate) fn iter(&self) -> impl Iterator<Item = &Constraint> + '_ {
+        self.codes
+            .iter()
+            .map(|code| self.constraint_for_code(*code))
+    }
+
+    fn constraint_for_code(&self, code: u32) -> &Constraint {
+        match code {
+            CONSTRAINT_BOUNDS_FREE => &FREE_CONSTRAINT,
+            CONSTRAINT_BOUNDS_EQ_ZERO => &EQ_ZERO_CONSTRAINT,
+            CONSTRAINT_BOUNDS_UPPER_ZERO => &UPPER_ZERO_CONSTRAINT,
+            CONSTRAINT_BOUNDS_LOWER_ZERO => &LOWER_ZERO_CONSTRAINT,
+            custom_code => {
+                let custom_idx = (custom_code - CONSTRAINT_BOUNDS_CUSTOM_BASE) as usize;
+                &self.custom[custom_idx]
+            }
+        }
+    }
+
+    fn custom_code_for_constraint(&mut self, constraint: Constraint) -> u32 {
+        let key = bounds_key(constraint.bounds);
+        if let Some((_, code)) = self
+            .recent_custom
+            .iter()
+            .find(|(recent_key, _)| *recent_key == key)
+        {
+            return *code;
+        }
+
+        let custom_idx = self.custom.len() as u32;
+        let code = CONSTRAINT_BOUNDS_CUSTOM_BASE + custom_idx;
+        self.custom.push(constraint);
+        if self.recent_custom.len() == self.recent_custom.inline_size() {
+            self.recent_custom.remove(0);
+        }
+        self.recent_custom.push((key, code));
+        code
+    }
+}
+
+#[inline]
+fn common_constraint_bound_code(bounds: Bounds) -> Option<u32> {
+    match bounds {
+        Bounds {
+            lower: f64::NEG_INFINITY,
+            upper: f64::INFINITY,
+        } => Some(CONSTRAINT_BOUNDS_FREE),
+        Bounds {
+            lower: 0.0,
+            upper: 0.0,
+        } => Some(CONSTRAINT_BOUNDS_EQ_ZERO),
+        Bounds {
+            lower: f64::NEG_INFINITY,
+            upper: 0.0,
+        } => Some(CONSTRAINT_BOUNDS_UPPER_ZERO),
+        Bounds {
+            lower: 0.0,
+            upper: f64::INFINITY,
+        } => Some(CONSTRAINT_BOUNDS_LOWER_ZERO),
+        _ => None,
+    }
+}
+
 pub use csc_import::CscInput;
 pub use error::ModelError;
 pub use inspect::{
@@ -55,10 +368,10 @@ pub use view::{ModelFingerprint, ModelPatch, ModelView, PatchedModelView, Struct
 /// The internal representation uses column-first sparse storage (CSC format).
 #[derive(Debug, Clone)]
 pub struct Model {
-    pub(crate) variables: Vec<Bounds>,
+    pub(crate) variables: VariableStore,
     pub(crate) variable_is_integer_bits: Vec<u64>,
     pub(crate) variable_is_inactive_bits: Vec<u64>,
-    pub(crate) constraints: Vec<Constraint>,
+    pub(crate) constraints: ConstraintStore,
     pub(crate) objective: Objective,
     pub(crate) objective_name: Option<String>,
     simplify_level: SimplifyLevel,
@@ -109,10 +422,10 @@ impl Model {
     /// Create a new empty model.
     pub fn new() -> Self {
         Self {
-            variables: Vec::new(),
+            variables: VariableStore::new(),
             variable_is_integer_bits: Vec::new(),
             variable_is_inactive_bits: Vec::new(),
-            constraints: Vec::new(),
+            constraints: ConstraintStore::new(),
             objective: Objective::new(),
             objective_name: None,
             simplify_level: SimplifyLevel::default(),
@@ -132,10 +445,10 @@ impl Model {
     /// Create a new model with pre-allocated storage capacities.
     pub fn with_capacities(variable_capacity: usize, constraint_capacity: usize) -> Self {
         Self {
-            variables: Vec::with_capacity(variable_capacity),
+            variables: VariableStore::with_capacity(variable_capacity),
             variable_is_integer_bits: Vec::with_capacity(variable_capacity.div_ceil(BITS_PER_WORD)),
             variable_is_inactive_bits: Vec::new(),
-            constraints: Vec::with_capacity(constraint_capacity),
+            constraints: ConstraintStore::with_capacity(constraint_capacity),
             objective: Objective::new(),
             objective_name: None,
             simplify_level: SimplifyLevel::default(),
@@ -183,10 +496,43 @@ impl Model {
         &self.objective
     }
 
+    #[doc(hidden)]
+    pub fn take_objective_terms_for_consumed_solve(&mut self) -> Vec<(VariableId, f64)> {
+        std::mem::take(&mut self.objective.terms)
+    }
+
+    #[doc(hidden)]
+    pub fn drain_column_for_consumed_solve(
+        &mut self,
+        variable_id: VariableId,
+        mut visit: impl FnMut(ConstraintId, f64),
+    ) -> bool {
+        let idx = variable_id.inner() as usize;
+        let Some(column) = self.columns.get_mut(idx) else {
+            return false;
+        };
+        for (constraint_id, coefficient) in std::mem::take(column) {
+            visit(constraint_id, coefficient);
+        }
+        true
+    }
+
+    pub(crate) fn shrink_retained_storage(&mut self) {
+        self.variables.shrink_to_fit();
+        self.variable_is_integer_bits.shrink_to_fit();
+        self.variable_is_inactive_bits.shrink_to_fit();
+        self.constraints.shrink_to_fit();
+        self.columns.shrink_to_fit();
+        for column in &mut self.columns {
+            column.shrink_to_fit();
+        }
+        self.slack_handles.shrink_to_fit();
+    }
+
     #[inline]
-    pub(crate) fn push_variable(&mut self, variable: Variable) {
+    pub(crate) fn push_variable(&mut self, variable: Variable) -> Result<(), ModelError> {
         let idx = self.variables.len();
-        self.variables.push(variable.bounds);
+        self.variables.push_bounds(variable.bounds)?;
         self.columns.push(ColumnVec::new());
         if variable.is_integer {
             Self::write_packed_flag(&mut self.variable_is_integer_bits, idx, true);
@@ -194,11 +540,12 @@ impl Model {
         if !variable.is_active {
             Self::write_packed_flag(&mut self.variable_is_inactive_bits, idx, true);
         }
+        Ok(())
     }
 
     #[inline]
     pub(crate) fn get_variable_by_index(&self, idx: usize) -> Option<Variable> {
-        let bounds = *self.variables.get(idx)?;
+        let bounds = self.variables.get_bounds(idx)?;
         Some(Variable {
             bounds,
             is_integer: Self::read_packed_flag(&self.variable_is_integer_bits, idx),
@@ -276,6 +623,20 @@ impl Model {
 
         let skip_zeros = matches!(self.simplify_level, SimplifyLevel::Light);
 
+        if terms_are_sorted_unique_nonzero(&terms) {
+            tracing::debug!(
+                component = "model",
+                operation = "lower_expr",
+                status = "success",
+                simplify_level = self.simplify_level.as_str(),
+                expr_terms_in = terms_in,
+                expr_terms_out = terms.len(),
+                duration_ms = started.elapsed().as_secs_f64() * 1000.0,
+                "Lowered already-normalized linear expression"
+            );
+            return terms;
+        }
+
         // Pre-filter zeros if needed (in-place)
         if skip_zeros {
             terms.retain(|(_, coeff)| *coeff != 0.0);
@@ -319,14 +680,42 @@ impl Model {
         terms
     }
 
-    pub(crate) fn add_objective_terms(&mut self, terms: Vec<(VariableId, f64)>) {
+    pub fn add_objective_terms(&mut self, terms: Vec<(VariableId, f64)>) -> Result<(), ModelError> {
         if terms.is_empty() {
-            return;
+            return Ok(());
+        }
+        if self.objective.sense.is_none() {
+            return Err(ModelError::NoObjective);
+        }
+        for (var_id, coeff) in &terms {
+            self.ensure_variable_exists(*var_id)?;
+            if !coefficient_is_valid(*coeff) {
+                return Err(ModelError::InvalidCoefficient {
+                    coefficient: *coeff,
+                });
+            }
         }
         let mut merged = std::mem::take(&mut self.objective.terms);
         merged.extend(terms);
         self.objective.terms = self.normalize_terms(merged);
+        Ok(())
     }
+}
+
+#[inline]
+fn terms_are_sorted_unique_nonzero(terms: &[(VariableId, f64)]) -> bool {
+    let mut previous: Option<u32> = None;
+    for (var_id, coefficient) in terms {
+        if *coefficient == 0.0 {
+            return false;
+        }
+        let current = var_id.inner();
+        if previous.is_some_and(|previous| current <= previous) {
+            return false;
+        }
+        previous = Some(current);
+    }
+    true
 }
 
 impl Default for Model {
@@ -387,6 +776,16 @@ mod tests {
         assert_eq!(model.num_variables(), 0);
         assert_eq!(model.num_constraints(), 0);
         assert!(model.variables.capacity() >= 32);
+        assert!(model.constraints.capacity() >= 16);
+    }
+
+    #[test]
+    fn test_reserve_constraints_preallocates_without_adding_rows() {
+        let mut model = Model::new();
+
+        model.reserve_constraints(16);
+
+        assert_eq!(model.num_constraints(), 0);
         assert!(model.constraints.capacity() >= 16);
     }
 
@@ -462,6 +861,83 @@ mod tests {
     }
 
     #[test]
+    fn test_constraint_store_compacts_common_bounds_and_roundtrips_custom_bounds() {
+        let mut model = Model::new();
+        let equality = model
+            .add_constraint(Constraint {
+                bounds: Bounds::new(0.0, 0.0),
+            })
+            .unwrap();
+        let upper_zero = model
+            .add_constraint(Constraint {
+                bounds: Bounds::new(f64::NEG_INFINITY, 0.0),
+            })
+            .unwrap();
+        let custom = model
+            .add_constraint(Constraint {
+                bounds: Bounds::new(3.0, 7.0),
+            })
+            .unwrap();
+
+        assert_eq!(model.constraints.custom.len(), 1);
+        assert_eq!(
+            model.get_constraint(equality).unwrap().bounds,
+            Bounds::new(0.0, 0.0)
+        );
+        assert_eq!(
+            model.get_constraint(upper_zero).unwrap().bounds,
+            Bounds::new(f64::NEG_INFINITY, 0.0)
+        );
+        assert_eq!(
+            model.get_constraint(custom).unwrap().bounds,
+            Bounds::new(3.0, 7.0)
+        );
+    }
+
+    #[test]
+    fn test_constraint_store_reuses_recent_custom_bounds() {
+        let mut model = Model::new();
+        let first = model
+            .add_constraint(Constraint {
+                bounds: Bounds::new(3.0, 7.0),
+            })
+            .unwrap();
+        let second = model
+            .add_constraint(Constraint {
+                bounds: Bounds::new(3.0, 7.0),
+            })
+            .unwrap();
+        let third = model
+            .add_constraint(Constraint {
+                bounds: Bounds::new(5.0, 9.0),
+            })
+            .unwrap();
+        let fourth = model
+            .add_constraint(Constraint {
+                bounds: Bounds::new(3.0, 7.0),
+            })
+            .unwrap();
+
+        assert_eq!(model.constraints.custom.len(), 2);
+        assert_eq!(
+            model.get_constraint(first).unwrap().bounds,
+            Bounds::new(3.0, 7.0)
+        );
+        assert_eq!(
+            model.get_constraint(second).unwrap().bounds,
+            Bounds::new(3.0, 7.0)
+        );
+        assert_eq!(
+            model.get_constraint(third).unwrap().bounds,
+            Bounds::new(5.0, 9.0)
+        );
+        assert_eq!(
+            model.get_constraint(fourth).unwrap().bounds,
+            Bounds::new(3.0, 7.0)
+        );
+    }
+
+    #[test]
     fn test_set_objective() {
         let mut model = Model::new();
         let var_id = model
@@ -480,6 +956,60 @@ mod tests {
         model.set_objective(objective).unwrap();
         assert_eq!(model.objective().sense, Some(Sense::Minimize));
         assert_eq!(model.objective().terms.len(), 1);
+    }
+
+    #[test]
+    fn test_set_objective_trims_excess_term_capacity() {
+        let mut model = Model::new();
+        let var_id = model
+            .add_variable(Variable {
+                bounds: Bounds::new(0.0, 10.0),
+                is_integer: false,
+                is_active: true,
+            })
+            .unwrap();
+        let mut terms = Vec::with_capacity(16);
+        terms.push((var_id, 1.0));
+
+        model
+            .set_objective(Objective {
+                sense: Some(Sense::Minimize),
+                terms,
+            })
+            .unwrap();
+
+        assert_eq!(
+            model.objective().terms.capacity(),
+            model.objective().terms.len()
+        );
+    }
+
+    #[test]
+    fn test_set_objective_shrinks_retained_column_capacity() {
+        let mut model = Model::new();
+        let var_id = model
+            .add_variable(Variable::continuous(Bounds::new(0.0, 10.0)))
+            .unwrap();
+        for _ in 0..3 {
+            let constraint_id = model
+                .add_constraint(Constraint {
+                    bounds: Bounds::new(0.0, 1.0),
+                })
+                .unwrap();
+            model.set_coefficient(var_id, constraint_id, 1.0).unwrap();
+        }
+        model.columns[var_id.inner() as usize].reserve(16);
+
+        model
+            .set_objective(Objective {
+                sense: Some(Sense::Minimize),
+                terms: vec![(var_id, 1.0)],
+            })
+            .unwrap();
+
+        let column = &model.columns[var_id.inner() as usize];
+        assert_eq!(column.len(), 3);
+        assert_eq!(column.capacity(), 3);
     }
 
     #[test]
@@ -564,7 +1094,9 @@ mod tests {
             })
             .unwrap();
 
-        model.add_objective_terms(vec![(x, 2.0), (y, 3.0), (x, -1.0)]);
+        model
+            .add_objective_terms(vec![(x, 2.0), (y, 3.0), (x, -1.0)])
+            .unwrap();
 
         assert_eq!(model.objective().sense, Some(Sense::Minimize));
         let mut terms = model.objective().terms.clone();
@@ -590,9 +1122,61 @@ mod tests {
             })
             .unwrap();
 
-        model.add_objective_terms(Vec::new());
+        model.add_objective_terms(Vec::new()).unwrap();
 
         assert_eq!(model.objective().terms, vec![(x, 1.0)]);
+    }
+
+    #[test]
+    fn test_take_objective_terms_preserves_sense_and_drains_terms() {
+        let mut model = Model::new();
+        let x = model
+            .add_variable(Variable {
+                bounds: Bounds::new(0.0, 10.0),
+                is_integer: false,
+                is_active: true,
+            })
+            .unwrap();
+        model
+            .set_objective(Objective {
+                sense: Some(Sense::Minimize),
+                terms: vec![(x, 2.0)],
+            })
+            .unwrap();
+
+        let terms = model.take_objective_terms_for_consumed_solve();
+
+        assert_eq!(terms, vec![(x, 2.0)]);
+        assert_eq!(model.objective().sense, Some(Sense::Minimize));
+        assert!(model.objective().terms.is_empty());
+    }
+
+    #[test]
+    fn test_drain_column_for_consumed_solve_visits_entries_and_clears_column() {
+        let mut model = Model::new();
+        let x = model
+            .add_variable(Variable {
+                bounds: Bounds::new(0.0, 10.0),
+                is_integer: false,
+                is_active: true,
+            })
+            .unwrap();
+        let row = model
+            .add_constraint(Constraint {
+                bounds: Bounds::new(0.0, 100.0),
+            })
+            .unwrap();
+        model.set_coefficient(x, row, 3.5).unwrap();
+
+        let mut drained = Vec::new();
+        assert!(
+            model.drain_column_for_consumed_solve(x, |constraint_id, coefficient| {
+                drained.push((constraint_id, coefficient));
+            })
+        );
+
+        assert_eq!(drained, vec![(row, 3.5)]);
+        assert!(model.get_column(x).is_some_and(|column| column.is_empty()));
     }
 
     #[test]
@@ -742,6 +1326,231 @@ mod tests {
 
         let col_v2 = model.get_column(v2).expect("v2 column missing");
         assert_eq!(col_v2, &vec![(c2, 3.5)]);
+    }
+
+    #[test]
+    fn test_streaming_constraint_batch_inserts_rows_without_retained_batch() {
+        let mut model = Model::new();
+        let v1 = model
+            .add_variable(Variable::continuous(Bounds::new(0.0, 10.0)))
+            .unwrap();
+        let v2 = model
+            .add_variable(Variable::continuous(Bounds::new(0.0, 10.0)))
+            .unwrap();
+
+        let rows = vec![
+            (vec![(v1, 1.0)], Bounds::new(0.0, 5.0)),
+            (vec![(v1, -1.0), (v2, 2.0)], Bounds::new(3.0, 3.0)),
+        ];
+
+        let first = model
+            .add_constraints_batch_streaming(rows.len(), rows)
+            .unwrap();
+
+        assert_eq!(first, ConstraintId::new(0));
+        assert_eq!(model.num_constraints(), 2);
+        assert_eq!(
+            model.get_column(v1).expect("v1 column missing"),
+            &vec![(ConstraintId::new(0), 1.0), (ConstraintId::new(1), -1.0)]
+        );
+        assert_eq!(
+            model.get_column(v2).expect("v2 column missing"),
+            &vec![(ConstraintId::new(1), 2.0)]
+        );
+    }
+
+    #[test]
+    fn test_compact_indexed_constraints_use_dense_row_indices() {
+        let mut model = Model::new();
+        for _ in 0..6 {
+            model
+                .add_variable(Variable::continuous(Bounds::new(0.0, 10.0)))
+                .unwrap();
+        }
+
+        let first = model
+            .add_constraints_compact_indexed(
+                &[(0, 1.0), (3, -2.0)],
+                &[0, 2],
+                &[Bounds::new(0.0, 1.0), Bounds::new(4.0, 4.0)],
+            )
+            .unwrap();
+
+        assert_eq!(first, ConstraintId::new(0));
+        assert_eq!(model.num_constraints(), 2);
+        assert_eq!(
+            model
+                .get_column(VariableId::new(0))
+                .expect("v0 column missing"),
+            &vec![(ConstraintId::new(0), 1.0)]
+        );
+        assert_eq!(
+            model
+                .get_column(VariableId::new(2))
+                .expect("v2 column missing"),
+            &vec![(ConstraintId::new(1), 1.0)]
+        );
+        assert_eq!(
+            model
+                .get_column(VariableId::new(3))
+                .expect("v3 column missing"),
+            &vec![(ConstraintId::new(0), -2.0)]
+        );
+        assert_eq!(
+            model
+                .get_column(VariableId::new(5))
+                .expect("v5 column missing"),
+            &vec![(ConstraintId::new(1), -2.0)]
+        );
+    }
+
+    #[test]
+    fn test_add_variables_uniform_assigns_contiguous_ids() {
+        let mut model = Model::new();
+        let first = model
+            .add_variables_uniform(Variable::continuous(Bounds::new(0.0, 10.0)), 3)
+            .unwrap();
+
+        assert_eq!(first, VariableId::new(0));
+        assert_eq!(model.num_variables(), 3);
+        assert_eq!(model.next_variable_id, 3);
+        for idx in 0..3 {
+            let variable = model.get_variable(VariableId::new(idx)).unwrap();
+            assert_eq!(variable.bounds, Bounds::new(0.0, 10.0));
+            assert!(variable.is_active);
+            assert!(!variable.is_integer);
+        }
+
+        let second = model
+            .add_variables_uniform(Variable::integer(Bounds::new(-1.0, 4.0)), 2)
+            .unwrap();
+
+        assert_eq!(second, VariableId::new(3));
+        assert_eq!(model.num_variables(), 5);
+        for idx in 3..5 {
+            let variable = model.get_variable(VariableId::new(idx)).unwrap();
+            assert_eq!(variable.bounds, Bounds::new(-1.0, 4.0));
+            assert!(variable.is_integer);
+        }
+    }
+
+    #[test]
+    fn test_add_variables_uniform_rejects_invalid_bounds() {
+        let mut model = Model::new();
+        let result = model.add_variables_uniform(Variable::continuous(Bounds::new(5.0, 1.0)), 2);
+
+        assert_eq!(
+            result,
+            Err(ModelError::InvalidVariableBounds {
+                lower: 5.0,
+                upper: 1.0
+            })
+        );
+        assert_eq!(model.num_variables(), 0);
+    }
+
+    #[test]
+    fn test_add_variables_with_bounds_assigns_contiguous_ids() {
+        let mut model = Model::new();
+        let bounds = [
+            Bounds::new(0.0, 1.0),
+            Bounds::new(2.0, 5.0),
+            Bounds::new(-3.0, 4.0),
+        ];
+
+        let first = model
+            .add_variables_with_bounds(&bounds, true, true)
+            .unwrap();
+
+        assert_eq!(first, VariableId::new(0));
+        assert_eq!(model.num_variables(), 3);
+        assert_eq!(model.next_variable_id, 3);
+        for (idx, expected_bounds) in bounds.iter().copied().enumerate() {
+            let variable = model.get_variable(VariableId::new(idx as u32)).unwrap();
+            assert_eq!(variable.bounds, expected_bounds);
+            assert!(variable.is_integer);
+            assert!(variable.is_active);
+        }
+    }
+
+    #[test]
+    fn test_variable_store_compacts_common_bounds_and_deduplicates_custom_bounds() {
+        let mut model = Model::new();
+        model
+            .add_variables_uniform(Variable::continuous(Bounds::new(0.0, f64::INFINITY)), 3)
+            .unwrap();
+        model
+            .add_variables_with_bounds(
+                &[
+                    Bounds::new(0.0, 7.0),
+                    Bounds::new(0.0, 7.0),
+                    Bounds::new(0.0, 9.0),
+                    Bounds::new(0.0, 7.0),
+                ],
+                false,
+                true,
+            )
+            .unwrap();
+
+        assert_eq!(model.variables.custom.len(), 2);
+        assert_eq!(
+            model.get_variable(VariableId::new(0)).unwrap().bounds,
+            Bounds::new(0.0, f64::INFINITY)
+        );
+        assert_eq!(
+            model.get_variable(VariableId::new(3)).unwrap().bounds,
+            Bounds::new(0.0, 7.0)
+        );
+        assert_eq!(
+            model.get_variable(VariableId::new(5)).unwrap().bounds,
+            Bounds::new(0.0, 9.0)
+        );
+    }
+
+    #[test]
+    fn test_add_variables_with_bounds_rejects_invalid_bounds() {
+        let mut model = Model::new();
+        let bounds = [Bounds::new(0.0, 1.0), Bounds::new(5.0, 1.0)];
+        let result = model.add_variables_with_bounds(&bounds, false, true);
+
+        assert_eq!(
+            result,
+            Err(ModelError::InvalidVariableBounds {
+                lower: 5.0,
+                upper: 1.0
+            })
+        );
+        assert_eq!(model.num_variables(), 0);
+    }
+
+    #[test]
+    fn normalize_terms_keeps_already_sorted_unique_terms() {
+        let model = Model::new();
+        let terms = vec![
+            (VariableId::new(1), 2.0),
+            (VariableId::new(3), -4.0),
+            (VariableId::new(8), 1.5),
+        ];
+
+        assert!(super::terms_are_sorted_unique_nonzero(&terms));
+        assert_eq!(model.normalize_terms(terms.clone()), terms);
+    }
+
+    #[test]
+    fn normalize_terms_still_merges_duplicates_and_removes_zeros() {
+        let model = Model::new();
+        let terms = vec![
+            (VariableId::new(3), 1.0),
+            (VariableId::new(1), 2.0),
+            (VariableId::new(3), -1.0),
+            (VariableId::new(2), 0.0),
+        ];
+
+        assert!(!super::terms_are_sorted_unique_nonzero(&terms));
+        assert_eq!(
+            model.normalize_terms(terms),
+            vec![(VariableId::new(1), 2.0)]
+        );
     }
 
     #[test]

--- a/crates/arco-model/src/model/slack.rs
+++ b/crates/arco-model/src/model/slack.rs
@@ -68,7 +68,7 @@ impl Model {
             objective_terms.push((slack_var, objective_coeff));
         }
 
-        self.add_objective_terms(objective_terms);
+        self.add_objective_terms(objective_terms)?;
 
         tracing::debug!(
             component = "slack",

--- a/crates/arco-ops/src/execution_backends.rs
+++ b/crates/arco-ops/src/execution_backends.rs
@@ -56,6 +56,22 @@ pub(crate) fn solve_model_view_with_builtin_backend(
     registry.solve(family, model, config)
 }
 
+pub(crate) fn solve_owned_model_with_builtin_backend(
+    family: &str,
+    model: arco_model::Model,
+    config: &SolverConfig,
+) -> Result<ModelViewSolveResult, SolverError> {
+    let family = normalize_model_view_backend_family(family);
+    if family == "highs" {
+        return arco_highs::solve_owned_model(model, config);
+    }
+    #[cfg(feature = "xpress")]
+    if family == "xpress" {
+        return arco_xpress::solve_owned_model(model, config);
+    }
+    solve_model_view_with_builtin_backend(family, &model, config)
+}
+
 pub(crate) fn builtin_solver_version(family: &str) -> Option<String> {
     match normalize_model_view_backend_family(family) {
         "highs" => highs_version(),

--- a/crates/arco-ops/src/lib.rs
+++ b/crates/arco-ops/src/lib.rs
@@ -270,6 +270,18 @@ impl ArcoOps {
         crate::execution_backends::solve_model_view_with_builtin_backend(family, model, config)
     }
 
+    /// Solve an owned in-memory model through a builtin backend.
+    ///
+    /// This is intended for memory-sensitive callers that will not use the
+    /// model after solver handoff.
+    pub fn solve_owned_model_with_builtin_backend(
+        family: &str,
+        model: arco_model::Model,
+        config: &SolverConfig,
+    ) -> Result<ModelViewSolveResult, SolverError> {
+        crate::execution_backends::solve_owned_model_with_builtin_backend(family, model, config)
+    }
+
     /// Return the version for a builtin backend family when available.
     pub fn builtin_solver_version(family: &str) -> Option<String> {
         crate::execution_backends::builtin_solver_version(family)

--- a/crates/arco-solver/src/lib.rs
+++ b/crates/arco-solver/src/lib.rs
@@ -23,6 +23,7 @@ pub use conformance::{
 };
 pub use model_view_backend::{
     ModelViewBackend, ModelViewBackendRegistry, validate_model_view_solve_result,
+    validate_model_view_solve_result_with_config,
 };
 pub use preflight::{
     PreflightError, SolverRequirements, preflight_model_view, preflight_selection,

--- a/crates/arco-solver/src/model_view_backend.rs
+++ b/crates/arco-solver/src/model_view_backend.rs
@@ -75,7 +75,7 @@ impl<'a> ModelViewBackendRegistry<'a> {
             ))
         })?;
         let result = backend.solve_model_view(model, config)?;
-        validate_model_view_solve_result(model, &result)?;
+        validate_model_view_solve_result_with_config(model, &result, config)?;
         Ok(result)
     }
 }
@@ -85,17 +85,47 @@ pub fn validate_model_view_solve_result(
     model: &(impl ModelView + ?Sized),
     result: &ModelViewSolveResult,
 ) -> Result<(), SolverError> {
+    validate_model_view_solve_result_shape(model, result, false)
+}
+
+/// Validate a backend result against the supplied solver configuration.
+///
+/// Solver results normally include primal values. Callers may opt into an
+/// objective-only result with the private `arco.extract_solution=false` option
+/// to avoid large post-solve solution vectors when only status/objective
+/// metadata are needed.
+pub fn validate_model_view_solve_result_with_config(
+    model: &(impl ModelView + ?Sized),
+    result: &ModelViewSolveResult,
+    config: &SolverConfig,
+) -> Result<(), SolverError> {
+    validate_model_view_solve_result_shape(model, result, allows_omitted_primal_values(config))
+}
+
+fn validate_model_view_solve_result_shape(
+    model: &(impl ModelView + ?Sized),
+    result: &ModelViewSolveResult,
+    allow_omitted_primal_values: bool,
+) -> Result<(), SolverError> {
     let expected_fingerprint = model.fingerprint();
-    if result.fingerprint != expected_fingerprint {
+    if result.fingerprint.0 != 0 && result.fingerprint != expected_fingerprint {
         return Err(SolverError::InvalidResultShape(
             "result fingerprint does not match input model fingerprint".to_string(),
         ));
     }
-    validate_required_len(
-        "primal_values",
-        result.primal_values.len(),
-        model.num_variables(),
-    )?;
+    if allow_omitted_primal_values {
+        validate_optional_len(
+            "primal_values",
+            result.primal_values.len(),
+            model.num_variables(),
+        )?;
+    } else {
+        validate_required_len(
+            "primal_values",
+            result.primal_values.len(),
+            model.num_variables(),
+        )?;
+    }
     validate_optional_len(
         "variable_duals",
         result.variable_duals.len(),
@@ -112,6 +142,13 @@ pub fn validate_model_view_solve_result(
         model.num_constraints(),
     )?;
     Ok(())
+}
+
+fn allows_omitted_primal_values(config: &SolverConfig) -> bool {
+    config
+        .parameters
+        .get("arco.extract_solution")
+        .is_some_and(|value| value == "false")
 }
 
 fn validate_required_len(name: &str, actual: usize, expected: usize) -> Result<(), SolverError> {
@@ -138,7 +175,9 @@ mod tests {
         ModelViewBackend, ModelViewBackendRegistry, ModelViewSolveResult, SolverConfig,
         SolverError, SolverStatus,
     };
-    use arco_model::{Bounds, Model, ModelView, Objective, Sense, Variable, expr::Expr};
+    use arco_model::{
+        Bounds, Model, ModelFingerprint, ModelView, Objective, Sense, Variable, expr::Expr,
+    };
     use std::sync::Mutex;
 
     struct FixtureBackend;
@@ -233,6 +272,47 @@ mod tests {
             .expect_err("bad result shape should fail");
 
         assert!(matches!(error, SolverError::InvalidResultShape(_)));
+    }
+
+    #[test]
+    fn registry_accepts_objective_only_result_when_solution_extraction_is_disabled() {
+        let backend = BadShapeBackend;
+        let mut registry = ModelViewBackendRegistry::new();
+        registry.register(&backend);
+        let mut model = Model::new();
+        model
+            .add_variable(Variable::continuous(Bounds::new(0.0, 1.0)))
+            .expect("add variable");
+        let config = SolverConfig::new().with_parameter("arco.extract_solution", "false");
+
+        let result = registry
+            .solve("bad_shape", &model, &config)
+            .expect("objective-only result should be accepted when explicitly requested");
+
+        assert!(result.primal_values.is_empty());
+        assert!(result.objective_value.abs() <= f64::EPSILON);
+    }
+
+    #[test]
+    fn validation_accepts_zero_fingerprint_sentinel_when_lengths_match() {
+        let mut model = Model::new();
+        model
+            .add_variable(Variable::continuous(Bounds::new(0.0, 1.0)))
+            .expect("add variable");
+
+        let result = ModelViewSolveResult {
+            fingerprint: ModelFingerprint(0),
+            status: SolverStatus::Optimal,
+            objective_value: 0.0,
+            primal_values: vec![0.0],
+            variable_duals: Vec::new(),
+            row_values: Vec::new(),
+            constraint_duals: Vec::new(),
+            metadata: Default::default(),
+        };
+
+        super::validate_model_view_solve_result(&model, &result)
+            .expect("zero fingerprint sentinel should skip only fingerprint validation");
     }
 
     #[test]

--- a/crates/arco-xpress/src/ffi.rs
+++ b/crates/arco-xpress/src/ffi.rs
@@ -108,6 +108,8 @@ type XPRSgetlpsolFn = unsafe extern "C" fn(
 type XPRSgetmipsolFn = unsafe extern "C" fn(XPRSprob, *mut c_double, *mut c_double) -> c_int;
 type XPRSaddmipsolFn =
     unsafe extern "C" fn(XPRSprob, c_int, *const c_double, *const c_int, *const c_char) -> c_int;
+type XPRSchgboundsFn =
+    unsafe extern "C" fn(XPRSprob, c_int, *const c_int, *const c_char, *const c_double) -> c_int;
 type XPRSsetintcontrolFn = unsafe extern "C" fn(XPRSprob, c_int, c_int) -> c_int;
 type XPRSgetintcontrolFn = unsafe extern "C" fn(XPRSprob, c_int, *mut c_int) -> c_int;
 type XPRSsetdblcontrolFn = unsafe extern "C" fn(XPRSprob, c_int, c_double) -> c_int;
@@ -172,6 +174,7 @@ pub struct Api {
     pub xprs_getlpsol: XPRSgetlpsolFn,
     pub xprs_getmipsol: XPRSgetmipsolFn,
     pub xprs_addmipsol: XPRSaddmipsolFn,
+    pub xprs_chgbounds: XPRSchgboundsFn,
     pub xprs_setintcontrol: XPRSsetintcontrolFn,
     pub xprs_getintcontrol: XPRSgetintcontrolFn,
     pub xprs_setdblcontrol: XPRSsetdblcontrolFn,
@@ -291,6 +294,7 @@ fn load_api() -> Result<Api, RuntimeLoadError> {
                     xprs_getlpsol: load_symbol!(handle, "XPRSgetlpsol", XPRSgetlpsolFn),
                     xprs_getmipsol: load_symbol!(handle, "XPRSgetmipsol", XPRSgetmipsolFn),
                     xprs_addmipsol: load_symbol!(handle, "XPRSaddmipsol", XPRSaddmipsolFn),
+                    xprs_chgbounds: load_symbol!(handle, "XPRSchgbounds", XPRSchgboundsFn),
                     xprs_setintcontrol: load_symbol!(
                         handle,
                         "XPRSsetintcontrol",

--- a/crates/arco-xpress/src/lib.rs
+++ b/crates/arco-xpress/src/lib.rs
@@ -11,5 +11,5 @@ mod status;
 pub use solution::Solution;
 pub use solver::{
     Solver, XpressModelViewBackend, detect_xpress_dir, detect_xpress_license_path,
-    solve_model_view, xpress_runtime_available,
+    solve_model_view, solve_owned_model, xpress_runtime_available,
 };

--- a/crates/arco-xpress/src/solver.rs
+++ b/crates/arco-xpress/src/solver.rs
@@ -6,7 +6,7 @@ use crate::status;
 use arco_model::{ConstraintId, ModelFingerprint, ModelView, Sense, VariableId};
 use arco_solver::{
     ModelViewBackend, ModelViewSolveResult, Solve, SolverConfig, SolverDiagnostic, SolverError,
-    SolverModelStats, validate_model_view_solve_result,
+    SolverModelStats, validate_model_view_solve_result_with_config,
 };
 use std::collections::BTreeMap;
 use std::ffi::{CStr, CString, c_char, c_int, c_void};
@@ -261,12 +261,12 @@ fn format_xpress_failure_message(action: &str, rc: c_int, last_error: Option<&st
     }
 }
 
-fn xpress_failure_error(
+fn xpress_failure_error_for_stats(
     api: &'static ffi::Api,
     prob: ffi::XPRSprob,
     action: &str,
     rc: c_int,
-    model: &(impl ModelView + ?Sized),
+    stats: &SolverModelStats,
 ) -> SolverError {
     let last_error = xprs_last_error(api, prob);
     if last_error
@@ -278,7 +278,7 @@ fn xpress_failure_error(
             operation: action.trim_start_matches("XPRS").to_ascii_lowercase(),
             return_code: rc,
             limit: 5000,
-            model: xpress_model_stats(model),
+            model: stats.clone(),
         });
     }
 
@@ -397,6 +397,7 @@ fn validate_solver_config(config: &SolverConfig) -> Result<(), SolverError> {
     ensure_non_negative_finite_setting("time_limit", config.time_limit)?;
     ensure_non_negative_finite_setting("mip_gap", config.mip_gap)?;
     ensure_non_negative_finite_setting("tolerance", config.tolerance)?;
+    let _ = lp_optimize_flags(config)?;
 
     if let Some(0) = config.threads {
         return Err(SolverError::InvalidSettings(
@@ -404,6 +405,26 @@ fn validate_solver_config(config: &SolverConfig) -> Result<(), SolverError> {
         ));
     }
     Ok(())
+}
+
+fn lp_optimize_flags(config: &SolverConfig) -> Result<Option<&'static str>, SolverError> {
+    let algorithm = config
+        .parameters
+        .get("xpress.lp_algorithm")
+        .map_or("auto", String::as_str);
+    match algorithm {
+        "auto" | "" => Ok(None),
+        "primal" | "primal_simplex" | "p" => Ok(Some("p")),
+        "dual" | "dual_simplex" | "d" => Ok(Some("d")),
+        "barrier" | "b" => Ok(Some("b")),
+        "primal_barrier" | "primal+barrier" | "pb" | "bp" => Ok(Some("pb")),
+        "dual_barrier" | "dual+barrier" | "db" | "bd" => Ok(Some("db")),
+        "primal_dual" | "primal+dual" | "pd" | "dp" => Ok(Some("pd")),
+        "all" | "pdb" | "pbd" | "dpb" | "dbp" | "bpd" | "bdp" => Ok(Some("pdb")),
+        other => Err(SolverError::InvalidSettings(format!(
+            "xpress.lp_algorithm must be one of auto, primal, dual, barrier, primal_barrier, dual_barrier, primal_dual, or all (got {other:?})"
+        ))),
+    }
 }
 
 #[allow(unsafe_code)]
@@ -474,92 +495,153 @@ struct SolveArtifacts {
     metadata: BTreeMap<String, f64>,
 }
 
-#[allow(unsafe_code)]
-fn solve_problem(
+struct PreparedModelViewSolve {
+    problem: PreparedXpressProblem,
+    fingerprint: ModelFingerprint,
+    fingerprint_seconds: f64,
+    num_variables: usize,
+    num_constraints: usize,
+}
+
+struct PreparedModelViewLoad {
+    load_data: XpressLoadData,
+    fingerprint: ModelFingerprint,
+    fingerprint_seconds: f64,
+    num_variables: usize,
+    num_constraints: usize,
+}
+
+struct PreparedXpressProblem {
+    prob_guard: ProbGuard,
+    _env_guard: XpressGuard,
+    api: &'static ffi::Api,
+    ncols: usize,
+    nrows: usize,
+    has_integer: bool,
+    stats: SolverModelStats,
+    matrix_build_seconds: f64,
+    solve_started: Instant,
+}
+
+struct XpressLoadData {
+    ncols: usize,
+    nrows: usize,
+    has_integer: bool,
+    stats: SolverModelStats,
+    sense: Sense,
+    objective_coefficients: XpressObjectiveCoefficients,
+    variable_bounds: XpressVariableBounds,
+    row_types: Vec<u8>,
+    rhs: Vec<f64>,
+    rng: Option<Vec<f64>>,
+    matrix: XpressColumnMatrix,
+    col_types: Vec<u8>,
+    int_col_indices: Vec<c_int>,
+    int_col_limits: Vec<f64>,
+    matrix_build_seconds: f64,
+    solve_started: Instant,
+}
+
+struct XpressColumnMatrix {
+    mstart: Vec<c_int>,
+    mrwind: Vec<c_int>,
+    dmatval: Vec<f64>,
+}
+
+enum XpressObjectiveCoefficients {
+    Dense(Vec<f64>),
+    Sparse(Vec<(VariableId, f64)>),
+}
+
+enum XpressVariableBounds {
+    Full {
+        lower_bounds: Vec<f64>,
+        upper_bounds: Vec<f64>,
+    },
+    DefaultNonnegativeWithUpperChanges {
+        upper_indices: Vec<c_int>,
+        upper_types: Vec<u8>,
+        upper_values: Vec<f64>,
+    },
+}
+
+impl XpressVariableBounds {
+    fn load_ptrs(&self) -> (*const f64, *const f64) {
+        match self {
+            Self::Full {
+                lower_bounds,
+                upper_bounds,
+            } => (lower_bounds.as_ptr(), upper_bounds.as_ptr()),
+            Self::DefaultNonnegativeWithUpperChanges { .. } => (std::ptr::null(), std::ptr::null()),
+        }
+    }
+
+    fn lower_bound_for_integer_column(&self, index: usize) -> Option<f64> {
+        match self {
+            Self::Full { lower_bounds, .. } => lower_bounds.get(index).copied(),
+            Self::DefaultNonnegativeWithUpperChanges { .. } => Some(0.0),
+        }
+    }
+
+    #[allow(unsafe_code)]
+    fn apply_deferred_changes(
+        self,
+        api: &'static ffi::Api,
+        prob: ffi::XPRSprob,
+        stats: &SolverModelStats,
+    ) -> Result<(), SolverError> {
+        let Self::DefaultNonnegativeWithUpperChanges {
+            upper_indices,
+            upper_types,
+            upper_values,
+        } = self
+        else {
+            return Ok(());
+        };
+        if upper_indices.is_empty() {
+            return Ok(());
+        }
+
+        ffi::check_xprs(unsafe {
+            (api.xprs_chgbounds)(
+                prob,
+                upper_indices.len() as c_int,
+                upper_indices.as_ptr(),
+                upper_types.as_ptr().cast::<c_char>(),
+                upper_values.as_ptr(),
+            )
+        })
+        .map_err(|rc| xpress_failure_error_for_stats(api, prob, "XPRSchgbounds", rc, stats))
+    }
+}
+
+impl XpressObjectiveCoefficients {
+    fn into_dense(self, ncols: usize) -> Vec<f64> {
+        match self {
+            Self::Dense(coefficients) => coefficients,
+            Self::Sparse(terms) => {
+                let mut coefficients = vec![0.0; ncols];
+                for (variable_id, coefficient) in terms {
+                    let index = variable_id.inner() as usize;
+                    if index < coefficients.len() {
+                        coefficients[index] += coefficient;
+                    }
+                }
+                coefficients
+            }
+        }
+    }
+}
+
+fn build_xpress_column_matrix(
     model: &(impl ModelView + ?Sized),
-    config: &SolverConfig,
-) -> Result<SolveArtifacts, SolverError> {
-    if model.num_variables() == 0 {
-        return Err(SolverError::EmptyModel);
-    }
-
-    let solve_started = Instant::now();
-    let ncols = model.num_variables();
-    let nrows = model.num_constraints();
-    let sense = model.objective().sense.unwrap_or(Sense::Minimize);
-
-    debug!(
-        component = "solver",
-        operation = "solve",
-        solver = "xpress",
-        variables = ncols as u64,
-        constraints = nrows as u64,
-        "Starting Xpress solve"
-    );
-
-    let mut objective_coefficients = vec![0.0; ncols];
-    for (variable_id, coefficient) in &model.objective().terms {
-        let index = variable_id.inner() as usize;
-        let variable = model
-            .variable(*variable_id)
-            .ok_or(SolverError::InvalidVariableId(variable_id.inner()))?;
-        if variable.is_active && index < objective_coefficients.len() {
-            objective_coefficients[index] += *coefficient;
-        }
-    }
-
-    let mut lower_bounds = Vec::with_capacity(ncols);
-    let mut upper_bounds = Vec::with_capacity(ncols);
-    let mut col_types = Vec::new();
-    let mut int_col_indices = Vec::new();
-    let mut int_col_limits = Vec::new();
-    let mut has_integer = false;
-
-    for index in 0..ncols {
-        let variable_id = VariableId::new(index as u32);
-        let variable = model
-            .variable(variable_id)
-            .ok_or(SolverError::InvalidVariableId(variable_id.inner()))?;
-        if variable.is_active {
-            lower_bounds.push(clamp_bound(variable.bounds.lower));
-            upper_bounds.push(clamp_bound(variable.bounds.upper));
-        } else {
-            lower_bounds.push(0.0);
-            upper_bounds.push(0.0);
-        }
-
-        if variable.is_integer && variable.is_active {
-            has_integer = true;
-            col_types.push(
-                if variable.bounds.lower >= -1e-12 && variable.bounds.upper <= 1.0 + 1e-12 {
-                    b'B'
-                } else {
-                    b'I'
-                },
-            );
-            int_col_indices.push(index as c_int);
-            int_col_limits.push(lower_bounds[index]);
-        }
-    }
-
-    let mut row_types = Vec::with_capacity(nrows);
-    let mut rhs = Vec::with_capacity(nrows);
-    let mut rng = Vec::with_capacity(nrows);
-    for index in 0..nrows {
-        let constraint = model
-            .constraint(ConstraintId::new(index as u32))
-            .ok_or_else(|| SolverError::SolverSpecific(format!("missing constraint {index}")))?;
-        let (row_type, rhs_value, range_value) =
-            bounds_to_xpress_row(constraint.bounds.lower, constraint.bounds.upper);
-        row_types.push(row_type);
-        rhs.push(rhs_value);
-        rng.push(range_value);
-    }
-
-    let matrix_build_start = Instant::now();
+    ncols: usize,
+    nrows: usize,
+    expected_coefficients: usize,
+) -> Result<XpressColumnMatrix, SolverError> {
     let mut mstart = Vec::with_capacity(ncols + 1);
-    let mut mrwind = Vec::new();
-    let mut dmatval = Vec::new();
+    let mut mrwind = Vec::with_capacity(expected_coefficients);
+    let mut dmatval = Vec::with_capacity(expected_coefficients);
     for index in 0..ncols {
         mstart.push(mrwind.len() as c_int);
         let variable_id = VariableId::new(index as u32);
@@ -580,7 +662,267 @@ fn solve_problem(
         }
     }
     mstart.push(mrwind.len() as c_int);
+    Ok(XpressColumnMatrix {
+        mstart,
+        mrwind,
+        dmatval,
+    })
+}
+
+fn build_xpress_variable_bounds(
+    model: &(impl ModelView + ?Sized),
+    ncols: usize,
+) -> Result<XpressVariableBounds, SolverError> {
+    let mut can_use_default_nonnegative_bounds = true;
+    for index in 0..ncols {
+        let variable_id = VariableId::new(index as u32);
+        let variable = model
+            .variable(variable_id)
+            .ok_or(SolverError::InvalidVariableId(variable_id.inner()))?;
+        if !variable.is_active {
+            continue;
+        }
+        if variable.is_integer || variable.bounds.lower != 0.0 {
+            can_use_default_nonnegative_bounds = false;
+            break;
+        }
+    }
+
+    if can_use_default_nonnegative_bounds {
+        let mut upper_indices = Vec::new();
+        let mut upper_values = Vec::new();
+        for index in 0..ncols {
+            let variable_id = VariableId::new(index as u32);
+            let variable = model
+                .variable(variable_id)
+                .ok_or(SolverError::InvalidVariableId(variable_id.inner()))?;
+            let upper = if variable.is_active {
+                clamp_bound(variable.bounds.upper)
+            } else {
+                0.0
+            };
+            if upper < ffi::XPRS_PLUSINFINITY {
+                upper_indices.push(index as c_int);
+                upper_values.push(upper);
+            }
+        }
+        return Ok(XpressVariableBounds::DefaultNonnegativeWithUpperChanges {
+            upper_types: vec![b'U'; upper_indices.len()],
+            upper_indices,
+            upper_values,
+        });
+    }
+
+    let mut lower_bounds = Vec::with_capacity(ncols);
+    let mut upper_bounds = Vec::with_capacity(ncols);
+    for index in 0..ncols {
+        let variable_id = VariableId::new(index as u32);
+        let variable = model
+            .variable(variable_id)
+            .ok_or(SolverError::InvalidVariableId(variable_id.inner()))?;
+        if variable.is_active {
+            lower_bounds.push(clamp_bound(variable.bounds.lower));
+            upper_bounds.push(clamp_bound(variable.bounds.upper));
+        } else {
+            lower_bounds.push(0.0);
+            upper_bounds.push(0.0);
+        }
+    }
+
+    Ok(XpressVariableBounds::Full {
+        lower_bounds,
+        upper_bounds,
+    })
+}
+
+fn dense_objective_coefficients(
+    model: &(impl ModelView + ?Sized),
+    terms: &[(VariableId, f64)],
+    ncols: usize,
+) -> Result<Vec<f64>, SolverError> {
+    let mut objective_coefficients = vec![0.0; ncols];
+    for (variable_id, coefficient) in terms {
+        let index = variable_id.inner() as usize;
+        let variable = model
+            .variable(*variable_id)
+            .ok_or(SolverError::InvalidVariableId(variable_id.inner()))?;
+        if variable.is_active && index < objective_coefficients.len() {
+            objective_coefficients[index] += *coefficient;
+        }
+    }
+    Ok(objective_coefficients)
+}
+
+fn retain_active_objective_terms(
+    model: &(impl ModelView + ?Sized),
+    terms: &mut Vec<(VariableId, f64)>,
+    ncols: usize,
+) -> Result<(), SolverError> {
+    let mut write_index = 0;
+    for read_index in 0..terms.len() {
+        let (variable_id, coefficient) = terms[read_index];
+        let index = variable_id.inner() as usize;
+        let variable = model
+            .variable(variable_id)
+            .ok_or(SolverError::InvalidVariableId(variable_id.inner()))?;
+        if variable.is_active && index < ncols {
+            terms[write_index] = (variable_id, coefficient);
+            write_index += 1;
+        }
+    }
+    terms.truncate(write_index);
+    Ok(())
+}
+
+#[allow(unsafe_code)]
+fn prepare_load_data(model: &(impl ModelView + ?Sized)) -> Result<XpressLoadData, SolverError> {
+    let ncols = model.num_variables();
+    let objective_coefficients =
+        dense_objective_coefficients(model, model.objective().terms.as_slice(), ncols)?;
+    prepare_load_data_with_objective(
+        model,
+        XpressObjectiveCoefficients::Dense(objective_coefficients),
+    )
+}
+
+#[allow(unsafe_code)]
+fn prepare_load_data_with_objective(
+    model: &(impl ModelView + ?Sized),
+    objective_coefficients: XpressObjectiveCoefficients,
+) -> Result<XpressLoadData, SolverError> {
+    if model.num_variables() == 0 {
+        return Err(SolverError::EmptyModel);
+    }
+
+    let solve_started = Instant::now();
+    let ncols = model.num_variables();
+    let nrows = model.num_constraints();
+    let stats = xpress_model_stats(model);
+    let sense = model.objective().sense.unwrap_or(Sense::Minimize);
+
+    debug!(
+        component = "solver",
+        operation = "solve",
+        solver = "xpress",
+        variables = ncols as u64,
+        constraints = nrows as u64,
+        "Starting Xpress solve"
+    );
+
+    let variable_bounds = build_xpress_variable_bounds(model, ncols)?;
+    let mut col_types = Vec::new();
+    let mut int_col_indices = Vec::new();
+    let mut int_col_limits = Vec::new();
+    let mut has_integer = false;
+
+    for index in 0..ncols {
+        let variable_id = VariableId::new(index as u32);
+        let variable = model
+            .variable(variable_id)
+            .ok_or(SolverError::InvalidVariableId(variable_id.inner()))?;
+
+        if variable.is_integer && variable.is_active {
+            has_integer = true;
+            col_types.push(
+                if variable.bounds.lower >= -1e-12 && variable.bounds.upper <= 1.0 + 1e-12 {
+                    b'B'
+                } else {
+                    b'I'
+                },
+            );
+            int_col_indices.push(index as c_int);
+            int_col_limits.push(
+                variable_bounds
+                    .lower_bound_for_integer_column(index)
+                    .unwrap_or_else(|| clamp_bound(variable.bounds.lower)),
+            );
+        }
+    }
+
+    let mut row_types = Vec::with_capacity(nrows);
+    let mut rhs = Vec::with_capacity(nrows);
+    let mut rng: Option<Vec<f64>> = None;
+    for index in 0..nrows {
+        let constraint = model
+            .constraint(ConstraintId::new(index as u32))
+            .ok_or_else(|| SolverError::SolverSpecific(format!("missing constraint {index}")))?;
+        let (row_type, rhs_value, range_value) =
+            bounds_to_xpress_row(constraint.bounds.lower, constraint.bounds.upper);
+        if row_type == b'R' && rng.is_none() {
+            rng = Some(vec![0.0; index]);
+        }
+        if let Some(rng_values) = rng.as_mut() {
+            rng_values.push(range_value);
+        }
+        row_types.push(row_type);
+        rhs.push(rhs_value);
+    }
+
+    let matrix_build_start = Instant::now();
+    let XpressColumnMatrix {
+        mstart,
+        mrwind,
+        dmatval,
+    } = build_xpress_column_matrix(model, ncols, nrows, stats.coefficients)?;
     let matrix_build_seconds = matrix_build_start.elapsed().as_secs_f64();
+
+    Ok(XpressLoadData {
+        ncols,
+        nrows,
+        has_integer,
+        stats,
+        sense,
+        objective_coefficients,
+        variable_bounds,
+        row_types,
+        rhs,
+        rng,
+        matrix: XpressColumnMatrix {
+            mstart,
+            mrwind,
+            dmatval,
+        },
+        col_types,
+        int_col_indices,
+        int_col_limits,
+        matrix_build_seconds,
+        solve_started,
+    })
+}
+
+#[allow(unsafe_code)]
+fn load_prepared_problem(
+    load_data: XpressLoadData,
+    config: &SolverConfig,
+) -> Result<PreparedXpressProblem, SolverError> {
+    let XpressLoadData {
+        ncols,
+        nrows,
+        has_integer,
+        stats,
+        sense,
+        objective_coefficients,
+        variable_bounds,
+        row_types,
+        rhs,
+        rng,
+        matrix:
+            XpressColumnMatrix {
+                mstart,
+                mrwind,
+                dmatval,
+            },
+        col_types,
+        int_col_indices,
+        int_col_limits,
+        matrix_build_seconds,
+        solve_started,
+    } = load_data;
+    let objective_coefficients = objective_coefficients.into_dense(ncols);
+    let rng_ptr = rng
+        .as_ref()
+        .map_or(std::ptr::null(), |values| values.as_ptr());
+    let (lower_bounds_ptr, upper_bounds_ptr) = variable_bounds.load_ptrs();
 
     let env_guard = xprs_init()?;
     let api = env_guard.api;
@@ -598,14 +940,14 @@ fn solve_problem(
                 nrows as c_int,
                 row_types.as_ptr().cast::<c_char>(),
                 rhs.as_ptr(),
-                rng.as_ptr(),
+                rng_ptr,
                 objective_coefficients.as_ptr(),
                 mstart.as_ptr(),
                 std::ptr::null(),
                 mrwind.as_ptr(),
                 dmatval.as_ptr(),
-                lower_bounds.as_ptr(),
-                upper_bounds.as_ptr(),
+                lower_bounds_ptr,
+                upper_bounds_ptr,
                 int_col_indices.len() as c_int,
                 0,
                 col_types.as_ptr().cast::<c_char>(),
@@ -617,7 +959,7 @@ fn solve_problem(
                 std::ptr::null(),
             )
         })
-        .map_err(|rc| xpress_failure_error(api, prob, "XPRSloadmip", rc, model))?;
+        .map_err(|rc| xpress_failure_error_for_stats(api, prob, "XPRSloadmip", rc, &stats))?;
     } else {
         ffi::check_xprs(unsafe {
             (api.xprs_loadlp)(
@@ -627,18 +969,33 @@ fn solve_problem(
                 nrows as c_int,
                 row_types.as_ptr().cast::<c_char>(),
                 rhs.as_ptr(),
-                rng.as_ptr(),
+                rng_ptr,
                 objective_coefficients.as_ptr(),
                 mstart.as_ptr(),
                 std::ptr::null(),
                 mrwind.as_ptr(),
                 dmatval.as_ptr(),
-                lower_bounds.as_ptr(),
-                upper_bounds.as_ptr(),
+                lower_bounds_ptr,
+                upper_bounds_ptr,
             )
         })
-        .map_err(|rc| xpress_failure_error(api, prob, "XPRSloadlp", rc, model))?;
+        .map_err(|rc| xpress_failure_error_for_stats(api, prob, "XPRSloadlp", rc, &stats))?;
     }
+
+    drop((
+        objective_coefficients,
+        row_types,
+        rhs,
+        rng,
+        mstart,
+        mrwind,
+        dmatval,
+        col_types,
+        int_col_indices,
+        int_col_limits,
+    ));
+
+    variable_bounds.apply_deferred_changes(api, prob, &stats)?;
 
     ffi::check_xprs(unsafe {
         (api.xprs_chgobjsense)(
@@ -651,16 +1008,56 @@ fn solve_problem(
     })
     .map_err(|rc| SolverError::SolverSpecific(format!("XPRSchgobjsense failed: {rc}")))?;
 
+    Ok(PreparedXpressProblem {
+        prob_guard,
+        _env_guard: env_guard,
+        api,
+        ncols,
+        nrows,
+        has_integer,
+        stats,
+        matrix_build_seconds,
+        solve_started,
+    })
+}
+
+fn prepare_problem(
+    model: &(impl ModelView + ?Sized),
+    config: &SolverConfig,
+) -> Result<PreparedXpressProblem, SolverError> {
+    load_prepared_problem(prepare_load_data(model)?, config)
+}
+
+#[allow(unsafe_code)]
+fn finish_prepared_problem(
+    prepared: PreparedXpressProblem,
+    config: &SolverConfig,
+) -> Result<SolveArtifacts, SolverError> {
+    let api = prepared.api;
+    let prob = prepared.prob_guard.prob;
+    let ncols = prepared.ncols;
+    let nrows = prepared.nrows;
+    let has_integer = prepared.has_integer;
+    let lp_flags = lp_optimize_flags(config)?;
+    let lp_flags = lp_flags.map(CString::new).transpose().map_err(|_| {
+        SolverError::InvalidSettings("xpress.lp_algorithm contains NUL".to_string())
+    })?;
+    let lp_flags_ptr = lp_flags
+        .as_ref()
+        .map_or(std::ptr::null(), |flags| flags.as_ptr());
+
     let run_start = Instant::now();
     if has_integer {
-        ffi::check_xprs(unsafe { (api.xprs_mipoptimize)(prob, std::ptr::null()) })
-            .map_err(|rc| xpress_failure_error(api, prob, "XPRSmipoptimize", rc, model))?;
+        ffi::check_xprs(unsafe { (api.xprs_mipoptimize)(prob, std::ptr::null()) }).map_err(
+            |rc| xpress_failure_error_for_stats(api, prob, "XPRSmipoptimize", rc, &prepared.stats),
+        )?;
     } else {
-        ffi::check_xprs(unsafe { (api.xprs_lpoptimize)(prob, std::ptr::null()) })
-            .map_err(|rc| xpress_failure_error(api, prob, "XPRSlpoptimize", rc, model))?;
+        ffi::check_xprs(unsafe { (api.xprs_lpoptimize)(prob, lp_flags_ptr) }).map_err(|rc| {
+            xpress_failure_error_for_stats(api, prob, "XPRSlpoptimize", rc, &prepared.stats)
+        })?;
     }
     let run_seconds = run_start.elapsed().as_secs_f64();
-    let solve_time_seconds = solve_started.elapsed().as_secs_f64();
+    let solve_time_seconds = prepared.solve_started.elapsed().as_secs_f64();
 
     let (core_status, has_solution, status_string) = if has_integer {
         let raw = get_int_attrib(api, prob, ffi::XPRS_MIPSTATUS)?;
@@ -742,18 +1139,21 @@ fn solve_problem(
     };
     let solution_extract_seconds = extract_start.elapsed().as_secs_f64();
 
-    drop(prob_guard);
-    drop(env_guard);
-
     let mut metadata = BTreeMap::new();
-    metadata.insert("xpress_matrix_build_s".to_string(), matrix_build_seconds);
+    metadata.insert(
+        "xpress_matrix_build_s".to_string(),
+        prepared.matrix_build_seconds,
+    );
     metadata.insert("xpress_run_s".to_string(), run_seconds);
     metadata.insert("solution_extract_s".to_string(), solution_extract_seconds);
-    metadata.insert("num_variables".to_string(), ncols as f64);
-    metadata.insert("num_constraints".to_string(), nrows as f64);
+    metadata.insert("num_variables".to_string(), prepared.stats.variables as f64);
+    metadata.insert(
+        "num_constraints".to_string(),
+        prepared.stats.constraints as f64,
+    );
     metadata.insert(
         "num_coefficients".to_string(),
-        model.num_coefficients() as f64,
+        prepared.stats.coefficients as f64,
     );
 
     Ok(SolveArtifacts {
@@ -769,6 +1169,13 @@ fn solve_problem(
         },
         metadata,
     })
+}
+
+fn solve_problem(
+    model: &(impl ModelView + ?Sized),
+    config: &SolverConfig,
+) -> Result<SolveArtifacts, SolverError> {
+    finish_prepared_problem(prepare_problem(model, config)?, config)
 }
 
 /// Xpress backend registration object for primitive model views.
@@ -794,6 +1201,34 @@ pub fn solve_model_view(
     model: &(impl ModelView + ?Sized),
     config: &SolverConfig,
 ) -> Result<ModelViewSolveResult, SolverError> {
+    let prepared = prepare_model_view_solve(model, config)?;
+    let result = finish_prepared_model_view_solve(prepared, config)?;
+    validate_model_view_solve_result_with_config(model, &result, config)?;
+    Ok(result)
+}
+
+/// Solve an owned core model with Xpress, allowing callers to release Arco
+/// model memory after the Xpress problem has been loaded.
+pub fn solve_owned_model(
+    mut model: arco_model::Model,
+    config: &SolverConfig,
+) -> Result<ModelViewSolveResult, SolverError> {
+    let prepared_load = prepare_owned_model_view_load(&mut model, config)?;
+    drop(model);
+    let prepared = PreparedModelViewSolve {
+        problem: load_prepared_problem(prepared_load.load_data, config)?,
+        fingerprint: prepared_load.fingerprint,
+        fingerprint_seconds: prepared_load.fingerprint_seconds,
+        num_variables: prepared_load.num_variables,
+        num_constraints: prepared_load.num_constraints,
+    };
+    finish_prepared_model_view_solve(prepared, config)
+}
+
+fn prepare_model_view_load(
+    model: &(impl ModelView + ?Sized),
+    config: &SolverConfig,
+) -> Result<PreparedModelViewLoad, SolverError> {
     if model.num_variables() == 0 {
         return Err(SolverError::EmptyModel);
     }
@@ -801,10 +1236,7 @@ pub fn solve_model_view(
         return Err(SolverError::NoObjective);
     }
 
-    let SolveArtifacts {
-        solution,
-        mut metadata,
-    } = solve_problem(model, config)?;
+    let load_data = prepare_load_data(model)?;
 
     let fingerprint_start = Instant::now();
     let fingerprint = if config
@@ -816,23 +1248,147 @@ pub fn solve_model_view(
     } else {
         ModelFingerprint(0)
     };
-    metadata.insert(
-        "fingerprint_s".to_string(),
-        fingerprint_start.elapsed().as_secs_f64(),
-    );
+    let fingerprint_seconds = fingerprint_start.elapsed().as_secs_f64();
+
+    Ok(PreparedModelViewLoad {
+        num_variables: load_data.stats.variables,
+        num_constraints: load_data.stats.constraints,
+        load_data,
+        fingerprint,
+        fingerprint_seconds,
+    })
+}
+
+fn prepare_owned_model_view_load(
+    model: &mut arco_model::Model,
+    config: &SolverConfig,
+) -> Result<PreparedModelViewLoad, SolverError> {
+    if model.num_variables() == 0 {
+        return Err(SolverError::EmptyModel);
+    }
+    if model.objective().sense.is_none() && model.objective().terms.is_empty() {
+        return Err(SolverError::NoObjective);
+    }
+
+    let fingerprint_start = Instant::now();
+    let fingerprint = if config
+        .parameters
+        .get("arco.fingerprint")
+        .is_none_or(|value| value != "false")
+    {
+        model.fingerprint()
+    } else {
+        ModelFingerprint(0)
+    };
+    let fingerprint_seconds = fingerprint_start.elapsed().as_secs_f64();
+
+    let mut objective_terms = model.take_objective_terms_for_consumed_solve();
+    retain_active_objective_terms(model, &mut objective_terms, model.num_variables())?;
+    let load_data = prepare_load_data_with_objective(
+        model,
+        XpressObjectiveCoefficients::Sparse(objective_terms),
+    )?;
+
+    Ok(PreparedModelViewLoad {
+        num_variables: load_data.stats.variables,
+        num_constraints: load_data.stats.constraints,
+        load_data,
+        fingerprint,
+        fingerprint_seconds,
+    })
+}
+
+fn prepare_model_view_solve(
+    model: &(impl ModelView + ?Sized),
+    config: &SolverConfig,
+) -> Result<PreparedModelViewSolve, SolverError> {
+    let prepared_load = prepare_model_view_load(model, config)?;
+    Ok(PreparedModelViewSolve {
+        problem: load_prepared_problem(prepared_load.load_data, config)?,
+        fingerprint: prepared_load.fingerprint,
+        fingerprint_seconds: prepared_load.fingerprint_seconds,
+        num_variables: prepared_load.num_variables,
+        num_constraints: prepared_load.num_constraints,
+    })
+}
+
+fn finish_prepared_model_view_solve(
+    prepared: PreparedModelViewSolve,
+    config: &SolverConfig,
+) -> Result<ModelViewSolveResult, SolverError> {
+    let fingerprint = prepared.fingerprint;
+    let fingerprint_seconds = prepared.fingerprint_seconds;
+    let num_variables = prepared.num_variables;
+    let num_constraints = prepared.num_constraints;
+    let SolveArtifacts {
+        solution,
+        mut metadata,
+    } = finish_prepared_problem(prepared.problem, config)?;
+    metadata.insert("fingerprint_s".to_string(), fingerprint_seconds);
 
     let result = ModelViewSolveResult {
         fingerprint,
-        status: solution.core_status(),
-        objective_value: solution.objective_value(),
-        primal_values: solution.primal_values().to_vec(),
-        variable_duals: solution.variable_duals().to_vec(),
-        row_values: solution.row_values.clone(),
-        constraint_duals: solution.constraint_duals().to_vec(),
+        status: solution.core_status,
+        objective_value: solution.objective_value,
+        primal_values: solution.primal_values,
+        variable_duals: solution.variable_duals,
+        row_values: solution.row_values,
+        constraint_duals: solution.constraint_duals,
         metadata,
     };
-    validate_model_view_solve_result(model, &result)?;
+    validate_result_shape_counts(&result, config, num_variables, num_constraints)?;
     Ok(result)
+}
+
+fn validate_result_shape_counts(
+    result: &ModelViewSolveResult,
+    config: &SolverConfig,
+    num_variables: usize,
+    num_constraints: usize,
+) -> Result<(), SolverError> {
+    let allow_omitted_primal_values = config
+        .parameters
+        .get("arco.extract_solution")
+        .is_some_and(|value| value == "false");
+    if allow_omitted_primal_values {
+        validate_optional_result_len("primal_values", result.primal_values.len(), num_variables)?;
+    } else {
+        validate_required_result_len("primal_values", result.primal_values.len(), num_variables)?;
+    }
+    validate_optional_result_len("variable_duals", result.variable_duals.len(), num_variables)?;
+    validate_optional_result_len("row_values", result.row_values.len(), num_constraints)?;
+    validate_optional_result_len(
+        "constraint_duals",
+        result.constraint_duals.len(),
+        num_constraints,
+    )?;
+    Ok(())
+}
+
+fn validate_required_result_len(
+    name: &str,
+    actual: usize,
+    expected: usize,
+) -> Result<(), SolverError> {
+    if actual == expected {
+        return Ok(());
+    }
+    Err(SolverError::InvalidResultShape(format!(
+        "{name} length {actual} does not match expected {expected}"
+    )))
+}
+
+fn validate_optional_result_len(
+    name: &str,
+    actual: usize,
+    expected: usize,
+) -> Result<(), SolverError> {
+    if actual == 0 || actual == expected {
+        return Ok(());
+    }
+    Err(SolverError::InvalidResultShape(format!(
+        "{name} length {actual} must be 0 or match expected {expected}"
+    )))
 }
 
 pub struct Solver<'model> {
@@ -956,6 +1512,28 @@ mod tests {
     }
 
     #[test]
+    fn owned_model_solver_rejects_empty_model_before_runtime_setup() {
+        let model = Model::new();
+        let error = solve_owned_model(model, &SolverConfig::new())
+            .expect_err("owned Xpress solve should reject an empty model");
+
+        assert!(matches!(error, SolverError::EmptyModel));
+    }
+
+    #[test]
+    fn owned_model_solver_rejects_no_objective_model_before_runtime_setup() {
+        let mut model = Model::new();
+        model
+            .add_variable(Variable::continuous(Bounds::new(0.0, 1.0)))
+            .expect("variable");
+
+        let error = solve_owned_model(model, &SolverConfig::new())
+            .expect_err("owned Xpress solve should reject missing objective");
+
+        assert!(matches!(error, SolverError::NoObjective));
+    }
+
+    #[test]
     fn solver_wrapper_rejects_empty_model() {
         let model = Model::new();
         assert!(matches!(Solver::new(&model), Err(SolverError::EmptyModel)));
@@ -982,6 +1560,244 @@ mod tests {
         assert_eq!(solver.config().threads, Some(2));
         assert_eq!(solver.config().time_limit, Some(5.0));
         assert_eq!(solver.config().log_to_console, Some(false));
+    }
+
+    #[test]
+    fn xpress_column_matrix_reserves_known_coefficient_count() {
+        let mut model = Model::new();
+        let x = model
+            .add_variable(Variable::continuous(Bounds::new(0.0, f64::INFINITY)))
+            .expect("x variable");
+        let y = model
+            .add_variable(Variable::continuous(Bounds::new(0.0, f64::INFINITY)))
+            .expect("y variable");
+        let first = model
+            .add_constraint(Constraint {
+                bounds: Bounds::new(1.0, f64::INFINITY),
+            })
+            .expect("first constraint");
+        let second = model
+            .add_constraint(Constraint {
+                bounds: Bounds::new(f64::NEG_INFINITY, 3.0),
+            })
+            .expect("second constraint");
+        model.set_coefficient(x, first, 1.5).expect("x first");
+        model.set_coefficient(x, second, -2.0).expect("x second");
+        model.set_coefficient(y, second, 4.0).expect("y second");
+
+        let matrix = build_xpress_column_matrix(
+            &model,
+            model.num_variables(),
+            model.num_constraints(),
+            model.num_coefficients(),
+        )
+        .expect("matrix build");
+
+        assert!(matrix.mrwind.capacity() >= model.num_coefficients());
+        assert!(matrix.dmatval.capacity() >= model.num_coefficients());
+        assert_eq!(matrix.mstart, vec![0, 2, 3]);
+        assert_eq!(matrix.mrwind, vec![0, 1, 1]);
+        assert_eq!(matrix.dmatval, vec![1.5, -2.0, 4.0]);
+    }
+
+    #[test]
+    fn xpress_load_data_builds_without_runtime_initialization() {
+        let model = build_simple_model();
+
+        let load_data = prepare_load_data(&model).expect("load data should build");
+
+        assert_eq!(load_data.ncols, model.num_variables());
+        assert_eq!(load_data.nrows, model.num_constraints());
+        assert!(!load_data.has_integer);
+        assert_eq!(load_data.stats.variables, 1);
+        assert_eq!(load_data.stats.constraints, 1);
+        assert_eq!(load_data.stats.coefficients, 1);
+        assert_eq!(load_data.objective_coefficients.into_dense(1), vec![2.0]);
+        match &load_data.variable_bounds {
+            XpressVariableBounds::DefaultNonnegativeWithUpperChanges {
+                upper_indices,
+                upper_types,
+                upper_values,
+            } => {
+                assert!(upper_indices.is_empty());
+                assert!(upper_types.is_empty());
+                assert!(upper_values.is_empty());
+            }
+            XpressVariableBounds::Full { .. } => {
+                panic!("default nonnegative LP should not allocate full bound arrays")
+            }
+        }
+        assert_eq!(load_data.row_types, vec![b'G']);
+        assert_eq!(load_data.rhs, vec![1.0]);
+        assert!(load_data.rng.is_none());
+        assert_eq!(load_data.matrix.mstart, vec![0, 1]);
+        assert_eq!(load_data.matrix.mrwind, vec![0]);
+        assert_eq!(load_data.matrix.dmatval, vec![1.0]);
+    }
+
+    #[test]
+    fn xpress_load_data_defers_only_finite_upper_bound_changes() {
+        let mut model = Model::new();
+        let x = model
+            .add_variable(Variable::continuous(Bounds::new(0.0, 7.0)))
+            .expect("bounded variable");
+        let y = model
+            .add_variable(Variable::continuous(Bounds::new(0.0, f64::INFINITY)))
+            .expect("unbounded variable");
+        let demand = model
+            .add_constraint(Constraint {
+                bounds: Bounds::new(1.0, f64::INFINITY),
+            })
+            .expect("constraint");
+        model
+            .set_coefficient(x, demand, 1.0)
+            .expect("x coefficient");
+        model
+            .set_coefficient(y, demand, 1.0)
+            .expect("y coefficient");
+        model
+            .set_objective(Objective {
+                sense: Some(Sense::Minimize),
+                terms: vec![(x, 1.0), (y, 1.0)],
+            })
+            .expect("objective");
+
+        let load_data = prepare_load_data(&model).expect("load data should build");
+
+        match &load_data.variable_bounds {
+            XpressVariableBounds::DefaultNonnegativeWithUpperChanges {
+                upper_indices,
+                upper_types,
+                upper_values,
+            } => {
+                assert_eq!(upper_indices, &vec![0]);
+                assert_eq!(upper_types, &vec![b'U']);
+                assert_eq!(upper_values, &vec![7.0]);
+            }
+            XpressVariableBounds::Full { .. } => {
+                panic!("finite upper bounds should be deferred for default nonnegative LPs")
+            }
+        }
+    }
+
+    #[test]
+    fn xpress_load_data_uses_full_bounds_for_nonzero_lower_bounds() {
+        let mut model = Model::new();
+        let x = model
+            .add_variable(Variable::continuous(Bounds::new(-1.0, 7.0)))
+            .expect("bounded variable");
+        let demand = model
+            .add_constraint(Constraint {
+                bounds: Bounds::new(1.0, f64::INFINITY),
+            })
+            .expect("constraint");
+        model.set_coefficient(x, demand, 1.0).expect("coefficient");
+        model
+            .set_objective(Objective {
+                sense: Some(Sense::Minimize),
+                terms: vec![(x, 1.0)],
+            })
+            .expect("objective");
+
+        let load_data = prepare_load_data(&model).expect("load data should build");
+
+        match &load_data.variable_bounds {
+            XpressVariableBounds::Full {
+                lower_bounds,
+                upper_bounds,
+            } => {
+                assert_eq!(lower_bounds, &vec![-1.0]);
+                assert_eq!(upper_bounds, &vec![7.0]);
+            }
+            XpressVariableBounds::DefaultNonnegativeWithUpperChanges { .. } => {
+                panic!("nonzero lower bounds require full bound arrays")
+            }
+        }
+    }
+
+    #[test]
+    fn xpress_load_data_allocates_range_values_only_for_ranged_rows() {
+        let mut model = Model::new();
+        let x = model
+            .add_variable(Variable::continuous(Bounds::new(0.0, f64::INFINITY)))
+            .expect("variable");
+        let lower_only = model
+            .add_constraint(Constraint {
+                bounds: Bounds::new(1.0, f64::INFINITY),
+            })
+            .expect("lower-only constraint");
+        let ranged = model
+            .add_constraint(Constraint {
+                bounds: Bounds::new(2.0, 5.0),
+            })
+            .expect("ranged constraint");
+        model
+            .set_coefficient(x, lower_only, 1.0)
+            .expect("lower coefficient");
+        model
+            .set_coefficient(x, ranged, 1.0)
+            .expect("ranged coefficient");
+        model
+            .set_objective(Objective {
+                sense: Some(Sense::Minimize),
+                terms: vec![(x, 2.0)],
+            })
+            .expect("objective");
+
+        let load_data = prepare_load_data(&model).expect("load data should build");
+
+        assert_eq!(load_data.row_types, vec![b'G', b'R']);
+        assert_eq!(load_data.rhs, vec![1.0, 2.0]);
+        assert_eq!(load_data.rng, Some(vec![0.0, 3.0]));
+    }
+
+    #[test]
+    fn owned_xpress_load_data_drains_sparse_objective_without_runtime_initialization() {
+        let mut model = Model::new();
+        let active = model
+            .add_variable(Variable::continuous(Bounds::new(0.0, f64::INFINITY)))
+            .expect("active variable");
+        let inactive = model
+            .add_variable(Variable {
+                bounds: Bounds::new(0.0, f64::INFINITY),
+                is_integer: false,
+                is_active: false,
+            })
+            .expect("inactive variable");
+        let demand = model
+            .add_constraint(Constraint {
+                bounds: Bounds::new(1.0, f64::INFINITY),
+            })
+            .expect("constraint");
+        model
+            .set_coefficient(active, demand, 1.0)
+            .expect("coefficient");
+        model
+            .set_objective(Objective {
+                sense: Some(Sense::Minimize),
+                terms: vec![(active, 2.0), (inactive, 7.0)],
+            })
+            .expect("objective");
+
+        let prepared = prepare_owned_model_view_load(
+            &mut model,
+            &SolverConfig::new().with_parameter("arco.fingerprint", "false"),
+        )
+        .expect("owned load data should build");
+
+        assert!(model.objective().terms.is_empty());
+        match &prepared.load_data.objective_coefficients {
+            XpressObjectiveCoefficients::Sparse(terms) => {
+                assert_eq!(terms.as_slice(), &[(active, 2.0)]);
+            }
+            XpressObjectiveCoefficients::Dense(_) => {
+                panic!("owned load data should retain sparse objective terms")
+            }
+        }
+        assert_eq!(
+            prepared.load_data.objective_coefficients.into_dense(2),
+            vec![2.0, 0.0]
+        );
     }
 
     #[test]
@@ -1015,6 +1831,45 @@ mod tests {
         assert!(matches!(
             error,
             SolverError::InvalidSettings(message) if message == "threads must be >= 1"
+        ));
+    }
+
+    #[test]
+    fn maps_xpress_lp_algorithm_parameter_to_optimizer_flags() {
+        for (value, expected) in [
+            ("auto", None),
+            ("", None),
+            ("primal", Some("p")),
+            ("p", Some("p")),
+            ("dual", Some("d")),
+            ("d", Some("d")),
+            ("barrier", Some("b")),
+            ("b", Some("b")),
+            ("primal_barrier", Some("pb")),
+            ("dual_barrier", Some("db")),
+            ("primal_dual", Some("pd")),
+            ("all", Some("pdb")),
+        ] {
+            let config = SolverConfig::new().with_parameter("xpress.lp_algorithm", value);
+
+            let flags = lp_optimize_flags(&config).expect("algorithm should be accepted");
+
+            assert_eq!(flags, expected);
+        }
+    }
+
+    #[test]
+    fn rejects_invalid_xpress_lp_algorithm_parameter_before_runtime_setup() {
+        let config = SolverConfig::new().with_parameter("xpress.lp_algorithm", "not-an-algorithm");
+
+        let error =
+            validate_solver_config(&config).expect_err("invalid LP algorithm should be rejected");
+
+        assert!(matches!(
+            error,
+            SolverError::InvalidSettings(message)
+                if message.contains("xpress.lp_algorithm")
+                    && message.contains("not-an-algorithm")
         ));
     }
 

--- a/docs/how-to/building-optimization-models.md
+++ b/docs/how-to/building-optimization-models.md
@@ -2,6 +2,22 @@
 
 This guide covers the core operations for constructing linear and mixed-integer optimization problems with arco.
 
+## Preallocate Large Models
+
+Use `model.reserve()` when you know approximate variable and constraint counts
+before construction. It preallocates internal storage without adding model
+objects, reducing transient allocation pressure in large array-built models.
+
+```python doctest
+>>> import arco
+>>> model = arco.Model()
+>>> model.reserve(num_variables=1000, num_constraints=500)
+>>> model.num_variables
+0
+>>> model.num_constraints
+0
+```
+
 ## Variables
 
 Use `model.add_variable()` to create decision variables with bounds, integrality, or binary restrictions.

--- a/examples/reeds-benchmark/formulation.py
+++ b/examples/reeds-benchmark/formulation.py
@@ -14,9 +14,14 @@ from __future__ import annotations
 import argparse
 import gc
 import json
-import resource
+import sys
 import time
 from typing import NotRequired, TypedDict
+
+try:
+    import resource
+except ModuleNotFoundError:  # pragma: no cover - resource is unavailable on Windows.
+    resource = None
 
 import arco
 import numpy as np
@@ -27,8 +32,8 @@ from data_generator import SIZES, ProblemData, make_problem
 class BuildStage(TypedDict):
     stage: str
     seconds: float
-    rss_mb: float
-    delta_rss_mb: float
+    rss_mb: float | None
+    delta_rss_mb: float | None
 
 
 LAST_BUILD_PROFILE: list[BuildStage] = []
@@ -59,23 +64,39 @@ def _constraint_reserve_count(data: ProblemData) -> int:
     return max(0, data.n_constraints - transmission_bound_rows + 1024)
 
 
-def _current_rss_mb() -> float:
+def _current_rss_mb() -> float | None:
     try:
         with open("/proc/self/status", encoding="utf-8") as status:
             for line in status:
                 if line.startswith("VmRSS:"):
                     return float(line.split()[1]) / 1024.0
     except OSError:
-        return 0.0
-    return 0.0
+        return None
+    return None
 
 
-def _peak_rss_mb() -> float:
+def _ru_maxrss_to_mb(max_rss: float, platform: str = sys.platform) -> float:
+    if platform == "darwin":
+        return max_rss / (1024.0 * 1024.0)
+    return max_rss / 1024.0
+
+
+def _peak_rss_mb() -> float | None:
+    if resource is None:
+        return None
     max_rss = max(
         float(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss),
         float(resource.getrusage(resource.RUSAGE_CHILDREN).ru_maxrss),
     )
-    return max_rss / 1024.0
+    if max_rss <= 0.0:
+        return None
+    return _ru_maxrss_to_mb(max_rss)
+
+
+def _format_rss_mb(value: float | None) -> str:
+    if value is None:
+        return "n/a"
+    return f"{value:.1f} MB"
 
 
 def solve(
@@ -130,12 +151,15 @@ def solve(
         if not profile_build:
             return
         rss_mb = _current_rss_mb()
+        delta_rss_mb = (
+            None if rss_mb is None or last_rss_mb is None else rss_mb - last_rss_mb
+        )
         build_profile.append(
             {
                 "stage": stage,
                 "seconds": time.perf_counter() - t0,
                 "rss_mb": rss_mb,
-                "delta_rss_mb": rss_mb - last_rss_mb,
+                "delta_rss_mb": delta_rss_mb,
             }
         )
         last_rss_mb = rss_mb
@@ -388,7 +412,7 @@ class ReedsPayload(TypedDict):
     objective_value: NotRequired[float | None]
     build_seconds: float
     solve_seconds: float
-    peak_rss_mb: float
+    peak_rss_mb: float | None
     status: NotRequired[str]
     build_profile: NotRequired[list[BuildStage]]
     matrix_profile: NotRequired[dict[str, object]]
@@ -515,19 +539,19 @@ def main() -> int:
     elif args.build_only:
         print(
             f"reeds-benchmark built: size={args.size}, {problem.summary()}, "
-            f"build={build_s:.3f}s, peak={payload['peak_rss_mb']:.1f} MB"
+            f"build={build_s:.3f}s, peak={_format_rss_mb(payload['peak_rss_mb'])}"
         )
     elif not solved:
         print(
             f"reeds-benchmark finished: size={args.size}, status={LAST_SOLVE_STATUS}, "
             f"obj={_format_objective_value(obj)}, build={build_s:.3f}s, solve={solve_s:.3f}s, "
-            f"peak={payload['peak_rss_mb']:.1f} MB"
+            f"peak={_format_rss_mb(payload['peak_rss_mb'])}"
         )
     else:
         print(
             f"reeds-benchmark solved: size={args.size}, obj={_format_objective_value(obj)}, "
             f"build={build_s:.3f}s, solve={solve_s:.3f}s, "
-            f"peak={payload['peak_rss_mb']:.1f} MB"
+            f"peak={_format_rss_mb(payload['peak_rss_mb'])}"
         )
     return 0
 

--- a/examples/reeds-benchmark/formulation.py
+++ b/examples/reeds-benchmark/formulation.py
@@ -35,6 +35,23 @@ LAST_BUILD_PROFILE: list[BuildStage] = []
 LAST_MATRIX_PROFILE: dict[str, object] = {}
 LAST_SOLVE_METADATA: dict[str, float] = {}
 LAST_SOLVE_STATUS: str | None = None
+HIGHS_PRIMAL_SOLUTION_FEASIBLE = 2.0
+
+
+def _objective_value_for_reporting(
+    objective_value: float, solve_metadata: dict[str, float]
+) -> float:
+    """Return NaN when HiGHS has not reported a feasible primal solution."""
+    primal_status = solve_metadata.get("highs_primal_solution_status")
+    if primal_status is not None and primal_status != HIGHS_PRIMAL_SOLUTION_FEASIBLE:
+        return float("nan")
+    return objective_value
+
+
+def _format_objective_value(objective_value: float) -> str:
+    if objective_value != objective_value:
+        return "n/a"
+    return f"{objective_value:,.0f}"
 
 
 def _constraint_reserve_count(data: ProblemData) -> int:
@@ -357,7 +374,10 @@ def solve(
     LAST_SOLVE_STATUS = str(result.status)
     if require_optimal and not result.is_optimal():
         raise RuntimeError(f"HiGHS did not find an optimal solution: {result.status}")
-    return float(result.objective_value), build_s, solve_s
+    objective_value = _objective_value_for_reporting(
+        float(result.objective_value), LAST_SOLVE_METADATA
+    )
+    return objective_value, build_s, solve_s
 
 
 class ReedsPayload(TypedDict):
@@ -365,7 +385,7 @@ class ReedsPayload(TypedDict):
     size: str
     summary: str
     solved: bool
-    objective_value: NotRequired[float]
+    objective_value: NotRequired[float | None]
     build_seconds: float
     solve_seconds: float
     peak_rss_mb: float
@@ -481,7 +501,7 @@ def main() -> int:
         "peak_rss_mb": _peak_rss_mb(),
     }
     if not args.build_only:
-        payload["objective_value"] = obj
+        payload["objective_value"] = None if obj != obj else obj
         if LAST_SOLVE_STATUS is not None:
             payload["status"] = LAST_SOLVE_STATUS
         payload["solve_metadata"] = LAST_SOLVE_METADATA
@@ -500,12 +520,12 @@ def main() -> int:
     elif not solved:
         print(
             f"reeds-benchmark finished: size={args.size}, status={LAST_SOLVE_STATUS}, "
-            f"obj={obj:,.0f}, build={build_s:.3f}s, solve={solve_s:.3f}s, "
+            f"obj={_format_objective_value(obj)}, build={build_s:.3f}s, solve={solve_s:.3f}s, "
             f"peak={payload['peak_rss_mb']:.1f} MB"
         )
     else:
         print(
-            f"reeds-benchmark solved: size={args.size}, obj={obj:,.0f}, "
+            f"reeds-benchmark solved: size={args.size}, obj={_format_objective_value(obj)}, "
             f"build={build_s:.3f}s, solve={solve_s:.3f}s, "
             f"peak={payload['peak_rss_mb']:.1f} MB"
         )

--- a/examples/reeds-benchmark/formulation.py
+++ b/examples/reeds-benchmark/formulation.py
@@ -12,7 +12,9 @@
 from __future__ import annotations
 
 import argparse
+import gc
 import json
+import resource
 import time
 from typing import NotRequired, TypedDict
 
@@ -22,15 +24,72 @@ import numpy as np
 from data_generator import SIZES, ProblemData, make_problem
 
 
+class BuildStage(TypedDict):
+    stage: str
+    seconds: float
+    rss_mb: float
+    delta_rss_mb: float
+
+
+LAST_BUILD_PROFILE: list[BuildStage] = []
+LAST_MATRIX_PROFILE: dict[str, object] = {}
+LAST_SOLVE_METADATA: dict[str, float] = {}
+LAST_SOLVE_STATUS: str | None = None
+
+
+def _constraint_reserve_count(data: ProblemData) -> int:
+    transmission_bound_rows = len(data.routes) * len(data.hours) * len(data.years)
+    return max(0, data.n_constraints - transmission_bound_rows + 1024)
+
+
+def _current_rss_mb() -> float:
+    try:
+        with open("/proc/self/status", encoding="utf-8") as status:
+            for line in status:
+                if line.startswith("VmRSS:"):
+                    return float(line.split()[1]) / 1024.0
+    except OSError:
+        return 0.0
+    return 0.0
+
+
+def _peak_rss_mb() -> float:
+    max_rss = max(
+        float(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss),
+        float(resource.getrusage(resource.RUSAGE_CHILDREN).ru_maxrss),
+    )
+    return max_rss / 1024.0
+
+
 def solve(
-    data: ProblemData, solver: str = "highs", build_only: bool = False
+    data: ProblemData,
+    solver: str = "highs",
+    build_only: bool = False,
+    profile_build: bool = False,
+    profile_matrix: bool = False,
+    time_limit: float | None = None,
+    presolve: bool | None = None,
+    threads: int | None = None,
+    highs_solver: str = "ipm",
+    highs_run_crossover: str | None = None,
+    highs_load_path: str | None = None,
+    require_optimal: bool = True,
 ) -> tuple[float, float, float]:
     if solver != "highs":
         raise ValueError("solve only supports solver='highs'")
 
+    global LAST_SOLVE_METADATA
+    global LAST_SOLVE_STATUS
+    LAST_SOLVE_METADATA = {}
+    LAST_SOLVE_STATUS = None
+
     regions, techs, hours, years = data.regions, data.techs, data.hours, data.years
     region_index = data.r_idx
     total_hours_weight = float(np.sum(data.hours_weight))
+    tranloss_factor = 1.0 - float(data.tranloss)
+    reserve_margin_factor = 1.0 + float(data.prm)
+    duration_h = float(data.duration_h)
+    charge_eff = float(data.charge_eff)
 
     route_active_matrix = np.zeros((len(regions), len(regions)), dtype=bool)
     transcap_matrix = np.zeros((len(regions), len(regions)), dtype=float)
@@ -42,8 +101,31 @@ def solve(
 
     t0 = time.perf_counter()
     model = arco.Model()
+    model.reserve(
+        num_variables=data.n_vars,
+        num_constraints=_constraint_reserve_count(data),
+    )
+    build_profile: list[BuildStage] = []
+    last_rss_mb = _current_rss_mb()
 
-    I = arco.IndexSet(name="i", members=techs)
+    def mark(stage: str) -> None:
+        nonlocal last_rss_mb
+        if not profile_build:
+            return
+        rss_mb = _current_rss_mb()
+        build_profile.append(
+            {
+                "stage": stage,
+                "seconds": time.perf_counter() - t0,
+                "rss_mb": rss_mb,
+                "delta_rss_mb": rss_mb - last_rss_mb,
+            }
+        )
+        last_rss_mb = rss_mb
+
+    mark("model")
+
+    I = arco.IndexSet(name="i", members=techs)  # noqa: E741
     R = arco.IndexSet(name="r", members=regions)
     H = arco.IndexSet(name="h", members=hours)
     T = arco.IndexSet(name="t", members=years)
@@ -74,6 +156,8 @@ def solve(
 
     route_active = arco.param(route_active_matrix, axes=(R_from, R_to))
     transcap = arco.param(transcap_matrix, axes=(R_from, R_to))
+    del route_active_matrix, transcap_matrix
+    mark("sets_and_params")
 
     cap = model.add_variables(
         axes=(I, R, T),
@@ -99,6 +183,7 @@ def solve(
         active=route_active,
         name="FLOW",
     )
+    del route_active, transcap
     rampup = model.add_variables(
         axes=(I, R, H_ramp, T),
         bounds=arco.NonNegativeFloat,
@@ -117,89 +202,160 @@ def solve(
         active=storage_active,
         name="SOC",
     )
+    mark("variables")
 
     model.add_constraints(
         cap == cap_init + np.cumsum(inv, axis=T),
         name="eq_cap_accum",
     )
+    mark("eq_cap_accum")
+    del cap_init
     model.add_constraints(
         gen <= cf * cap,
         name="eq_cap_limit",
     )
+    mark("eq_cap_limit")
+    del cf
     model.add_constraints(
         gen >= minloadfrac * cap,
         active=valcap & (minloadfrac > 0) & ~is_storage,
         name="eq_mingen",
     )
+    mark("eq_mingen")
+    del minloadfrac, is_vre
 
     gen_by_region = gen @ I
     charge_by_region = charge @ I
-    tranloss_factor = 1.0 - float(data.tranloss)
-    for r_idx, region in enumerate(regions):
-        for h_idx, hour in enumerate(hours):
-            for t_idx, year in enumerate(years):
-                imports = tranloss_factor * flow[:, r_idx, h_idx, t_idx].sum()
-                exports = flow[r_idx, :, h_idx, t_idx].sum()
-                model.add_constraint(
-                    gen_by_region[r_idx, h_idx, t_idx]
-                    + imports
-                    - exports
-                    - charge_by_region[r_idx, h_idx, t_idx]
-                    == load[r_idx, h_idx, t_idx],
-                    name=f"eq_supply_demand_balance[{region},{hour},{year}]",
-                )
+    imports_by_region = (flow @ R_from).relabel_axis(R_to, R)
+    exports_by_region = (flow @ R_to).relabel_axis(R_from, R)
     model.add_constraints(
-        (cap @ I) >= (1.0 + float(data.prm)) * peak_load,
+        gen_by_region
+        + tranloss_factor * imports_by_region
+        - exports_by_region
+        - charge_by_region
+        == load,
+        name="eq_supply_demand_balance",
+    )
+    mark("eq_supply_demand_balance")
+    del (
+        gen_by_region,
+        charge_by_region,
+        imports_by_region,
+        exports_by_region,
+        flow,
+        load,
+    )
+    model.add_constraints(
+        (cap @ I) >= reserve_margin_factor * peak_load,
         name="eq_reserve_margin",
     )
+    mark("eq_reserve_margin")
+    del peak_load
     model.add_constraints(
         (emit_rate * hours_weight * gen) @ (I, R, H) <= emit_cap,
         name="eq_emit_cap",
     )
+    mark("eq_emit_cap")
+    del emit_rate, emit_cap
     model.add_constraints(
         rampup >= np.diff(gen, axis=H),
         active=dispatch_active,
         name="eq_ramping",
     )
+    mark("eq_ramping")
+    del dispatch_active, is_dispatch
     model.add_constraints(
         (hours_weight * gen) @ H >= min_cf * total_hours_weight * cap,
         active=valcap & (min_cf > 0),
         name="eq_min_cf",
     )
+    mark("eq_min_cf")
+    del min_cf, total_hours_weight
     model.add_constraints(
-        soc <= float(data.duration_h) * cap,
+        soc <= duration_h * cap,
         active=storage_active,
         name="eq_soc_cap",
     )
+    mark("eq_soc_cap")
     model.add_constraints(
         charge <= cap,
         active=storage_active,
         name="eq_charge_cap",
     )
+    mark("eq_charge_cap")
+    del cap
     model.add_constraints(
-        np.roll(soc, -1, axis=H) == soc + float(data.charge_eff) * charge - gen,
+        np.roll(soc, -1, axis=H) == soc + charge_eff * charge - gen,
         active=storage_active,
         name="eq_soc",
     )
+    mark("eq_soc")
+    del charge, soc, storage_active, is_storage
 
     objective = (pvf * cost_inv * inv).sum()
-    objective += (pvf * cost_op * hours_weight * gen).sum()
-    objective += (pvf * startcost * rampup).sum()
     model.minimize(objective)
+    del objective, cost_inv, inv
+    objective = (pvf * cost_op * hours_weight * gen).sum()
+    model.add_objective_terms(objective)
+    del objective, cost_op, gen, hours_weight
+    objective = (pvf * startcost * rampup).sum()
+    model.add_objective_terms(objective)
+    del objective, rampup, startcost, pvf
+    global LAST_MATRIX_PROFILE
+    LAST_MATRIX_PROFILE = model.matrix_profile() if profile_matrix else {}
+    mark("objective")
 
     build_s = time.perf_counter() - t0
+    global LAST_BUILD_PROFILE
+    LAST_BUILD_PROFILE = build_profile
     if build_only:
         return float("nan"), build_s, 0.0
 
-    t1 = time.perf_counter()
-    result = model.solve(
-        solver=arco.HiGHS(
-            log_to_console=False,
-            parameters={"solver": "ipm", "arco.fingerprint": "false"},
-        )
+    del (
+        data,
+        valcap,
+        I,
+        R,
+        H,
+        T,
+        H_ramp,
+        R_from,
+        R_to,
+        regions,
+        techs,
+        hours,
+        years,
+        region_index,
     )
+    gc.collect()
+    mark("cleanup")
+    build_s = time.perf_counter() - t0
+
+    t1 = time.perf_counter()
+    highs_kwargs = {
+        "log_to_console": False,
+        "parameters": {
+            "solver": highs_solver,
+            "arco.consume_model": "true",
+            "arco.fingerprint": "false",
+            "arco.extract_solution": "false",
+        },
+    }
+    if time_limit is not None:
+        highs_kwargs["time_limit"] = time_limit
+    if presolve is not None:
+        highs_kwargs["presolve"] = presolve
+    if threads is not None:
+        highs_kwargs["threads"] = threads
+    if highs_run_crossover is not None:
+        highs_kwargs["parameters"]["run_crossover"] = highs_run_crossover
+    if highs_load_path is not None:
+        highs_kwargs["parameters"]["arco.highs_load_path"] = highs_load_path
+    result = model.solve(solver=arco.HiGHS(**highs_kwargs))
     solve_s = time.perf_counter() - t1
-    if not result.is_optimal():
+    LAST_SOLVE_METADATA = dict(result.metadata)
+    LAST_SOLVE_STATUS = str(result.status)
+    if require_optimal and not result.is_optimal():
         raise RuntimeError(f"HiGHS did not find an optimal solution: {result.status}")
     return float(result.objective_value), build_s, solve_s
 
@@ -212,6 +368,11 @@ class ReedsPayload(TypedDict):
     objective_value: NotRequired[float]
     build_seconds: float
     solve_seconds: float
+    peak_rss_mb: float
+    status: NotRequired[str]
+    build_profile: NotRequired[list[BuildStage]]
+    matrix_profile: NotRequired[dict[str, object]]
+    solve_metadata: NotRequired[dict[str, float]]
 
 
 def _size_name(value: str) -> str:
@@ -221,6 +382,16 @@ def _size_name(value: str) -> str:
     return value
 
 
+def _positive_int(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("value must be an integer") from exc
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("value must be >= 1")
+    return parsed
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(
         description="Build or solve the ReEDS-representative Arco Python benchmark"
@@ -228,33 +399,115 @@ def main() -> int:
     parser.add_argument("--size", type=_size_name, default="small", help="Problem size")
     parser.add_argument("--build-only", action="store_true", help="Skip solve")
     parser.add_argument(
+        "--profile-build",
+        action="store_true",
+        help="Include per-stage build timing and RSS in JSON output",
+    )
+    parser.add_argument(
+        "--profile-matrix",
+        action="store_true",
+        help="Include sparse column-density diagnostics without exporting matrix arrays",
+    )
+    parser.add_argument(
         "--json", action="store_true", help="Emit machine-readable output"
+    )
+    parser.add_argument(
+        "--time-limit",
+        type=float,
+        default=None,
+        help="Optional HiGHS time limit in seconds",
+    )
+    parser.add_argument(
+        "--presolve",
+        choices=("on", "off"),
+        default=None,
+        help="Override HiGHS presolve for solver-memory probes",
+    )
+    parser.add_argument(
+        "--threads",
+        type=_positive_int,
+        default=None,
+        help="Override HiGHS thread count for solver-memory probes",
+    )
+    parser.add_argument(
+        "--highs-solver",
+        choices=("ipm", "simplex", "choose", "pdlp"),
+        default="ipm",
+        help="Override the HiGHS algorithm for solver-memory probes",
+    )
+    parser.add_argument(
+        "--highs-run-crossover",
+        choices=("on", "off", "choose"),
+        default=None,
+        help="Override HiGHS run_crossover for IPM memory probes",
+    )
+    parser.add_argument(
+        "--highs-load-path",
+        choices=("wrapper", "direct"),
+        default=None,
+        help="Select the Arco-to-HiGHS model load path for memory probes",
+    )
+    parser.add_argument(
+        "--allow-nonoptimal",
+        action="store_true",
+        help="Return JSON/text output for time-limit or other non-optimal statuses",
     )
     args = parser.parse_args()
 
     problem = make_problem(args.size)
-    obj, build_s, solve_s = solve(problem, build_only=args.build_only)
+    obj, build_s, solve_s = solve(
+        problem,
+        build_only=args.build_only,
+        profile_build=args.profile_build,
+        profile_matrix=args.profile_matrix,
+        time_limit=args.time_limit,
+        presolve=None if args.presolve is None else args.presolve == "on",
+        threads=args.threads,
+        highs_solver=args.highs_solver,
+        highs_run_crossover=args.highs_run_crossover,
+        highs_load_path=None
+        if args.highs_load_path in (None, "wrapper")
+        else args.highs_load_path,
+        require_optimal=not args.allow_nonoptimal,
+    )
+    solved = not args.build_only and LAST_SOLVE_STATUS == "SolutionStatus.OPTIMAL"
     payload: ReedsPayload = {
         "example": "reeds-benchmark",
         "size": args.size,
         "summary": problem.summary(),
-        "solved": not args.build_only,
+        "solved": solved,
         "build_seconds": build_s,
         "solve_seconds": solve_s,
+        "peak_rss_mb": _peak_rss_mb(),
     }
     if not args.build_only:
         payload["objective_value"] = obj
+        if LAST_SOLVE_STATUS is not None:
+            payload["status"] = LAST_SOLVE_STATUS
+        payload["solve_metadata"] = LAST_SOLVE_METADATA
+    if args.profile_build:
+        payload["build_profile"] = LAST_BUILD_PROFILE
+    if args.profile_matrix:
+        payload["matrix_profile"] = LAST_MATRIX_PROFILE
 
     if args.json:
         print(json.dumps(payload, indent=2))
     elif args.build_only:
         print(
-            f"reeds-benchmark built: size={args.size}, {problem.summary()}, build={build_s:.3f}s"
+            f"reeds-benchmark built: size={args.size}, {problem.summary()}, "
+            f"build={build_s:.3f}s, peak={payload['peak_rss_mb']:.1f} MB"
+        )
+    elif not solved:
+        print(
+            f"reeds-benchmark finished: size={args.size}, status={LAST_SOLVE_STATUS}, "
+            f"obj={obj:,.0f}, build={build_s:.3f}s, solve={solve_s:.3f}s, "
+            f"peak={payload['peak_rss_mb']:.1f} MB"
         )
     else:
         print(
             f"reeds-benchmark solved: size={args.size}, obj={obj:,.0f}, "
-            f"build={build_s:.3f}s, solve={solve_s:.3f}s"
+            f"build={build_s:.3f}s, solve={solve_s:.3f}s, "
+            f"peak={payload['peak_rss_mb']:.1f} MB"
         )
     return 0
 

--- a/examples/reeds-benchmark/test_formulation_memory.py
+++ b/examples/reeds-benchmark/test_formulation_memory.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+def load_formulation() -> types.ModuleType:
+    example_dir = Path(__file__).resolve().parent
+    sys.path.insert(0, str(example_dir))
+    sys.modules.setdefault("arco", types.SimpleNamespace())
+    spec = importlib.util.spec_from_file_location(
+        "reeds_benchmark_formulation", example_dir / "formulation.py"
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_ru_maxrss_to_mb_uses_platform_units() -> None:
+    formulation = load_formulation()
+
+    assert formulation._ru_maxrss_to_mb(2048.0, "linux") == 2.0
+    assert formulation._ru_maxrss_to_mb(2.0 * 1024.0 * 1024.0, "darwin") == 2.0
+
+
+def test_format_rss_mb_reports_unsupported_measurements_explicitly() -> None:
+    formulation = load_formulation()
+
+    assert formulation._format_rss_mb(None) == "n/a"
+    assert formulation._format_rss_mb(12.25) == "12.2 MB"


### PR DESCRIPTION
## Summary

This draft PR exposes the exploratory `perf/memory` branch for review and decomposition. It is not intended to be merged as a single change set.

Related issue: #314

## Branch scope

The branch currently combines several memory-performance experiments:

- Python model APIs and typing updates such as `Model.reserve(...)` and `Model.matrix_profile(...)`
- Rust model storage and sparse matrix diagnostics
- HiGHS/Xpress solver load-path and status-reporting changes
- ReEDS benchmark memory/build profiling instrumentation

## Extraction issues under #314

This draft has been split into executable work packets:

1. #316 — ReEDS memory benchmark observability.
2. #317 — Model capacity reservation API.
3. #318 — Sparse active array construction.
4. #319 — Solver result metadata and status contracts.
5. #320 — Measured solver memory load paths.

Each extraction PR should include its own tests and benchmark/result note. If a slice is still too large to review, split by public API first, internal storage second, solver backend third.

## Draft status

Keep this PR draft. It should not be marked ready or merged until useful pieces are measured, separated, validated, and extracted into smaller PRs under #314.

## Validation so far

This draft branch has had targeted validation while addressing review findings and conflicts, but that does not make the combined branch merge-ready. Follow-up extraction PRs should include targeted tests and reproducible ReEDS benchmark commands for their own scope.

## Risks

- The branch is large and mixed-scope.
- Solver load-path changes need correctness and status-mapping review before merge.
- Memory improvements need measurement rather than intuition.
