### PR TITLE
perf: extract measured solver memory load paths

### DIFF
--- a/bindings/python/src/model_solve.rs
+++ b/bindings/python/src/model_solve.rs
@@ -9,7 +9,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyAny;
 
 pub(crate) fn solve_model(
-    model: &PyModel,
+    model: &mut PyModel,
     py: Python<'_>,
     solver_obj: Option<&Bound<'_, PyAny>>,
     log_to_console: Option<bool>,
@@ -49,11 +49,7 @@ pub(crate) fn solve_model(
 
     let config = effective_settings.to_solver_config();
 
-    let result = match arco_ops::ArcoOps::solve_model_view_with_builtin_backend(
-        &selected_backend,
-        &model.inner,
-        &config,
-    ) {
+    let result = match solve_with_selected_backend(model, &selected_backend, &config) {
         Ok(solution) => Ok(PySolveResult::new(solution_from_model_view_result(
             solution,
         ))),
@@ -64,6 +60,28 @@ pub(crate) fn solve_model(
     }?;
 
     Py::new(py, result)
+}
+
+fn solve_with_selected_backend(
+    model: &mut PyModel,
+    selected_backend: &str,
+    config: &arco_ops::solve::SolverConfig,
+) -> Result<ModelViewSolveResult, SolverError> {
+    if matches!(selected_backend, "highs" | "xpress")
+        && config
+            .parameters
+            .get("arco.consume_model")
+            .is_some_and(|value| value == "true")
+    {
+        let owned_model = std::mem::take(&mut model.inner);
+        return arco_ops::ArcoOps::solve_owned_model_with_builtin_backend(
+            selected_backend,
+            owned_model,
+            config,
+        );
+    }
+
+    arco_ops::ArcoOps::solve_model_view_with_builtin_backend(selected_backend, &model.inner, config)
 }
 
 fn reject_unsupported_primal_start(primal_start: Option<&[(u32, f64)]>) -> Result<(), SolverError> {

--- a/bindings/python/src/solver.rs
+++ b/bindings/python/src/solver.rs
@@ -1,6 +1,7 @@
 //! Python wrappers for solver configuration and instances.
 
 use crate::py_modules::errors::SolverInvalidSettingError;
+use arco_ops::ArcoOps;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 use std::collections::BTreeMap;
@@ -656,6 +657,10 @@ fn solver_runtime_info_for_family(py: Python<'_>, family: &str) -> PyResult<Py<P
             let configured = std::env::var("XPAUTH_PATH").ok();
             info.set_item("configured_license_path", configured)?;
             info.set_item("backend_enabled", xpress_backend_enabled())?;
+            info.set_item(
+                "runtime_available",
+                ArcoOps::builtin_solver_version("xpress").as_deref() == Some("available"),
+            )?;
         }
         "highs" | "scip" | "ipopt" => {
             info.set_item("requires_license", false)?;
@@ -663,6 +668,10 @@ fn solver_runtime_info_for_family(py: Python<'_>, family: &str) -> PyResult<Py<P
             info.set_item("runtime_env_var", Option::<String>::None)?;
             info.set_item("runtime_dir", Option::<String>::None)?;
             info.set_item("configured_license_path", Option::<String>::None)?;
+            info.set_item(
+                "runtime_available",
+                ArcoOps::builtin_solver_version(family).is_some(),
+            )?;
             info.set_item(
                 "backend_enabled",
                 family != "ipopt" || cfg!(feature = "ipopt"),

--- a/bindings/python/tests/test_xpress.py
+++ b/bindings/python/tests/test_xpress.py
@@ -20,6 +20,12 @@ HAS_XPRESS_RUNTIME = bool(XPRESS_RUNTIME_INFO.get("runtime_dir"))
 HAS_XPRESS_BACKEND = bool(XPRESS_RUNTIME_INFO.get("backend_enabled"))
 
 
+def test_xpress_runtime_info_reports_library_availability() -> None:
+    assert isinstance(XPRESS_RUNTIME_INFO["runtime_available"], bool)
+    if not XPRESS_RUNTIME_INFO.get("runtime_dir"):
+        assert XPRESS_RUNTIME_INFO["runtime_available"] is False
+
+
 @pytest.mark.skipif(
     not HAS_XPRESS_RUNTIME,
     reason="local Xpress runtime not available",

--- a/crates/arco-highs/src/lib.rs
+++ b/crates/arco-highs/src/lib.rs
@@ -10,4 +10,4 @@ pub use ffi::{
     highs_version,
 };
 pub use solution::Solution;
-pub use solver::{HighsModelViewBackend, SolverError, solve_model_view};
+pub use solver::{HighsModelViewBackend, SolverError, solve_model_view, solve_owned_model};

--- a/crates/arco-highs/src/solver.rs
+++ b/crates/arco-highs/src/solver.rs
@@ -3,11 +3,13 @@
 use crate::status::highs_model_status;
 use arco_model::{ConstraintId, ModelFingerprint, ModelView, Sense, VariableId};
 use arco_solver::{
-    ModelViewBackend, ModelViewSolveResult, SolverConfig, SolverStatusMapping,
-    validate_model_view_solve_result,
+    ModelViewBackend, ModelViewSolveResult, SolverConfig, SolverStatus, SolverStatusMapping,
+    validate_model_view_solve_result_with_config,
 };
-use highs::{ColProblem, Model as RawHighsModel, Row as HighsRow, Sense as HighsSense};
+use highs::SolvedModel as RawSolvedHighsModel;
+use highs::{ColProblem, HighsOptionValue, Model as RawHighsModel, Sense as HighsSense};
 use std::collections::BTreeMap;
+use std::ffi::{CString, c_void};
 use std::time::Instant;
 
 /// Re-export of contract solver error for backward compatibility.
@@ -52,38 +54,49 @@ fn apply_solver_config(
     validate_solver_config(config)?;
 
     if config.verbosity.unwrap_or(0) == 0 && !config.log_to_console.unwrap_or(false) {
-        highs_model.make_quiet();
+        try_set_highs_option(highs_model, "output_flag", false)?;
+        try_set_highs_option(highs_model, "log_to_console", false)?;
     }
     if let Some(level) = config.verbosity {
-        highs_model.set_option("output_flag", level > 0);
+        try_set_highs_option(highs_model, "output_flag", level > 0)?;
     }
     if config.log_to_console.unwrap_or(false) {
-        highs_model.set_option("log_to_console", true);
-        highs_model.set_option("output_flag", true);
+        try_set_highs_option(highs_model, "log_to_console", true)?;
+        try_set_highs_option(highs_model, "output_flag", true)?;
     }
     if let Some(limit) = config.time_limit {
-        highs_model.set_option("time_limit", limit);
+        try_set_highs_option(highs_model, "time_limit", limit)?;
     }
     if let Some(gap) = config.mip_gap {
-        highs_model.set_option("mip_rel_gap", gap);
+        try_set_highs_option(highs_model, "mip_rel_gap", gap)?;
     }
     if let Some(presolve) = config.presolve {
-        highs_model.set_option("presolve", if presolve { "on" } else { "off" });
+        try_set_highs_option(highs_model, "presolve", if presolve { "on" } else { "off" })?;
     }
     if let Some(threads) = config.threads {
-        highs_model.set_option("threads", threads as i32);
+        try_set_highs_option(highs_model, "threads", threads as i32)?;
     }
     if let Some(tolerance) = config.tolerance {
-        highs_model.set_option("primal_feasibility_tolerance", tolerance);
-        highs_model.set_option("dual_feasibility_tolerance", tolerance);
+        try_set_highs_option(highs_model, "primal_feasibility_tolerance", tolerance)?;
+        try_set_highs_option(highs_model, "dual_feasibility_tolerance", tolerance)?;
     }
     for (key, value) in &config.parameters {
         if key.starts_with("arco.") {
             continue;
         }
-        highs_model.set_option(key.as_str(), value.as_str());
+        try_set_highs_option(highs_model, key.as_str(), value.as_str())?;
     }
     Ok(())
+}
+
+fn try_set_highs_option<V: HighsOptionValue>(
+    highs_model: &mut RawHighsModel,
+    key: &str,
+    value: V,
+) -> Result<(), SolverError> {
+    highs_model.try_set_option(key, value).map_err(|_| {
+        SolverError::InvalidSettings(format!("invalid HiGHS option or value for {key:?}"))
+    })
 }
 
 /// Adapter implementation for primitive model-view solves through HiGHS.
@@ -109,6 +122,115 @@ pub fn solve_model_view(
     model: &(impl ModelView + ?Sized),
     config: &SolverConfig,
 ) -> Result<ModelViewSolveResult, SolverError> {
+    let prepared_problem = prepare_highs_problem(model, config)?;
+    let result =
+        finish_prepared_solve(optimise_prepared_problem(prepared_problem, config)?, config)?;
+    validate_model_view_solve_result_with_config(model, &result, config)?;
+    Ok(result)
+}
+
+/// Solve an owned core model, allowing callers to release model memory before
+/// the HiGHS algorithm starts.
+pub fn solve_owned_model(
+    mut model: arco_model::Model,
+    config: &SolverConfig,
+) -> Result<ModelViewSolveResult, SolverError> {
+    let prepared_problem = prepare_owned_highs_problem(&mut model, config)?;
+    drop(model);
+    let prepared = optimise_prepared_problem(prepared_problem, config)?;
+    finish_prepared_solve(prepared, config)
+}
+
+struct PreparedHighsProblem {
+    problem: PreparedHighsLoad,
+    load_path: HighsLoadPath,
+    sense: HighsSense,
+    fingerprint: ModelFingerprint,
+    matrix_build_seconds: f64,
+    fingerprint_seconds: f64,
+    num_variables: usize,
+    num_constraints: usize,
+    num_coefficients: usize,
+}
+
+struct PreparedHighsSolve {
+    highs_model: PreparedHighsModel,
+    load_path: HighsLoadPath,
+    fingerprint: ModelFingerprint,
+    matrix_build_seconds: f64,
+    fingerprint_seconds: f64,
+    num_variables: usize,
+    num_constraints: usize,
+    num_coefficients: usize,
+}
+
+enum PreparedHighsLoad {
+    Wrapper(ColProblem),
+    Direct(DirectHighsLoadData),
+}
+
+enum PreparedHighsModel {
+    Wrapper(RawHighsModel),
+    Direct(DirectHighsModel),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HighsLoadPath {
+    Wrapper,
+    Direct,
+}
+
+enum SolvedHighsModel {
+    Wrapper(RawSolvedHighsModel),
+    Direct {
+        model: DirectHighsModel,
+        model_status: highs_sys::HighsInt,
+    },
+}
+
+struct DirectHighsLoadData {
+    num_cols: highs_sys::HighsInt,
+    num_rows: highs_sys::HighsInt,
+    num_nonzeros: highs_sys::HighsInt,
+    col_cost: Vec<f64>,
+    col_lower: Vec<f64>,
+    col_upper: Vec<f64>,
+    row_lower: Vec<f64>,
+    row_upper: Vec<f64>,
+    a_start: Vec<highs_sys::HighsInt>,
+    a_index: Vec<highs_sys::HighsInt>,
+    a_value: Vec<f64>,
+    integrality: Option<Vec<highs_sys::HighsInt>>,
+}
+
+struct DirectHighsModel {
+    ptr: *mut c_void,
+}
+
+type SolutionVectors = (Vec<f64>, Vec<f64>, Vec<f64>, Vec<f64>);
+
+#[allow(unsafe_code)]
+impl Drop for DirectHighsModel {
+    fn drop(&mut self) {
+        if !self.ptr.is_null() {
+            unsafe {
+                highs_sys::Highs_destroy(self.ptr);
+            }
+        }
+    }
+}
+
+fn prepare_highs_problem(
+    model: &(impl ModelView + ?Sized),
+    config: &SolverConfig,
+) -> Result<PreparedHighsProblem, SolverError> {
+    prepare_highs_problem_with_objective_terms(model, model.objective().terms.as_slice(), config)
+}
+
+fn prepare_owned_highs_problem(
+    model: &mut arco_model::Model,
+    config: &SolverConfig,
+) -> Result<PreparedHighsProblem, SolverError> {
     if model.num_variables() == 0 {
         return Err(SolverError::EmptyModel);
     }
@@ -116,7 +238,163 @@ pub fn solve_model_view(
         return Err(SolverError::NoObjective);
     }
 
+    let fingerprint_start = Instant::now();
+    let fingerprint = if config
+        .parameters
+        .get("arco.fingerprint")
+        .is_none_or(|value| value != "false")
+    {
+        model.fingerprint()
+    } else {
+        ModelFingerprint(0)
+    };
+    let fingerprint_seconds = fingerprint_start.elapsed().as_secs_f64();
+
+    let objective_terms = model.take_objective_terms_for_consumed_solve();
+    match requested_load_path(config)? {
+        HighsLoadPath::Wrapper => prepare_highs_problem_with_objective_terms_and_fingerprint(
+            model,
+            objective_terms.as_slice(),
+            config,
+            fingerprint,
+            fingerprint_seconds,
+        ),
+        HighsLoadPath::Direct => prepare_consumed_direct_highs_problem(
+            model,
+            objective_terms.as_slice(),
+            fingerprint,
+            fingerprint_seconds,
+        ),
+    }
+}
+
+fn prepare_highs_problem_with_objective_terms(
+    model: &(impl ModelView + ?Sized),
+    objective_terms: &[(VariableId, f64)],
+    config: &SolverConfig,
+) -> Result<PreparedHighsProblem, SolverError> {
+    if model.num_variables() == 0 {
+        return Err(SolverError::EmptyModel);
+    }
+    if model.objective().sense.is_none() && model.objective().terms.is_empty() {
+        return Err(SolverError::NoObjective);
+    }
+
+    let fingerprint_start = Instant::now();
+    let fingerprint = if config
+        .parameters
+        .get("arco.fingerprint")
+        .is_none_or(|value| value != "false")
+    {
+        model.fingerprint()
+    } else {
+        ModelFingerprint(0)
+    };
+    let fingerprint_seconds = fingerprint_start.elapsed().as_secs_f64();
+
+    prepare_highs_problem_with_objective_terms_and_fingerprint(
+        model,
+        objective_terms,
+        config,
+        fingerprint,
+        fingerprint_seconds,
+    )
+}
+
+fn prepare_highs_problem_with_objective_terms_and_fingerprint(
+    model: &(impl ModelView + ?Sized),
+    objective_terms: &[(VariableId, f64)],
+    config: &SolverConfig,
+    fingerprint: ModelFingerprint,
+    fingerprint_seconds: f64,
+) -> Result<PreparedHighsProblem, SolverError> {
+    let objective_sense = model.objective().sense.ok_or(SolverError::NoObjective)?;
+
     let matrix_start = Instant::now();
+    let load_path = requested_load_path(config)?;
+    let problem = match load_path {
+        HighsLoadPath::Wrapper => {
+            PreparedHighsLoad::Wrapper(build_wrapper_highs_problem(model, objective_terms)?)
+        }
+        HighsLoadPath::Direct => {
+            PreparedHighsLoad::Direct(build_direct_highs_load_data(model, objective_terms)?)
+        }
+    };
+    let matrix_build_seconds = matrix_start.elapsed().as_secs_f64();
+
+    let sense = match objective_sense {
+        Sense::Minimize => HighsSense::Minimise,
+        Sense::Maximize => HighsSense::Maximise,
+    };
+
+    Ok(PreparedHighsProblem {
+        problem,
+        load_path,
+        sense,
+        fingerprint,
+        matrix_build_seconds,
+        fingerprint_seconds,
+        num_variables: model.num_variables(),
+        num_constraints: model.num_constraints(),
+        num_coefficients: model.num_coefficients(),
+    })
+}
+
+fn prepare_consumed_direct_highs_problem(
+    model: &mut arco_model::Model,
+    objective_terms: &[(VariableId, f64)],
+    fingerprint: ModelFingerprint,
+    fingerprint_seconds: f64,
+) -> Result<PreparedHighsProblem, SolverError> {
+    let objective_sense = model.objective().sense.ok_or(SolverError::NoObjective)?;
+    let num_variables = model.num_variables();
+    let num_constraints = model.num_constraints();
+    let num_coefficients = model.num_coefficients();
+
+    let matrix_start = Instant::now();
+    let problem = PreparedHighsLoad::Direct(build_direct_highs_load_data_consuming_model(
+        model,
+        objective_terms,
+        num_coefficients,
+    )?);
+    let matrix_build_seconds = matrix_start.elapsed().as_secs_f64();
+
+    let sense = match objective_sense {
+        Sense::Minimize => HighsSense::Minimise,
+        Sense::Maximize => HighsSense::Maximise,
+    };
+
+    Ok(PreparedHighsProblem {
+        problem,
+        load_path: HighsLoadPath::Direct,
+        sense,
+        fingerprint,
+        matrix_build_seconds,
+        fingerprint_seconds,
+        num_variables,
+        num_constraints,
+        num_coefficients,
+    })
+}
+
+fn requested_load_path(config: &SolverConfig) -> Result<HighsLoadPath, SolverError> {
+    match config
+        .parameters
+        .get("arco.highs_load_path")
+        .map(String::as_str)
+    {
+        None | Some("wrapper") => Ok(HighsLoadPath::Wrapper),
+        Some("direct") => Ok(HighsLoadPath::Direct),
+        Some(value) => Err(SolverError::InvalidSettings(format!(
+            "unsupported arco.highs_load_path value {value:?}"
+        ))),
+    }
+}
+
+fn build_wrapper_highs_problem(
+    model: &(impl ModelView + ?Sized),
+    objective_terms: &[(VariableId, f64)],
+) -> Result<ColProblem, SolverError> {
     let mut problem = ColProblem::new();
     let rows = (0..model.num_constraints())
         .map(|index| {
@@ -129,49 +407,36 @@ pub fn solve_model_view(
         })
         .collect::<Result<Vec<_>, SolverError>>()?;
 
-    let mut objective_coefficients = vec![0.0; model.num_variables()];
-    for (variable_id, coefficient) in &model.objective().terms {
-        let index = variable_id.inner() as usize;
-        if index < objective_coefficients.len() {
-            objective_coefficients[index] = *coefficient;
-        }
-    }
-
-    for (index, objective) in objective_coefficients.into_iter().enumerate() {
+    let mut objective_terms = objective_terms.iter().peekable();
+    for index in 0..model.num_variables() {
         let variable_id = VariableId::new(index as u32);
+        let objective = loop {
+            match objective_terms.peek().copied() {
+                Some((term_variable_id, _)) if term_variable_id.inner() as usize == index => {
+                    let coefficient = objective_terms.next().map_or(0.0, |(_, value)| *value);
+                    break coefficient;
+                }
+                Some((term_variable_id, _)) if (term_variable_id.inner() as usize) < index => {
+                    let _ = objective_terms.next();
+                }
+                _ => break 0.0,
+            }
+        };
         let variable = model
             .variable(variable_id)
             .ok_or(SolverError::InvalidVariableId(index as u32))?;
-        let Some(column) = model.column(variable_id) else {
-            if variable.is_integer {
-                problem.add_integer_column(
-                    objective,
-                    variable.bounds.lower..=variable.bounds.upper,
-                    Vec::<(HighsRow, f64)>::new(),
-                );
-            } else {
-                problem.add_column(
-                    objective,
-                    variable.bounds.lower..=variable.bounds.upper,
-                    Vec::<(HighsRow, f64)>::new(),
-                );
+        let column = model.column(variable_id).unwrap_or(&[]);
+        for (constraint_id, _) in column {
+            let row_index = constraint_id.inner() as usize;
+            if row_index >= rows.len() {
+                return Err(SolverError::SolverSpecific(format!(
+                    "constraint ID {row_index} does not exist"
+                )));
             }
-            continue;
-        };
-        let factors = column
-            .iter()
-            .map(|(constraint_id, coefficient)| {
-                let row_index = constraint_id.inner() as usize;
-                rows.get(row_index)
-                    .copied()
-                    .map(|row| (row, *coefficient))
-                    .ok_or_else(|| {
-                        SolverError::SolverSpecific(format!(
-                            "constraint ID {row_index} does not exist"
-                        ))
-                    })
-            })
-            .collect::<Result<Vec<_>, SolverError>>()?;
+        }
+        let factors = column.iter().map(|(constraint_id, coefficient)| {
+            (rows[constraint_id.inner() as usize], *coefficient)
+        });
         if variable.is_integer {
             problem.add_integer_column(
                 objective,
@@ -187,73 +452,588 @@ pub fn solve_model_view(
         }
     }
 
-    let matrix_build_seconds = matrix_start.elapsed().as_secs_f64();
+    Ok(problem)
+}
 
-    let sense = match model.objective().sense.unwrap_or(Sense::Minimize) {
-        Sense::Minimize => HighsSense::Minimise,
-        Sense::Maximize => HighsSense::Maximise,
-    };
-    let mut highs_model = problem.optimise(sense);
-    apply_solver_config(&mut highs_model, config)?;
-    let highs_run_start = Instant::now();
-    let solved = highs_model.solve();
-    let highs_run_seconds = highs_run_start.elapsed().as_secs_f64();
-    let status = solved.status();
-    let mapped_status = highs_model_status(status);
-    if !mapped_status.has_solution() {
-        return Err(SolverError::SolveFailure {
-            status: mapped_status.to_solver_status(),
-        });
+fn build_direct_highs_load_data(
+    model: &(impl ModelView + ?Sized),
+    objective_terms: &[(VariableId, f64)],
+) -> Result<DirectHighsLoadData, SolverError> {
+    let num_cols = checked_highs_int(model.num_variables(), "variables")?;
+    let num_rows = checked_highs_int(model.num_constraints(), "constraints")?;
+    let num_nonzeros = checked_highs_int(model.num_coefficients(), "coefficients")?;
+    let ncols = model.num_variables();
+    let nrows = model.num_constraints();
+    let mut col_cost = Vec::with_capacity(ncols);
+    let mut col_lower = Vec::with_capacity(ncols);
+    let mut col_upper = Vec::with_capacity(ncols);
+    let mut row_lower = Vec::with_capacity(nrows);
+    let mut row_upper = Vec::with_capacity(nrows);
+    let mut a_start = Vec::with_capacity(ncols);
+    let mut a_index = Vec::with_capacity(model.num_coefficients());
+    let mut a_value = Vec::with_capacity(model.num_coefficients());
+    let mut integrality: Option<Vec<highs_sys::HighsInt>> = None;
+
+    for index in 0..nrows {
+        let constraint = model
+            .constraint(ConstraintId::new(index as u32))
+            .ok_or_else(|| {
+                SolverError::SolverSpecific(format!("constraint ID {index} does not exist"))
+            })?;
+        row_lower.push(constraint.bounds.lower);
+        row_upper.push(constraint.bounds.upper);
     }
-    let objective_value = solved.objective_value();
+
+    let mut objective_terms = objective_terms.iter().peekable();
+    for index in 0..ncols {
+        let variable_id = VariableId::new(index as u32);
+        let objective = objective_coefficient_for_index(&mut objective_terms, index);
+        let variable = model
+            .variable(variable_id)
+            .ok_or(SolverError::InvalidVariableId(index as u32))?;
+        if variable.is_integer && integrality.is_none() {
+            integrality = Some(vec![highs_sys::kHighsVarTypeContinuous; index]);
+        }
+        if let Some(integrality) = &mut integrality {
+            integrality.push(if variable.is_integer {
+                highs_sys::kHighsVarTypeInteger
+            } else {
+                highs_sys::kHighsVarTypeContinuous
+            });
+        }
+        col_cost.push(objective);
+        col_lower.push(variable.bounds.lower);
+        col_upper.push(variable.bounds.upper);
+        a_start.push(checked_highs_int(a_index.len(), "column start")?);
+        if let Some(column) = model.column(variable_id) {
+            for (constraint_id, coefficient) in column {
+                let row_index = constraint_id.inner() as usize;
+                if row_index >= nrows {
+                    return Err(SolverError::SolverSpecific(format!(
+                        "constraint ID {row_index} does not exist"
+                    )));
+                }
+                a_index.push(checked_highs_int(row_index, "row index")?);
+                a_value.push(*coefficient);
+            }
+        }
+    }
+
+    Ok(DirectHighsLoadData {
+        num_cols,
+        num_rows,
+        num_nonzeros,
+        col_cost,
+        col_lower,
+        col_upper,
+        row_lower,
+        row_upper,
+        a_start,
+        a_index,
+        a_value,
+        integrality,
+    })
+}
+
+fn build_direct_highs_load_data_consuming_model(
+    model: &mut arco_model::Model,
+    objective_terms: &[(VariableId, f64)],
+    num_coefficients: usize,
+) -> Result<DirectHighsLoadData, SolverError> {
+    let num_cols = checked_highs_int(model.num_variables(), "variables")?;
+    let num_rows = checked_highs_int(model.num_constraints(), "constraints")?;
+    let num_nonzeros = checked_highs_int(num_coefficients, "coefficients")?;
+    let ncols = model.num_variables();
+    let nrows = model.num_constraints();
+    let mut col_cost = Vec::with_capacity(ncols);
+    let mut col_lower = Vec::with_capacity(ncols);
+    let mut col_upper = Vec::with_capacity(ncols);
+    let mut row_lower = Vec::with_capacity(nrows);
+    let mut row_upper = Vec::with_capacity(nrows);
+    let mut a_start = Vec::with_capacity(ncols);
+    let mut a_index = Vec::with_capacity(num_coefficients);
+    let mut a_value = Vec::with_capacity(num_coefficients);
+    let mut integrality: Option<Vec<highs_sys::HighsInt>> = None;
+
+    for index in 0..nrows {
+        let constraint = model
+            .constraint(ConstraintId::new(index as u32))
+            .ok_or_else(|| {
+                SolverError::SolverSpecific(format!("constraint ID {index} does not exist"))
+            })?;
+        row_lower.push(constraint.bounds.lower);
+        row_upper.push(constraint.bounds.upper);
+    }
+
+    let mut objective_terms = objective_terms.iter().peekable();
+    for index in 0..ncols {
+        let variable_id = VariableId::new(index as u32);
+        let objective = objective_coefficient_for_index(&mut objective_terms, index);
+        let variable = model
+            .variable(variable_id)
+            .ok_or(SolverError::InvalidVariableId(index as u32))?;
+        if variable.is_integer && integrality.is_none() {
+            integrality = Some(vec![highs_sys::kHighsVarTypeContinuous; index]);
+        }
+        if let Some(integrality) = &mut integrality {
+            integrality.push(if variable.is_integer {
+                highs_sys::kHighsVarTypeInteger
+            } else {
+                highs_sys::kHighsVarTypeContinuous
+            });
+        }
+        col_cost.push(objective);
+        col_lower.push(variable.bounds.lower);
+        col_upper.push(variable.bounds.upper);
+        a_start.push(checked_highs_int(a_index.len(), "column start")?);
+
+        let mut column_error = None;
+        let found_column =
+            model.drain_column_for_consumed_solve(variable_id, |constraint_id, coefficient| {
+                if column_error.is_some() {
+                    return;
+                }
+                let row_index = constraint_id.inner() as usize;
+                if row_index >= nrows {
+                    column_error = Some(SolverError::SolverSpecific(format!(
+                        "constraint ID {row_index} does not exist"
+                    )));
+                    return;
+                }
+                match checked_highs_int(row_index, "row index") {
+                    Ok(row_index) => {
+                        a_index.push(row_index);
+                        a_value.push(coefficient);
+                    }
+                    Err(error) => column_error = Some(error),
+                }
+            });
+        if !found_column {
+            return Err(SolverError::InvalidVariableId(index as u32));
+        }
+        if let Some(error) = column_error {
+            return Err(error);
+        }
+    }
+
+    Ok(DirectHighsLoadData {
+        num_cols,
+        num_rows,
+        num_nonzeros,
+        col_cost,
+        col_lower,
+        col_upper,
+        row_lower,
+        row_upper,
+        a_start,
+        a_index,
+        a_value,
+        integrality,
+    })
+}
+
+fn objective_coefficient_for_index(
+    objective_terms: &mut std::iter::Peekable<std::slice::Iter<'_, (VariableId, f64)>>,
+    index: usize,
+) -> f64 {
+    loop {
+        match objective_terms.peek().copied() {
+            Some((term_variable_id, _)) if term_variable_id.inner() as usize == index => {
+                return objective_terms.next().map_or(0.0, |(_, value)| *value);
+            }
+            Some((term_variable_id, _)) if (term_variable_id.inner() as usize) < index => {
+                let _ = objective_terms.next();
+            }
+            _ => return 0.0,
+        }
+    }
+}
+
+fn checked_highs_int(value: usize, name: &str) -> Result<highs_sys::HighsInt, SolverError> {
+    highs_sys::HighsInt::try_from(value)
+        .map_err(|_| SolverError::SolverSpecific(format!("{name} count is too large for HiGHS")))
+}
+
+fn optimise_prepared_problem(
+    prepared: PreparedHighsProblem,
+    config: &SolverConfig,
+) -> Result<PreparedHighsSolve, SolverError> {
+    let highs_model = match prepared.problem {
+        PreparedHighsLoad::Wrapper(problem) => {
+            let mut highs_model = problem.optimise(prepared.sense);
+            apply_solver_config(&mut highs_model, config)?;
+            PreparedHighsModel::Wrapper(highs_model)
+        }
+        PreparedHighsLoad::Direct(load_data) => {
+            let mut highs_model = DirectHighsModel::load(load_data, prepared.sense)?;
+            apply_direct_solver_config(&mut highs_model, config)?;
+            PreparedHighsModel::Direct(highs_model)
+        }
+    };
+    Ok(PreparedHighsSolve {
+        highs_model,
+        load_path: prepared.load_path,
+        fingerprint: prepared.fingerprint,
+        matrix_build_seconds: prepared.matrix_build_seconds,
+        fingerprint_seconds: prepared.fingerprint_seconds,
+        num_variables: prepared.num_variables,
+        num_constraints: prepared.num_constraints,
+        num_coefficients: prepared.num_coefficients,
+    })
+}
+
+#[allow(unsafe_code)]
+impl DirectHighsModel {
+    fn load(load_data: DirectHighsLoadData, sense: HighsSense) -> Result<Self, SolverError> {
+        let ptr = unsafe { highs_sys::Highs_create() };
+        if ptr.is_null() {
+            return Err(SolverError::SolverNotAvailable(
+                "HiGHS_create returned NULL".to_string(),
+            ));
+        }
+        let mut model = Self { ptr };
+        model.set_bool_option("output_flag", false)?;
+        model.set_bool_option("log_to_console", false)?;
+        let sense = match sense {
+            HighsSense::Minimise => highs_sys::OBJECTIVE_SENSE_MINIMIZE,
+            HighsSense::Maximise => highs_sys::OBJECTIVE_SENSE_MAXIMIZE,
+        };
+        let status = unsafe {
+            if let Some(integrality) = load_data.integrality.as_ref() {
+                highs_sys::Highs_passMip(
+                    model.ptr,
+                    load_data.num_cols,
+                    load_data.num_rows,
+                    load_data.num_nonzeros,
+                    highs_sys::MATRIX_FORMAT_COLUMN_WISE,
+                    sense,
+                    0.0,
+                    load_data.col_cost.as_ptr(),
+                    load_data.col_lower.as_ptr(),
+                    load_data.col_upper.as_ptr(),
+                    load_data.row_lower.as_ptr(),
+                    load_data.row_upper.as_ptr(),
+                    load_data.a_start.as_ptr(),
+                    load_data.a_index.as_ptr(),
+                    load_data.a_value.as_ptr(),
+                    integrality.as_ptr(),
+                )
+            } else {
+                highs_sys::Highs_passLp(
+                    model.ptr,
+                    load_data.num_cols,
+                    load_data.num_rows,
+                    load_data.num_nonzeros,
+                    highs_sys::MATRIX_FORMAT_COLUMN_WISE,
+                    sense,
+                    0.0,
+                    load_data.col_cost.as_ptr(),
+                    load_data.col_lower.as_ptr(),
+                    load_data.col_upper.as_ptr(),
+                    load_data.row_lower.as_ptr(),
+                    load_data.row_upper.as_ptr(),
+                    load_data.a_start.as_ptr(),
+                    load_data.a_index.as_ptr(),
+                    load_data.a_value.as_ptr(),
+                )
+            }
+        };
+        ensure_highs_ok(status, "Highs_passLp/Highs_passMip")?;
+        Ok(model)
+    }
+
+    fn solve(&mut self) -> Result<highs_sys::HighsInt, SolverError> {
+        ensure_highs_ok(unsafe { highs_sys::Highs_run(self.ptr) }, "Highs_run")?;
+        Ok(unsafe { highs_sys::Highs_getModelStatus(self.ptr) })
+    }
+
+    fn objective_value(&self) -> f64 {
+        unsafe { highs_sys::Highs_getObjectiveValue(self.ptr) }
+    }
+
+    fn int_info_value(&self, key: &str) -> Result<highs_sys::HighsInt, SolverError> {
+        let key = cstring_highs_key(key)?;
+        let mut value = -1;
+        ensure_highs_ok(
+            unsafe { highs_sys::Highs_getIntInfoValue(self.ptr, key.as_ptr(), &mut value) },
+            key.to_string_lossy().as_ref(),
+        )?;
+        Ok(value)
+    }
+
+    fn solution_vectors(
+        &self,
+        num_variables: usize,
+        num_constraints: usize,
+    ) -> Result<SolutionVectors, SolverError> {
+        let mut primal_values = vec![0.0; num_variables];
+        let mut variable_duals = vec![0.0; num_variables];
+        let mut row_values = vec![0.0; num_constraints];
+        let mut constraint_duals = vec![0.0; num_constraints];
+        ensure_highs_ok(
+            unsafe {
+                highs_sys::Highs_getSolution(
+                    self.ptr,
+                    primal_values.as_mut_ptr(),
+                    variable_duals.as_mut_ptr(),
+                    row_values.as_mut_ptr(),
+                    constraint_duals.as_mut_ptr(),
+                )
+            },
+            "Highs_getSolution",
+        )?;
+        Ok((primal_values, variable_duals, row_values, constraint_duals))
+    }
+
+    fn set_bool_option(&mut self, key: &str, value: bool) -> Result<(), SolverError> {
+        let key = cstring_option_key(key)?;
+        ensure_highs_ok(
+            unsafe {
+                highs_sys::Highs_setBoolOptionValue(self.ptr, key.as_ptr(), i32::from(value))
+            },
+            key.to_string_lossy().as_ref(),
+        )
+    }
+
+    fn set_int_option(&mut self, key: &str, value: i32) -> Result<(), SolverError> {
+        let key = cstring_option_key(key)?;
+        ensure_highs_ok(
+            unsafe { highs_sys::Highs_setIntOptionValue(self.ptr, key.as_ptr(), value) },
+            key.to_string_lossy().as_ref(),
+        )
+    }
+
+    fn set_double_option(&mut self, key: &str, value: f64) -> Result<(), SolverError> {
+        let key = cstring_option_key(key)?;
+        ensure_highs_ok(
+            unsafe { highs_sys::Highs_setDoubleOptionValue(self.ptr, key.as_ptr(), value) },
+            key.to_string_lossy().as_ref(),
+        )
+    }
+
+    fn set_string_option(&mut self, key: &str, value: &str) -> Result<(), SolverError> {
+        let key = cstring_option_key(key)?;
+        let value = CString::new(value).map_err(|_| {
+            SolverError::InvalidSettings(format!(
+                "invalid HiGHS option value for {:?}: contains NUL",
+                key.to_string_lossy()
+            ))
+        })?;
+        ensure_highs_ok(
+            unsafe {
+                highs_sys::Highs_setStringOptionValue(self.ptr, key.as_ptr(), value.as_ptr())
+            },
+            key.to_string_lossy().as_ref(),
+        )
+    }
+}
+
+fn apply_direct_solver_config(
+    highs_model: &mut DirectHighsModel,
+    config: &SolverConfig,
+) -> Result<(), SolverError> {
+    validate_solver_config(config)?;
+
+    if config.verbosity.unwrap_or(0) == 0 && !config.log_to_console.unwrap_or(false) {
+        highs_model.set_bool_option("output_flag", false)?;
+        highs_model.set_bool_option("log_to_console", false)?;
+    }
+    if let Some(level) = config.verbosity {
+        highs_model.set_bool_option("output_flag", level > 0)?;
+    }
+    if config.log_to_console.unwrap_or(false) {
+        highs_model.set_bool_option("log_to_console", true)?;
+        highs_model.set_bool_option("output_flag", true)?;
+    }
+    if let Some(limit) = config.time_limit {
+        highs_model.set_double_option("time_limit", limit)?;
+    }
+    if let Some(gap) = config.mip_gap {
+        highs_model.set_double_option("mip_rel_gap", gap)?;
+    }
+    if let Some(presolve) = config.presolve {
+        highs_model.set_string_option("presolve", if presolve { "on" } else { "off" })?;
+    }
+    if let Some(threads) = config.threads {
+        highs_model.set_int_option("threads", threads as i32)?;
+    }
+    if let Some(tolerance) = config.tolerance {
+        highs_model.set_double_option("primal_feasibility_tolerance", tolerance)?;
+        highs_model.set_double_option("dual_feasibility_tolerance", tolerance)?;
+    }
+    for (key, value) in &config.parameters {
+        if key.starts_with("arco.") {
+            continue;
+        }
+        highs_model.set_string_option(key.as_str(), value.as_str())?;
+    }
+    Ok(())
+}
+
+fn ensure_highs_ok(status: highs_sys::HighsInt, operation: &str) -> Result<(), SolverError> {
+    if status == highs_sys::STATUS_OK || status == highs_sys::STATUS_WARNING {
+        Ok(())
+    } else {
+        Err(SolverError::InvalidSettings(format!(
+            "invalid HiGHS option or value for {operation:?}"
+        )))
+    }
+}
+
+fn cstring_option_key(key: &str) -> Result<CString, SolverError> {
+    CString::new(key).map_err(|_| {
+        SolverError::InvalidSettings(format!("invalid HiGHS option name {key:?}: contains NUL"))
+    })
+}
+
+fn cstring_highs_key(key: &str) -> Result<CString, SolverError> {
+    CString::new(key).map_err(|_| {
+        SolverError::SolverSpecific(format!("invalid HiGHS info key {key:?}: contains NUL"))
+    })
+}
+
+fn raw_highs_model_status_to_solver_status(status: highs_sys::HighsInt) -> SolverStatus {
+    match status {
+        highs_sys::MODEL_STATUS_OPTIMAL => SolverStatus::Optimal,
+        highs_sys::MODEL_STATUS_INFEASIBLE => SolverStatus::Infeasible,
+        highs_sys::MODEL_STATUS_UNBOUNDED => SolverStatus::Unbounded,
+        highs_sys::MODEL_STATUS_REACHED_TIME_LIMIT => SolverStatus::TimeLimit,
+        highs_sys::MODEL_STATUS_REACHED_ITERATION_LIMIT => SolverStatus::IterationLimit,
+        _ => SolverStatus::Unknown,
+    }
+}
+
+fn primal_solution_is_feasible(highs_primal_solution_status: f64) -> bool {
+    let feasible_status = highs_sys::SOLUTION_STATUS_FEASIBLE as f64;
+    (highs_primal_solution_status - feasible_status).abs() <= f64::EPSILON
+}
+
+fn objective_value_for_primal_solution_status(
+    objective_value: f64,
+    highs_primal_solution_status: f64,
+) -> f64 {
+    if primal_solution_is_feasible(highs_primal_solution_status) {
+        objective_value
+    } else {
+        f64::NAN
+    }
+}
+
+fn status_with_primal_solution_availability(
+    mapped_status: SolverStatus,
+    highs_primal_solution_status: f64,
+) -> SolverStatus {
+    if mapped_status.is_feasible() && !primal_solution_is_feasible(highs_primal_solution_status) {
+        SolverStatus::Unknown
+    } else {
+        mapped_status
+    }
+}
+
+fn finish_prepared_solve(
+    prepared: PreparedHighsSolve,
+    config: &SolverConfig,
+) -> Result<ModelViewSolveResult, SolverError> {
     let extract_solution = config
         .parameters
         .get("arco.extract_solution")
         .is_none_or(|value| value != "false");
+    let highs_run_start = Instant::now();
+    let solved_model = match prepared.highs_model {
+        PreparedHighsModel::Wrapper(model) => SolvedHighsModel::Wrapper(model.solve()),
+        PreparedHighsModel::Direct(mut model) => {
+            let model_status = model.solve()?;
+            SolvedHighsModel::Direct {
+                model,
+                model_status,
+            }
+        }
+    };
+    let (mapped_status, highs_model_status, highs_primal_solution_status, objective_value) =
+        match &solved_model {
+            SolvedHighsModel::Wrapper(model) => {
+                let model_status = model.status();
+                (
+                    highs_model_status(model_status).to_solver_status(),
+                    model_status as isize as f64,
+                    model.primal_solution_status() as isize as f64,
+                    model.objective_value(),
+                )
+            }
+            SolvedHighsModel::Direct {
+                model,
+                model_status,
+            } => (
+                raw_highs_model_status_to_solver_status(*model_status),
+                *model_status as f64,
+                model.int_info_value("primal_solution_status")? as f64,
+                model.objective_value(),
+            ),
+        };
+    let highs_run_seconds = highs_run_start.elapsed().as_secs_f64();
+    let objective_value =
+        objective_value_for_primal_solution_status(objective_value, highs_primal_solution_status);
+    let reported_status =
+        status_with_primal_solution_availability(mapped_status, highs_primal_solution_status);
+    if !reported_status.is_feasible() {
+        return Err(SolverError::SolveFailure {
+            status: reported_status,
+        });
+    }
     let solution_extract_start = Instant::now();
     let (primal_values, variable_duals, row_values, constraint_duals) = if extract_solution {
-        let solution = solved.get_solution();
-        (
-            solution.columns().to_vec(),
-            solution.dual_columns().to_vec(),
-            solution.rows().to_vec(),
-            solution.dual_rows().to_vec(),
-        )
+        match &solved_model {
+            SolvedHighsModel::Wrapper(model) => {
+                let solution = model.get_solution();
+                (
+                    solution.columns().to_vec(),
+                    solution.dual_columns().to_vec(),
+                    solution.rows().to_vec(),
+                    solution.dual_rows().to_vec(),
+                )
+            }
+            SolvedHighsModel::Direct { model, .. } => {
+                model.solution_vectors(prepared.num_variables, prepared.num_constraints)?
+            }
+        }
     } else {
         (Vec::new(), Vec::new(), Vec::new(), Vec::new())
     };
     let solution_extract_seconds = solution_extract_start.elapsed().as_secs_f64();
 
-    let fingerprint_start = Instant::now();
-    let fingerprint = if config
-        .parameters
-        .get("arco.fingerprint")
-        .is_none_or(|value| value != "false")
-    {
-        model.fingerprint()
-    } else {
-        ModelFingerprint(0)
-    };
-    let fingerprint_seconds = fingerprint_start.elapsed().as_secs_f64();
-
     let mut metadata = BTreeMap::new();
-    metadata.insert("highs_matrix_build_s".to_string(), matrix_build_seconds);
+    metadata.insert(
+        "highs_matrix_build_s".to_string(),
+        prepared.matrix_build_seconds,
+    );
+    metadata.insert(
+        "highs_direct_load_path".to_string(),
+        match prepared.load_path {
+            HighsLoadPath::Wrapper => 0.0,
+            HighsLoadPath::Direct => 1.0,
+        },
+    );
     metadata.insert("highs_run_s".to_string(), highs_run_seconds);
     metadata.insert("solution_extract_s".to_string(), solution_extract_seconds);
-    metadata.insert("fingerprint_s".to_string(), fingerprint_seconds);
-    metadata.insert("num_variables".to_string(), model.num_variables() as f64);
+    metadata.insert("fingerprint_s".to_string(), prepared.fingerprint_seconds);
+    metadata.insert("highs_model_status".to_string(), highs_model_status);
+    metadata.insert(
+        "highs_primal_solution_status".to_string(),
+        highs_primal_solution_status,
+    );
+    metadata.insert("num_variables".to_string(), prepared.num_variables as f64);
     metadata.insert(
         "num_constraints".to_string(),
-        model.num_constraints() as f64,
+        prepared.num_constraints as f64,
     );
     metadata.insert(
         "num_coefficients".to_string(),
-        model.num_coefficients() as f64,
+        prepared.num_coefficients as f64,
     );
 
     let result = ModelViewSolveResult {
-        fingerprint,
-        status: mapped_status.to_solver_status(),
+        fingerprint: prepared.fingerprint,
+        status: reported_status,
         objective_value,
         primal_values,
         variable_duals,
@@ -261,15 +1041,73 @@ pub fn solve_model_view(
         constraint_duals,
         metadata,
     };
-    validate_model_view_solve_result(model, &result)?;
+    validate_result_shape_counts(
+        &result,
+        config,
+        prepared.num_variables,
+        prepared.num_constraints,
+    )?;
     Ok(result)
+}
+
+fn validate_result_shape_counts(
+    result: &ModelViewSolveResult,
+    config: &SolverConfig,
+    num_variables: usize,
+    num_constraints: usize,
+) -> Result<(), SolverError> {
+    let allow_omitted_primal_values = config
+        .parameters
+        .get("arco.extract_solution")
+        .is_some_and(|value| value == "false");
+    if allow_omitted_primal_values {
+        validate_optional_result_len("primal_values", result.primal_values.len(), num_variables)?;
+    } else {
+        validate_required_result_len("primal_values", result.primal_values.len(), num_variables)?;
+    }
+    validate_optional_result_len("variable_duals", result.variable_duals.len(), num_variables)?;
+    validate_optional_result_len("row_values", result.row_values.len(), num_constraints)?;
+    validate_optional_result_len(
+        "constraint_duals",
+        result.constraint_duals.len(),
+        num_constraints,
+    )?;
+    Ok(())
+}
+
+fn validate_required_result_len(
+    name: &str,
+    actual: usize,
+    expected: usize,
+) -> Result<(), SolverError> {
+    if actual == expected {
+        return Ok(());
+    }
+    Err(SolverError::InvalidResultShape(format!(
+        "{name} length {actual} does not match expected {expected}"
+    )))
+}
+
+fn validate_optional_result_len(
+    name: &str,
+    actual: usize,
+    expected: usize,
+) -> Result<(), SolverError> {
+    if actual == 0 || actual == expected {
+        return Ok(());
+    }
+    Err(SolverError::InvalidResultShape(format!(
+        "{name} length {actual} must be 0 or match expected {expected}"
+    )))
 }
 
 #[cfg(test)]
 #[allow(clippy::float_cmp)]
 mod tests {
     use super::*;
-    use arco_model::{Bounds, Constraint, Model, ModelView, Objective, Sense, Variable};
+    use arco_model::{
+        Bounds, Constraint, Model, ModelFingerprint, ModelView, Objective, Sense, Variable,
+    };
     use arco_solver::{
         check_empty_model_rejected, check_no_objective_rejected, check_small_lp, check_small_milp,
     };
@@ -314,6 +1152,37 @@ mod tests {
     }
 
     #[test]
+    fn invalid_highs_option_value_returns_solver_error_instead_of_panicking() {
+        let mut model = Model::new();
+        let x = model
+            .add_variable(Variable::continuous(Bounds::new(0.0, f64::INFINITY)))
+            .expect("variable");
+        let demand = model
+            .add_constraint(Constraint {
+                bounds: Bounds::new(1.0, f64::INFINITY),
+            })
+            .expect("constraint");
+        model.set_coefficient(x, demand, 1.0).expect("coefficient");
+        model
+            .set_objective(Objective {
+                sense: Some(Sense::Minimize),
+                terms: vec![(x, 1.0)],
+            })
+            .expect("objective");
+
+        let config = SolverConfig::new().with_parameter("run_crossover", "false");
+        let error = solve_model_view(&model, &config)
+            .expect_err("invalid HiGHS option value should be reported");
+
+        assert!(matches!(
+            error,
+            SolverError::InvalidSettings(message)
+                if message.contains("invalid HiGHS option or value")
+                    && message.contains("run_crossover")
+        ));
+    }
+
+    #[test]
     fn model_view_problem_solves_directly() {
         let backend = HighsModelViewBackend;
         let report =
@@ -355,10 +1224,18 @@ mod tests {
         assert_eq!(result.metadata.get("num_variables"), Some(&1.0));
         assert_eq!(result.metadata.get("num_constraints"), Some(&1.0));
         assert_eq!(result.metadata.get("num_coefficients"), Some(&1.0));
+        assert_eq!(
+            result.metadata.get("highs_model_status"),
+            Some(&(highs_sys::MODEL_STATUS_OPTIMAL as f64))
+        );
+        assert_eq!(
+            result.metadata.get("highs_primal_solution_status"),
+            Some(&(highs_sys::SOLUTION_STATUS_FEASIBLE as f64))
+        );
     }
 
     #[test]
-    fn model_view_solver_rejects_missing_conformance_fields() {
+    fn model_view_solver_supports_objective_only_result_when_solution_extraction_is_disabled() {
         let mut model = Model::new();
         let x = model
             .add_variable(Variable::continuous(Bounds::new(0.0, f64::INFINITY)))
@@ -379,9 +1256,206 @@ mod tests {
         let config = SolverConfig::new()
             .with_parameter("arco.fingerprint", "false")
             .with_parameter("arco.extract_solution", "false");
-        let error = solve_model_view(&model, &config)
-            .expect_err("missing fingerprint and primal values should fail conformance");
+        let result = solve_model_view(&model, &config)
+            .expect("objective-only result should be accepted when explicitly requested");
 
-        assert!(matches!(error, SolverError::InvalidResultShape(_)));
+        assert_eq!(result.fingerprint, ModelFingerprint(0));
+        assert!(result.primal_values.is_empty());
+        assert!(result.variable_duals.is_empty());
+        assert!(result.row_values.is_empty());
+        assert!(result.constraint_duals.is_empty());
+        assert_eq!(result.objective_value, 2.0);
+    }
+
+    #[test]
+    fn owned_model_solver_supports_objective_only_result() {
+        let mut model = Model::new();
+        let x = model
+            .add_variable(Variable::continuous(Bounds::new(0.0, f64::INFINITY)))
+            .expect("variable");
+        let demand = model
+            .add_constraint(Constraint {
+                bounds: Bounds::new(1.0, f64::INFINITY),
+            })
+            .expect("constraint");
+        model.set_coefficient(x, demand, 1.0).expect("coefficient");
+        model
+            .set_objective(Objective {
+                sense: Some(Sense::Minimize),
+                terms: vec![(x, 2.0)],
+            })
+            .expect("objective");
+        let config = SolverConfig::new()
+            .with_parameter("arco.fingerprint", "false")
+            .with_parameter("arco.extract_solution", "false");
+
+        let result = solve_owned_model(model, &config).expect("owned solve succeeds");
+
+        assert_eq!(result.fingerprint, ModelFingerprint(0));
+        assert!(result.primal_values.is_empty());
+        assert_eq!(result.objective_value, 2.0);
+        assert_eq!(result.metadata.get("highs_direct_load_path"), Some(&0.0));
+    }
+
+    #[test]
+    fn direct_highs_load_path_solves_model_view_problem() {
+        let mut model = Model::new();
+        let x = model
+            .add_variable(Variable::continuous(Bounds::new(0.0, f64::INFINITY)))
+            .expect("variable");
+        let demand = model
+            .add_constraint(Constraint {
+                bounds: Bounds::new(1.0, f64::INFINITY),
+            })
+            .expect("constraint");
+        model.set_coefficient(x, demand, 1.0).expect("coefficient");
+        model
+            .set_objective(Objective {
+                sense: Some(Sense::Minimize),
+                terms: vec![(x, 2.0)],
+            })
+            .expect("objective");
+        let config = SolverConfig::new()
+            .with_parameter("arco.highs_load_path", "direct")
+            .with_parameter("arco.fingerprint", "false");
+
+        let result = solve_model_view(&model, &config).expect("direct HiGHS solve succeeds");
+
+        assert_eq!(result.fingerprint, ModelFingerprint(0));
+        assert!(result.status.is_feasible());
+        assert_eq!(result.primal_values, vec![1.0]);
+        assert_eq!(result.objective_value, 2.0);
+        assert_eq!(result.metadata.get("highs_direct_load_path"), Some(&1.0));
+        assert_eq!(
+            result.metadata.get("highs_model_status"),
+            Some(&(highs_sys::MODEL_STATUS_OPTIMAL as f64))
+        );
+        assert_eq!(
+            result.metadata.get("highs_primal_solution_status"),
+            Some(&(highs_sys::SOLUTION_STATUS_FEASIBLE as f64))
+        );
+    }
+
+    #[test]
+    fn direct_highs_load_path_supports_owned_objective_only_result() {
+        let mut model = Model::new();
+        let x = model
+            .add_variable(Variable::continuous(Bounds::new(0.0, f64::INFINITY)))
+            .expect("variable");
+        let demand = model
+            .add_constraint(Constraint {
+                bounds: Bounds::new(1.0, f64::INFINITY),
+            })
+            .expect("constraint");
+        model.set_coefficient(x, demand, 1.0).expect("coefficient");
+        model
+            .set_objective(Objective {
+                sense: Some(Sense::Minimize),
+                terms: vec![(x, 2.0)],
+            })
+            .expect("objective");
+        let config = SolverConfig::new()
+            .with_parameter("arco.highs_load_path", "direct")
+            .with_parameter("arco.fingerprint", "false")
+            .with_parameter("arco.extract_solution", "false");
+
+        let result = solve_owned_model(model, &config).expect("direct owned solve succeeds");
+
+        assert_eq!(result.fingerprint, ModelFingerprint(0));
+        assert!(result.primal_values.is_empty());
+        assert_eq!(result.objective_value, 2.0);
+        assert_eq!(result.metadata.get("highs_direct_load_path"), Some(&1.0));
+        assert_eq!(result.metadata.get("num_coefficients"), Some(&1.0));
+        assert_eq!(
+            result.metadata.get("highs_model_status"),
+            Some(&(highs_sys::MODEL_STATUS_OPTIMAL as f64))
+        );
+        assert_eq!(
+            result.metadata.get("highs_primal_solution_status"),
+            Some(&(highs_sys::SOLUTION_STATUS_FEASIBLE as f64))
+        );
+    }
+
+    #[test]
+    fn objective_value_is_omitted_without_primal_solution() {
+        assert_eq!(
+            objective_value_for_primal_solution_status(
+                2.0,
+                highs_sys::SOLUTION_STATUS_FEASIBLE as f64
+            ),
+            2.0
+        );
+
+        for status in [
+            highs_sys::SOLUTION_STATUS_NONE as f64,
+            highs_sys::SOLUTION_STATUS_INFEASIBLE as f64,
+        ] {
+            assert!(objective_value_for_primal_solution_status(2.0, status).is_nan());
+        }
+    }
+
+    #[test]
+    fn limit_status_without_primal_solution_is_not_reported_feasible() {
+        assert_eq!(
+            status_with_primal_solution_availability(
+                SolverStatus::TimeLimit,
+                highs_sys::SOLUTION_STATUS_FEASIBLE as f64
+            ),
+            SolverStatus::TimeLimit
+        );
+        assert_eq!(
+            status_with_primal_solution_availability(
+                SolverStatus::TimeLimit,
+                highs_sys::SOLUTION_STATUS_NONE as f64
+            ),
+            SolverStatus::Unknown
+        );
+        assert_eq!(
+            status_with_primal_solution_availability(
+                SolverStatus::IterationLimit,
+                highs_sys::SOLUTION_STATUS_INFEASIBLE as f64
+            ),
+            SolverStatus::Unknown
+        );
+        assert_eq!(
+            status_with_primal_solution_availability(
+                SolverStatus::Infeasible,
+                highs_sys::SOLUTION_STATUS_NONE as f64
+            ),
+            SolverStatus::Infeasible
+        );
+    }
+
+    #[test]
+    fn direct_highs_load_path_reports_invalid_options() {
+        let mut model = Model::new();
+        let x = model
+            .add_variable(Variable::continuous(Bounds::new(0.0, f64::INFINITY)))
+            .expect("variable");
+        let demand = model
+            .add_constraint(Constraint {
+                bounds: Bounds::new(1.0, f64::INFINITY),
+            })
+            .expect("constraint");
+        model.set_coefficient(x, demand, 1.0).expect("coefficient");
+        model
+            .set_objective(Objective {
+                sense: Some(Sense::Minimize),
+                terms: vec![(x, 1.0)],
+            })
+            .expect("objective");
+        let config = SolverConfig::new()
+            .with_parameter("arco.highs_load_path", "direct")
+            .with_parameter("run_crossover", "false");
+
+        let error = solve_model_view(&model, &config)
+            .expect_err("invalid direct HiGHS option value should be reported");
+
+        assert!(matches!(
+            error,
+            SolverError::InvalidSettings(message)
+                if message.contains("invalid HiGHS option or value")
+                    && message.contains("run_crossover")
+        ));
     }
 }

--- a/crates/arco-model/src/model/builder.rs
+++ b/crates/arco-model/src/model/builder.rs
@@ -3,7 +3,9 @@
 use crate::expr::{ComparisonSense, ConstraintExpr, Expr};
 use crate::ids::{ConstraintId, VariableId};
 use crate::model::error::ModelError;
-use crate::model::{BITS_PER_WORD, Model, bounds_are_valid, coefficient_is_valid, column_upsert};
+use crate::model::{
+    BITS_PER_WORD, ColumnVec, Model, bounds_are_valid, coefficient_is_valid, column_upsert,
+};
 use crate::types::{Bounds, Constraint, Objective, Sense, Variable};
 
 impl Model {
@@ -22,6 +24,11 @@ impl Model {
         }
     }
 
+    /// Pre-allocate capacity for the given number of additional constraints.
+    pub fn reserve_constraints(&mut self, count: usize) {
+        self.constraints.reserve(count);
+    }
+
     /// Add a variable to the model.
     pub fn add_variable(&mut self, variable: Variable) -> Result<VariableId, ModelError> {
         if !bounds_are_valid(variable.bounds.lower, variable.bounds.upper) {
@@ -34,9 +41,115 @@ impl Model {
         let id = VariableId::new(self.next_variable_id);
         self.next_variable_id += 1;
 
-        self.push_variable(variable);
+        self.push_variable(variable)?;
 
         Ok(id)
+    }
+
+    /// Add a contiguous block of variables that share bounds and integrality.
+    ///
+    /// This avoids repeated validation and per-variable method dispatch in large
+    /// array builders while preserving the same contiguous ID assignment as
+    /// calling `add_variable` repeatedly.
+    pub fn add_variables_uniform(
+        &mut self,
+        variable: Variable,
+        count: usize,
+    ) -> Result<VariableId, ModelError> {
+        if !bounds_are_valid(variable.bounds.lower, variable.bounds.upper) {
+            return Err(ModelError::InvalidVariableBounds {
+                lower: variable.bounds.lower,
+                upper: variable.bounds.upper,
+            });
+        }
+        if count == 0 {
+            return Ok(VariableId::new(self.next_variable_id));
+        }
+
+        let count_u32 = u32::try_from(count).map_err(|_| ModelError::InvalidCscData {
+            reason: "variable block size exceeds u32 id space".to_string(),
+        })?;
+        let first_id = self.next_variable_id;
+        let next_id =
+            first_id
+                .checked_add(count_u32)
+                .ok_or_else(|| ModelError::InvalidCscData {
+                    reason: "variable block would exceed u32 id space".to_string(),
+                })?;
+
+        self.reserve_variables(count);
+
+        let start_idx = self.variables.len();
+        self.variables.extend_repeated(variable.bounds, count)?;
+        self.columns.resize_with(start_idx + count, ColumnVec::new);
+        if variable.is_integer {
+            for idx in start_idx..start_idx + count {
+                Self::write_packed_flag(&mut self.variable_is_integer_bits, idx, true);
+            }
+        }
+        if !variable.is_active {
+            for idx in start_idx..start_idx + count {
+                Self::write_packed_flag(&mut self.variable_is_inactive_bits, idx, true);
+            }
+        }
+        self.next_variable_id = next_id;
+
+        Ok(VariableId::new(first_id))
+    }
+
+    /// Add a contiguous block of variables with per-variable bounds and shared flags.
+    ///
+    /// This is the array-bounds companion to `add_variables_uniform`: callers can
+    /// validate and insert a large variable block without per-variable method
+    /// dispatch while preserving contiguous IDs.
+    pub fn add_variables_with_bounds(
+        &mut self,
+        bounds: &[Bounds],
+        is_integer: bool,
+        is_active: bool,
+    ) -> Result<VariableId, ModelError> {
+        for bound in bounds {
+            if !bounds_are_valid(bound.lower, bound.upper) {
+                return Err(ModelError::InvalidVariableBounds {
+                    lower: bound.lower,
+                    upper: bound.upper,
+                });
+            }
+        }
+        if bounds.is_empty() {
+            return Ok(VariableId::new(self.next_variable_id));
+        }
+
+        let count_u32 = u32::try_from(bounds.len()).map_err(|_| ModelError::InvalidCscData {
+            reason: "variable block size exceeds u32 id space".to_string(),
+        })?;
+        let first_id = self.next_variable_id;
+        let next_id =
+            first_id
+                .checked_add(count_u32)
+                .ok_or_else(|| ModelError::InvalidCscData {
+                    reason: "variable block would exceed u32 id space".to_string(),
+                })?;
+
+        self.reserve_variables(bounds.len());
+
+        let start_idx = self.variables.len();
+        self.variables.extend_from_slice(bounds)?;
+        self.columns
+            .resize_with(start_idx + bounds.len(), ColumnVec::new);
+        if is_integer {
+            for idx in start_idx..start_idx + bounds.len() {
+                Self::write_packed_flag(&mut self.variable_is_integer_bits, idx, true);
+            }
+        }
+        if !is_active {
+            for idx in start_idx..start_idx + bounds.len() {
+                Self::write_packed_flag(&mut self.variable_is_inactive_bits, idx, true);
+            }
+        }
+        self.next_variable_id = next_id;
+
+        Ok(VariableId::new(first_id))
     }
 
     /// Add a constraint to the model.
@@ -68,12 +181,14 @@ impl Model {
             }
         }
 
-        let normalized = self.normalize_terms(objective.terms);
+        let mut normalized = self.normalize_terms(objective.terms);
+        normalized.shrink_to_fit();
         self.objective = Objective {
             sense: Some(sense),
             terms: normalized,
         };
         self.objective_name = None;
+        self.shrink_retained_storage();
         tracing::debug!(
             component = "model",
             operation = "set_objective",
@@ -176,6 +291,59 @@ impl Model {
         Ok(ConstraintId::new(first_constraint_id))
     }
 
+    /// Add compact constraints where each row maps term patterns through a dense row index.
+    ///
+    /// For each inserted row, a pattern `(start_var_id, coeff)` is expanded to
+    /// variable `start_var_id + row_index`. This keeps Python active-mask paths
+    /// from allocating a per-row term vector when active rows are sparse.
+    pub fn add_constraints_compact_indexed(
+        &mut self,
+        term_patterns: &[(u32, f64)],
+        row_indices: &[usize],
+        bounds_list: &[Bounds],
+    ) -> Result<ConstraintId, ModelError> {
+        let count = row_indices.len();
+        if count == 0 {
+            return Ok(ConstraintId::new(self.next_constraint_id));
+        }
+        if bounds_list.len() != count {
+            return Err(ModelError::InvalidCscData {
+                reason: "compact indexed constraint bounds length must match row indices"
+                    .to_string(),
+            });
+        }
+
+        self.constraints.reserve(count);
+        let first_constraint_id = self.next_constraint_id;
+
+        for (row_index, bounds) in row_indices.iter().copied().zip(bounds_list.iter()) {
+            if !bounds_are_valid(bounds.lower, bounds.upper) {
+                return Err(ModelError::InvalidConstraintBounds {
+                    lower: bounds.lower,
+                    upper: bounds.upper,
+                });
+            }
+
+            let constraint_id = ConstraintId::new(self.next_constraint_id);
+            self.next_constraint_id += 1;
+            self.constraints.push(Constraint { bounds: *bounds });
+
+            for &(start_var_id, coeff) in term_patterns {
+                let Some(var_idx) = (start_var_id as usize).checked_add(row_index) else {
+                    return Err(ModelError::InvalidVariableId(VariableId::new(u32::MAX)));
+                };
+                if var_idx >= self.variables.len() {
+                    return Err(ModelError::InvalidVariableId(VariableId::new(
+                        var_idx as u32,
+                    )));
+                }
+                self.columns[var_idx].push((constraint_id, coeff));
+            }
+        }
+
+        Ok(ConstraintId::new(first_constraint_id))
+    }
+
     /// Add a batch of constraints with pre-normalized terms.
     ///
     /// Each constraint is given as a slice of `(VariableId, f64)` terms and a `Bounds`.
@@ -187,7 +355,27 @@ impl Model {
         &mut self,
         constraints: &[(Vec<(VariableId, f64)>, Bounds)],
     ) -> Result<ConstraintId, ModelError> {
-        let count = constraints.len();
+        self.add_constraints_batch_streaming(
+            constraints.len(),
+            constraints
+                .iter()
+                .map(|(terms, bounds)| (terms.as_slice(), *bounds)),
+        )
+    }
+
+    /// Add a streamed batch of constraints with pre-normalized term slices.
+    ///
+    /// Rows are consumed one at a time, so callers do not need to retain a full
+    /// batch of row vectors before inserting them into the model.
+    pub fn add_constraints_batch_streaming<I, T>(
+        &mut self,
+        count: usize,
+        constraints: I,
+    ) -> Result<ConstraintId, ModelError>
+    where
+        I: IntoIterator<Item = (T, Bounds)>,
+        T: AsRef<[(VariableId, f64)]>,
+    {
         if count == 0 {
             return Ok(ConstraintId::new(self.next_constraint_id));
         }
@@ -196,6 +384,7 @@ impl Model {
         let first_constraint_id = self.next_constraint_id;
 
         for (terms, bounds) in constraints {
+            let terms = terms.as_ref();
             if !bounds_are_valid(bounds.lower, bounds.upper) {
                 return Err(ModelError::InvalidConstraintBounds {
                     lower: bounds.lower,
@@ -205,7 +394,7 @@ impl Model {
 
             let constraint_id = ConstraintId::new(self.next_constraint_id);
             self.next_constraint_id += 1;
-            self.constraints.push(Constraint { bounds: *bounds });
+            self.constraints.push(Constraint { bounds });
 
             for &(var_id, coeff) in terms {
                 // Skip validation for each coefficient since terms are pre-normalized.

--- a/crates/arco-model/src/model/csc_import.rs
+++ b/crates/arco-model/src/model/csc_import.rs
@@ -88,7 +88,7 @@ impl Model {
                 bounds: Bounds::new(lower, upper),
                 is_integer: is_integer[idx],
                 is_active: true,
-            });
+            })?;
         }
 
         for idx in 0..num_constraints {

--- a/crates/arco-model/src/model/inspect.rs
+++ b/crates/arco-model/src/model/inspect.rs
@@ -172,7 +172,7 @@ impl Model {
 
         let variables = self
             .variables
-            .iter()
+            .iter_bounds()
             .enumerate()
             .map(|(idx, bounds)| (VariableId::new(idx as u32), bounds))
             .filter(|(id, _)| var_filter.as_ref().is_none_or(|filter| filter.contains(id)))
@@ -184,7 +184,7 @@ impl Model {
                         .variable_names
                         .as_ref()
                         .and_then(|names| names.get(&id).cloned()),
-                    bounds: *bounds,
+                    bounds,
                     is_integer: Self::read_packed_flag(&self.variable_is_integer_bits, idx),
                     is_active: !Self::read_packed_flag(&self.variable_is_inactive_bits, idx),
                     metadata: self

--- a/crates/arco-model/src/model/mod.rs
+++ b/crates/arco-model/src/model/mod.rs
@@ -36,6 +36,319 @@ use std::time::Instant;
 /// heap-allocated otherwise.
 pub(crate) type ColumnVec = SmallVec<[(ConstraintId, f64); 2]>;
 
+const VARIABLE_BOUNDS_FREE: u32 = 0;
+const VARIABLE_BOUNDS_NONNEGATIVE: u32 = 1;
+const VARIABLE_BOUNDS_UNIT: u32 = 2;
+const VARIABLE_BOUNDS_CUSTOM_BASE: u32 = 3;
+
+const CONSTRAINT_BOUNDS_FREE: u32 = 0;
+const CONSTRAINT_BOUNDS_EQ_ZERO: u32 = 1;
+const CONSTRAINT_BOUNDS_UPPER_ZERO: u32 = 2;
+const CONSTRAINT_BOUNDS_LOWER_ZERO: u32 = 3;
+const CONSTRAINT_BOUNDS_CUSTOM_BASE: u32 = 4;
+
+const FREE_BOUNDS: Bounds = Bounds {
+    lower: f64::NEG_INFINITY,
+    upper: f64::INFINITY,
+};
+const NONNEGATIVE_BOUNDS: Bounds = Bounds {
+    lower: 0.0,
+    upper: f64::INFINITY,
+};
+const UNIT_BOUNDS: Bounds = Bounds {
+    lower: 0.0,
+    upper: 1.0,
+};
+
+const FREE_CONSTRAINT: Constraint = Constraint {
+    bounds: FREE_BOUNDS,
+};
+const EQ_ZERO_CONSTRAINT: Constraint = Constraint {
+    bounds: Bounds {
+        lower: 0.0,
+        upper: 0.0,
+    },
+};
+const UPPER_ZERO_CONSTRAINT: Constraint = Constraint {
+    bounds: Bounds {
+        lower: f64::NEG_INFINITY,
+        upper: 0.0,
+    },
+};
+const LOWER_ZERO_CONSTRAINT: Constraint = Constraint {
+    bounds: Bounds {
+        lower: 0.0,
+        upper: f64::INFINITY,
+    },
+};
+
+/// Compact variable-bound storage.
+///
+/// Common bounds are represented as one u32 code per variable. Custom bounds
+/// are deduplicated by exact f64 bit pattern so repeated array-bound variables
+/// retain one side-table entry instead of one full `Bounds` per variable.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct VariableStore {
+    codes: Vec<u32>,
+    custom: Vec<Bounds>,
+    custom_lookup: HashMap<(u64, u64), u32>,
+}
+
+impl VariableStore {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn with_capacity(capacity: usize) -> Self {
+        Self {
+            codes: Vec::with_capacity(capacity),
+            custom: Vec::new(),
+            custom_lookup: HashMap::new(),
+        }
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.codes.len()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn capacity(&self) -> usize {
+        self.codes.capacity()
+    }
+
+    pub(crate) fn reserve(&mut self, additional: usize) {
+        self.codes.reserve(additional);
+    }
+
+    pub(crate) fn shrink_to_fit(&mut self) {
+        self.codes.shrink_to_fit();
+        self.custom.shrink_to_fit();
+        self.custom_lookup.shrink_to_fit();
+    }
+
+    pub(crate) fn push_bounds(&mut self, bounds: Bounds) -> Result<(), ModelError> {
+        let code = self.code_for_bounds(bounds)?;
+        self.codes.push(code);
+        Ok(())
+    }
+
+    pub(crate) fn extend_repeated(
+        &mut self,
+        bounds: Bounds,
+        count: usize,
+    ) -> Result<(), ModelError> {
+        let code = self.code_for_bounds(bounds)?;
+        self.codes.resize(self.codes.len() + count, code);
+        Ok(())
+    }
+
+    pub(crate) fn extend_from_slice(&mut self, bounds: &[Bounds]) -> Result<(), ModelError> {
+        self.codes.reserve(bounds.len());
+        let mut last_key: Option<(u64, u64)> = None;
+        let mut last_code = 0;
+        for bound in bounds {
+            let code = if let Some(code) = common_variable_bound_code(*bound) {
+                code
+            } else {
+                let key = bounds_key(*bound);
+                if Some(key) == last_key {
+                    last_code
+                } else {
+                    let code = self.custom_code_for_key(key, *bound)?;
+                    last_key = Some(key);
+                    last_code = code;
+                    code
+                }
+            };
+            self.codes.push(code);
+        }
+        Ok(())
+    }
+
+    pub(crate) fn get_bounds(&self, index: usize) -> Option<Bounds> {
+        let code = *self.codes.get(index)?;
+        self.bounds_for_code(code)
+    }
+
+    pub(crate) fn iter_bounds(&self) -> impl Iterator<Item = Bounds> + '_ {
+        self.codes
+            .iter()
+            .filter_map(|code| self.bounds_for_code(*code))
+    }
+
+    fn code_for_bounds(&mut self, bounds: Bounds) -> Result<u32, ModelError> {
+        if let Some(code) = common_variable_bound_code(bounds) {
+            return Ok(code);
+        }
+        self.custom_code_for_key(bounds_key(bounds), bounds)
+    }
+
+    fn custom_code_for_key(&mut self, key: (u64, u64), bounds: Bounds) -> Result<u32, ModelError> {
+        if let Some(code) = self.custom_lookup.get(&key) {
+            return Ok(*code);
+        }
+        let custom_idx =
+            u32::try_from(self.custom.len()).map_err(|_| ModelError::InvalidCscData {
+                reason: "too many custom variable bounds for compact storage".to_string(),
+            })?;
+        let code = VARIABLE_BOUNDS_CUSTOM_BASE
+            .checked_add(custom_idx)
+            .ok_or_else(|| ModelError::InvalidCscData {
+                reason: "too many custom variable bounds for compact storage".to_string(),
+            })?;
+        self.custom.push(bounds);
+        self.custom_lookup.insert(key, code);
+        Ok(code)
+    }
+
+    fn bounds_for_code(&self, code: u32) -> Option<Bounds> {
+        match code {
+            VARIABLE_BOUNDS_FREE => Some(FREE_BOUNDS),
+            VARIABLE_BOUNDS_NONNEGATIVE => Some(NONNEGATIVE_BOUNDS),
+            VARIABLE_BOUNDS_UNIT => Some(UNIT_BOUNDS),
+            custom_code => {
+                let custom_idx = (custom_code - VARIABLE_BOUNDS_CUSTOM_BASE) as usize;
+                self.custom.get(custom_idx).copied()
+            }
+        }
+    }
+}
+
+#[inline]
+fn bounds_key(bounds: Bounds) -> (u64, u64) {
+    (bounds.lower.to_bits(), bounds.upper.to_bits())
+}
+
+#[inline]
+fn common_variable_bound_code(bounds: Bounds) -> Option<u32> {
+    if bounds == FREE_BOUNDS {
+        Some(VARIABLE_BOUNDS_FREE)
+    } else if bounds == NONNEGATIVE_BOUNDS {
+        Some(VARIABLE_BOUNDS_NONNEGATIVE)
+    } else if bounds == UNIT_BOUNDS {
+        Some(VARIABLE_BOUNDS_UNIT)
+    } else {
+        None
+    }
+}
+
+/// Compact constraint-bound storage.
+///
+/// Common row bounds are represented as one u32 code per constraint. Uncommon
+/// bounds are stored once in a side table and referenced by code. This preserves
+/// stable constraint IDs while avoiding a 16-byte `Constraint` for every row.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct ConstraintStore {
+    codes: Vec<u32>,
+    custom: Vec<Constraint>,
+    recent_custom: SmallVec<[((u64, u64), u32); 8]>,
+}
+
+impl ConstraintStore {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn with_capacity(capacity: usize) -> Self {
+        Self {
+            codes: Vec::with_capacity(capacity),
+            custom: Vec::new(),
+            recent_custom: SmallVec::new(),
+        }
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.codes.len()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn capacity(&self) -> usize {
+        self.codes.capacity()
+    }
+
+    pub(crate) fn reserve(&mut self, additional: usize) {
+        self.codes.reserve(additional);
+    }
+
+    pub(crate) fn shrink_to_fit(&mut self) {
+        self.codes.shrink_to_fit();
+        self.custom.shrink_to_fit();
+    }
+
+    pub(crate) fn push(&mut self, constraint: Constraint) {
+        let code = common_constraint_bound_code(constraint.bounds)
+            .unwrap_or_else(|| self.custom_code_for_constraint(constraint));
+        self.codes.push(code);
+    }
+
+    pub(crate) fn get(&self, index: usize) -> Option<&Constraint> {
+        let code = *self.codes.get(index)?;
+        Some(self.constraint_for_code(code))
+    }
+
+    pub(crate) fn iter(&self) -> impl Iterator<Item = &Constraint> + '_ {
+        self.codes
+            .iter()
+            .map(|code| self.constraint_for_code(*code))
+    }
+
+    fn constraint_for_code(&self, code: u32) -> &Constraint {
+        match code {
+            CONSTRAINT_BOUNDS_FREE => &FREE_CONSTRAINT,
+            CONSTRAINT_BOUNDS_EQ_ZERO => &EQ_ZERO_CONSTRAINT,
+            CONSTRAINT_BOUNDS_UPPER_ZERO => &UPPER_ZERO_CONSTRAINT,
+            CONSTRAINT_BOUNDS_LOWER_ZERO => &LOWER_ZERO_CONSTRAINT,
+            custom_code => {
+                let custom_idx = (custom_code - CONSTRAINT_BOUNDS_CUSTOM_BASE) as usize;
+                &self.custom[custom_idx]
+            }
+        }
+    }
+
+    fn custom_code_for_constraint(&mut self, constraint: Constraint) -> u32 {
+        let key = bounds_key(constraint.bounds);
+        if let Some((_, code)) = self
+            .recent_custom
+            .iter()
+            .find(|(recent_key, _)| *recent_key == key)
+        {
+            return *code;
+        }
+
+        let custom_idx = self.custom.len() as u32;
+        let code = CONSTRAINT_BOUNDS_CUSTOM_BASE + custom_idx;
+        self.custom.push(constraint);
+        if self.recent_custom.len() == self.recent_custom.inline_size() {
+            self.recent_custom.remove(0);
+        }
+        self.recent_custom.push((key, code));
+        code
+    }
+}
+
+#[inline]
+fn common_constraint_bound_code(bounds: Bounds) -> Option<u32> {
+    match bounds {
+        Bounds {
+            lower: f64::NEG_INFINITY,
+            upper: f64::INFINITY,
+        } => Some(CONSTRAINT_BOUNDS_FREE),
+        Bounds {
+            lower: 0.0,
+            upper: 0.0,
+        } => Some(CONSTRAINT_BOUNDS_EQ_ZERO),
+        Bounds {
+            lower: f64::NEG_INFINITY,
+            upper: 0.0,
+        } => Some(CONSTRAINT_BOUNDS_UPPER_ZERO),
+        Bounds {
+            lower: 0.0,
+            upper: f64::INFINITY,
+        } => Some(CONSTRAINT_BOUNDS_LOWER_ZERO),
+        _ => None,
+    }
+}
+
 pub use csc_import::CscInput;
 pub use error::ModelError;
 pub use inspect::{
@@ -55,10 +368,10 @@ pub use view::{ModelFingerprint, ModelPatch, ModelView, PatchedModelView, Struct
 /// The internal representation uses column-first sparse storage (CSC format).
 #[derive(Debug, Clone)]
 pub struct Model {
-    pub(crate) variables: Vec<Bounds>,
+    pub(crate) variables: VariableStore,
     pub(crate) variable_is_integer_bits: Vec<u64>,
     pub(crate) variable_is_inactive_bits: Vec<u64>,
-    pub(crate) constraints: Vec<Constraint>,
+    pub(crate) constraints: ConstraintStore,
     pub(crate) objective: Objective,
     pub(crate) objective_name: Option<String>,
     simplify_level: SimplifyLevel,
@@ -109,10 +422,10 @@ impl Model {
     /// Create a new empty model.
     pub fn new() -> Self {
         Self {
-            variables: Vec::new(),
+            variables: VariableStore::new(),
             variable_is_integer_bits: Vec::new(),
             variable_is_inactive_bits: Vec::new(),
-            constraints: Vec::new(),
+            constraints: ConstraintStore::new(),
             objective: Objective::new(),
             objective_name: None,
             simplify_level: SimplifyLevel::default(),
@@ -132,10 +445,10 @@ impl Model {
     /// Create a new model with pre-allocated storage capacities.
     pub fn with_capacities(variable_capacity: usize, constraint_capacity: usize) -> Self {
         Self {
-            variables: Vec::with_capacity(variable_capacity),
+            variables: VariableStore::with_capacity(variable_capacity),
             variable_is_integer_bits: Vec::with_capacity(variable_capacity.div_ceil(BITS_PER_WORD)),
             variable_is_inactive_bits: Vec::new(),
-            constraints: Vec::with_capacity(constraint_capacity),
+            constraints: ConstraintStore::with_capacity(constraint_capacity),
             objective: Objective::new(),
             objective_name: None,
             simplify_level: SimplifyLevel::default(),
@@ -183,10 +496,43 @@ impl Model {
         &self.objective
     }
 
+    #[doc(hidden)]
+    pub fn take_objective_terms_for_consumed_solve(&mut self) -> Vec<(VariableId, f64)> {
+        std::mem::take(&mut self.objective.terms)
+    }
+
+    #[doc(hidden)]
+    pub fn drain_column_for_consumed_solve(
+        &mut self,
+        variable_id: VariableId,
+        mut visit: impl FnMut(ConstraintId, f64),
+    ) -> bool {
+        let idx = variable_id.inner() as usize;
+        let Some(column) = self.columns.get_mut(idx) else {
+            return false;
+        };
+        for (constraint_id, coefficient) in std::mem::take(column) {
+            visit(constraint_id, coefficient);
+        }
+        true
+    }
+
+    pub(crate) fn shrink_retained_storage(&mut self) {
+        self.variables.shrink_to_fit();
+        self.variable_is_integer_bits.shrink_to_fit();
+        self.variable_is_inactive_bits.shrink_to_fit();
+        self.constraints.shrink_to_fit();
+        self.columns.shrink_to_fit();
+        for column in &mut self.columns {
+            column.shrink_to_fit();
+        }
+        self.slack_handles.shrink_to_fit();
+    }
+
     #[inline]
-    pub(crate) fn push_variable(&mut self, variable: Variable) {
+    pub(crate) fn push_variable(&mut self, variable: Variable) -> Result<(), ModelError> {
         let idx = self.variables.len();
-        self.variables.push(variable.bounds);
+        self.variables.push_bounds(variable.bounds)?;
         self.columns.push(ColumnVec::new());
         if variable.is_integer {
             Self::write_packed_flag(&mut self.variable_is_integer_bits, idx, true);
@@ -194,11 +540,12 @@ impl Model {
         if !variable.is_active {
             Self::write_packed_flag(&mut self.variable_is_inactive_bits, idx, true);
         }
+        Ok(())
     }
 
     #[inline]
     pub(crate) fn get_variable_by_index(&self, idx: usize) -> Option<Variable> {
-        let bounds = *self.variables.get(idx)?;
+        let bounds = self.variables.get_bounds(idx)?;
         Some(Variable {
             bounds,
             is_integer: Self::read_packed_flag(&self.variable_is_integer_bits, idx),
@@ -276,6 +623,20 @@ impl Model {
 
         let skip_zeros = matches!(self.simplify_level, SimplifyLevel::Light);
 
+        if terms_are_sorted_unique_nonzero(&terms) {
+            tracing::debug!(
+                component = "model",
+                operation = "lower_expr",
+                status = "success",
+                simplify_level = self.simplify_level.as_str(),
+                expr_terms_in = terms_in,
+                expr_terms_out = terms.len(),
+                duration_ms = started.elapsed().as_secs_f64() * 1000.0,
+                "Lowered already-normalized linear expression"
+            );
+            return terms;
+        }
+
         // Pre-filter zeros if needed (in-place)
         if skip_zeros {
             terms.retain(|(_, coeff)| *coeff != 0.0);
@@ -319,14 +680,42 @@ impl Model {
         terms
     }
 
-    pub(crate) fn add_objective_terms(&mut self, terms: Vec<(VariableId, f64)>) {
+    pub fn add_objective_terms(&mut self, terms: Vec<(VariableId, f64)>) -> Result<(), ModelError> {
         if terms.is_empty() {
-            return;
+            return Ok(());
+        }
+        if self.objective.sense.is_none() {
+            return Err(ModelError::NoObjective);
+        }
+        for (var_id, coeff) in &terms {
+            self.ensure_variable_exists(*var_id)?;
+            if !coefficient_is_valid(*coeff) {
+                return Err(ModelError::InvalidCoefficient {
+                    coefficient: *coeff,
+                });
+            }
         }
         let mut merged = std::mem::take(&mut self.objective.terms);
         merged.extend(terms);
         self.objective.terms = self.normalize_terms(merged);
+        Ok(())
     }
+}
+
+#[inline]
+fn terms_are_sorted_unique_nonzero(terms: &[(VariableId, f64)]) -> bool {
+    let mut previous: Option<u32> = None;
+    for (var_id, coefficient) in terms {
+        if *coefficient == 0.0 {
+            return false;
+        }
+        let current = var_id.inner();
+        if previous.is_some_and(|previous| current <= previous) {
+            return false;
+        }
+        previous = Some(current);
+    }
+    true
 }
 
 impl Default for Model {
@@ -387,6 +776,16 @@ mod tests {
         assert_eq!(model.num_variables(), 0);
         assert_eq!(model.num_constraints(), 0);
         assert!(model.variables.capacity() >= 32);
+        assert!(model.constraints.capacity() >= 16);
+    }
+
+    #[test]
+    fn test_reserve_constraints_preallocates_without_adding_rows() {
+        let mut model = Model::new();
+
+        model.reserve_constraints(16);
+
+        assert_eq!(model.num_constraints(), 0);
         assert!(model.constraints.capacity() >= 16);
     }
 
@@ -462,6 +861,83 @@ mod tests {
     }
 
     #[test]
+    fn test_constraint_store_compacts_common_bounds_and_roundtrips_custom_bounds() {
+        let mut model = Model::new();
+        let equality = model
+            .add_constraint(Constraint {
+                bounds: Bounds::new(0.0, 0.0),
+            })
+            .unwrap();
+        let upper_zero = model
+            .add_constraint(Constraint {
+                bounds: Bounds::new(f64::NEG_INFINITY, 0.0),
+            })
+            .unwrap();
+        let custom = model
+            .add_constraint(Constraint {
+                bounds: Bounds::new(3.0, 7.0),
+            })
+            .unwrap();
+
+        assert_eq!(model.constraints.custom.len(), 1);
+        assert_eq!(
+            model.get_constraint(equality).unwrap().bounds,
+            Bounds::new(0.0, 0.0)
+        );
+        assert_eq!(
+            model.get_constraint(upper_zero).unwrap().bounds,
+            Bounds::new(f64::NEG_INFINITY, 0.0)
+        );
+        assert_eq!(
+            model.get_constraint(custom).unwrap().bounds,
+            Bounds::new(3.0, 7.0)
+        );
+    }
+
+    #[test]
+    fn test_constraint_store_reuses_recent_custom_bounds() {
+        let mut model = Model::new();
+        let first = model
+            .add_constraint(Constraint {
+                bounds: Bounds::new(3.0, 7.0),
+            })
+            .unwrap();
+        let second = model
+            .add_constraint(Constraint {
+                bounds: Bounds::new(3.0, 7.0),
+            })
+            .unwrap();
+        let third = model
+            .add_constraint(Constraint {
+                bounds: Bounds::new(5.0, 9.0),
+            })
+            .unwrap();
+        let fourth = model
+            .add_constraint(Constraint {
+                bounds: Bounds::new(3.0, 7.0),
+            })
+            .unwrap();
+
+        assert_eq!(model.constraints.custom.len(), 2);
+        assert_eq!(
+            model.get_constraint(first).unwrap().bounds,
+            Bounds::new(3.0, 7.0)
+        );
+        assert_eq!(
+            model.get_constraint(second).unwrap().bounds,
+            Bounds::new(3.0, 7.0)
+        );
+        assert_eq!(
+            model.get_constraint(third).unwrap().bounds,
+            Bounds::new(5.0, 9.0)
+        );
+        assert_eq!(
+            model.get_constraint(fourth).unwrap().bounds,
+            Bounds::new(3.0, 7.0)
+        );
+    }
+
+    #[test]
     fn test_set_objective() {
         let mut model = Model::new();
         let var_id = model
@@ -480,6 +956,60 @@ mod tests {
         model.set_objective(objective).unwrap();
         assert_eq!(model.objective().sense, Some(Sense::Minimize));
         assert_eq!(model.objective().terms.len(), 1);
+    }
+
+    #[test]
+    fn test_set_objective_trims_excess_term_capacity() {
+        let mut model = Model::new();
+        let var_id = model
+            .add_variable(Variable {
+                bounds: Bounds::new(0.0, 10.0),
+                is_integer: false,
+                is_active: true,
+            })
+            .unwrap();
+        let mut terms = Vec::with_capacity(16);
+        terms.push((var_id, 1.0));
+
+        model
+            .set_objective(Objective {
+                sense: Some(Sense::Minimize),
+                terms,
+            })
+            .unwrap();
+
+        assert_eq!(
+            model.objective().terms.capacity(),
+            model.objective().terms.len()
+        );
+    }
+
+    #[test]
+    fn test_set_objective_shrinks_retained_column_capacity() {
+        let mut model = Model::new();
+        let var_id = model
+            .add_variable(Variable::continuous(Bounds::new(0.0, 10.0)))
+            .unwrap();
+        for _ in 0..3 {
+            let constraint_id = model
+                .add_constraint(Constraint {
+                    bounds: Bounds::new(0.0, 1.0),
+                })
+                .unwrap();
+            model.set_coefficient(var_id, constraint_id, 1.0).unwrap();
+        }
+        model.columns[var_id.inner() as usize].reserve(16);
+
+        model
+            .set_objective(Objective {
+                sense: Some(Sense::Minimize),
+                terms: vec![(var_id, 1.0)],
+            })
+            .unwrap();
+
+        let column = &model.columns[var_id.inner() as usize];
+        assert_eq!(column.len(), 3);
+        assert_eq!(column.capacity(), 3);
     }
 
     #[test]
@@ -564,7 +1094,9 @@ mod tests {
             })
             .unwrap();
 
-        model.add_objective_terms(vec![(x, 2.0), (y, 3.0), (x, -1.0)]);
+        model
+            .add_objective_terms(vec![(x, 2.0), (y, 3.0), (x, -1.0)])
+            .unwrap();
 
         assert_eq!(model.objective().sense, Some(Sense::Minimize));
         let mut terms = model.objective().terms.clone();
@@ -590,9 +1122,61 @@ mod tests {
             })
             .unwrap();
 
-        model.add_objective_terms(Vec::new());
+        model.add_objective_terms(Vec::new()).unwrap();
 
         assert_eq!(model.objective().terms, vec![(x, 1.0)]);
+    }
+
+    #[test]
+    fn test_take_objective_terms_preserves_sense_and_drains_terms() {
+        let mut model = Model::new();
+        let x = model
+            .add_variable(Variable {
+                bounds: Bounds::new(0.0, 10.0),
+                is_integer: false,
+                is_active: true,
+            })
+            .unwrap();
+        model
+            .set_objective(Objective {
+                sense: Some(Sense::Minimize),
+                terms: vec![(x, 2.0)],
+            })
+            .unwrap();
+
+        let terms = model.take_objective_terms_for_consumed_solve();
+
+        assert_eq!(terms, vec![(x, 2.0)]);
+        assert_eq!(model.objective().sense, Some(Sense::Minimize));
+        assert!(model.objective().terms.is_empty());
+    }
+
+    #[test]
+    fn test_drain_column_for_consumed_solve_visits_entries_and_clears_column() {
+        let mut model = Model::new();
+        let x = model
+            .add_variable(Variable {
+                bounds: Bounds::new(0.0, 10.0),
+                is_integer: false,
+                is_active: true,
+            })
+            .unwrap();
+        let row = model
+            .add_constraint(Constraint {
+                bounds: Bounds::new(0.0, 100.0),
+            })
+            .unwrap();
+        model.set_coefficient(x, row, 3.5).unwrap();
+
+        let mut drained = Vec::new();
+        assert!(
+            model.drain_column_for_consumed_solve(x, |constraint_id, coefficient| {
+                drained.push((constraint_id, coefficient));
+            })
+        );
+
+        assert_eq!(drained, vec![(row, 3.5)]);
+        assert!(model.get_column(x).is_some_and(|column| column.is_empty()));
     }
 
     #[test]
@@ -742,6 +1326,231 @@ mod tests {
 
         let col_v2 = model.get_column(v2).expect("v2 column missing");
         assert_eq!(col_v2, &vec![(c2, 3.5)]);
+    }
+
+    #[test]
+    fn test_streaming_constraint_batch_inserts_rows_without_retained_batch() {
+        let mut model = Model::new();
+        let v1 = model
+            .add_variable(Variable::continuous(Bounds::new(0.0, 10.0)))
+            .unwrap();
+        let v2 = model
+            .add_variable(Variable::continuous(Bounds::new(0.0, 10.0)))
+            .unwrap();
+
+        let rows = vec![
+            (vec![(v1, 1.0)], Bounds::new(0.0, 5.0)),
+            (vec![(v1, -1.0), (v2, 2.0)], Bounds::new(3.0, 3.0)),
+        ];
+
+        let first = model
+            .add_constraints_batch_streaming(rows.len(), rows)
+            .unwrap();
+
+        assert_eq!(first, ConstraintId::new(0));
+        assert_eq!(model.num_constraints(), 2);
+        assert_eq!(
+            model.get_column(v1).expect("v1 column missing"),
+            &vec![(ConstraintId::new(0), 1.0), (ConstraintId::new(1), -1.0)]
+        );
+        assert_eq!(
+            model.get_column(v2).expect("v2 column missing"),
+            &vec![(ConstraintId::new(1), 2.0)]
+        );
+    }
+
+    #[test]
+    fn test_compact_indexed_constraints_use_dense_row_indices() {
+        let mut model = Model::new();
+        for _ in 0..6 {
+            model
+                .add_variable(Variable::continuous(Bounds::new(0.0, 10.0)))
+                .unwrap();
+        }
+
+        let first = model
+            .add_constraints_compact_indexed(
+                &[(0, 1.0), (3, -2.0)],
+                &[0, 2],
+                &[Bounds::new(0.0, 1.0), Bounds::new(4.0, 4.0)],
+            )
+            .unwrap();
+
+        assert_eq!(first, ConstraintId::new(0));
+        assert_eq!(model.num_constraints(), 2);
+        assert_eq!(
+            model
+                .get_column(VariableId::new(0))
+                .expect("v0 column missing"),
+            &vec![(ConstraintId::new(0), 1.0)]
+        );
+        assert_eq!(
+            model
+                .get_column(VariableId::new(2))
+                .expect("v2 column missing"),
+            &vec![(ConstraintId::new(1), 1.0)]
+        );
+        assert_eq!(
+            model
+                .get_column(VariableId::new(3))
+                .expect("v3 column missing"),
+            &vec![(ConstraintId::new(0), -2.0)]
+        );
+        assert_eq!(
+            model
+                .get_column(VariableId::new(5))
+                .expect("v5 column missing"),
+            &vec![(ConstraintId::new(1), -2.0)]
+        );
+    }
+
+    #[test]
+    fn test_add_variables_uniform_assigns_contiguous_ids() {
+        let mut model = Model::new();
+        let first = model
+            .add_variables_uniform(Variable::continuous(Bounds::new(0.0, 10.0)), 3)
+            .unwrap();
+
+        assert_eq!(first, VariableId::new(0));
+        assert_eq!(model.num_variables(), 3);
+        assert_eq!(model.next_variable_id, 3);
+        for idx in 0..3 {
+            let variable = model.get_variable(VariableId::new(idx)).unwrap();
+            assert_eq!(variable.bounds, Bounds::new(0.0, 10.0));
+            assert!(variable.is_active);
+            assert!(!variable.is_integer);
+        }
+
+        let second = model
+            .add_variables_uniform(Variable::integer(Bounds::new(-1.0, 4.0)), 2)
+            .unwrap();
+
+        assert_eq!(second, VariableId::new(3));
+        assert_eq!(model.num_variables(), 5);
+        for idx in 3..5 {
+            let variable = model.get_variable(VariableId::new(idx)).unwrap();
+            assert_eq!(variable.bounds, Bounds::new(-1.0, 4.0));
+            assert!(variable.is_integer);
+        }
+    }
+
+    #[test]
+    fn test_add_variables_uniform_rejects_invalid_bounds() {
+        let mut model = Model::new();
+        let result = model.add_variables_uniform(Variable::continuous(Bounds::new(5.0, 1.0)), 2);
+
+        assert_eq!(
+            result,
+            Err(ModelError::InvalidVariableBounds {
+                lower: 5.0,
+                upper: 1.0
+            })
+        );
+        assert_eq!(model.num_variables(), 0);
+    }
+
+    #[test]
+    fn test_add_variables_with_bounds_assigns_contiguous_ids() {
+        let mut model = Model::new();
+        let bounds = [
+            Bounds::new(0.0, 1.0),
+            Bounds::new(2.0, 5.0),
+            Bounds::new(-3.0, 4.0),
+        ];
+
+        let first = model
+            .add_variables_with_bounds(&bounds, true, true)
+            .unwrap();
+
+        assert_eq!(first, VariableId::new(0));
+        assert_eq!(model.num_variables(), 3);
+        assert_eq!(model.next_variable_id, 3);
+        for (idx, expected_bounds) in bounds.iter().copied().enumerate() {
+            let variable = model.get_variable(VariableId::new(idx as u32)).unwrap();
+            assert_eq!(variable.bounds, expected_bounds);
+            assert!(variable.is_integer);
+            assert!(variable.is_active);
+        }
+    }
+
+    #[test]
+    fn test_variable_store_compacts_common_bounds_and_deduplicates_custom_bounds() {
+        let mut model = Model::new();
+        model
+            .add_variables_uniform(Variable::continuous(Bounds::new(0.0, f64::INFINITY)), 3)
+            .unwrap();
+        model
+            .add_variables_with_bounds(
+                &[
+                    Bounds::new(0.0, 7.0),
+                    Bounds::new(0.0, 7.0),
+                    Bounds::new(0.0, 9.0),
+                    Bounds::new(0.0, 7.0),
+                ],
+                false,
+                true,
+            )
+            .unwrap();
+
+        assert_eq!(model.variables.custom.len(), 2);
+        assert_eq!(
+            model.get_variable(VariableId::new(0)).unwrap().bounds,
+            Bounds::new(0.0, f64::INFINITY)
+        );
+        assert_eq!(
+            model.get_variable(VariableId::new(3)).unwrap().bounds,
+            Bounds::new(0.0, 7.0)
+        );
+        assert_eq!(
+            model.get_variable(VariableId::new(5)).unwrap().bounds,
+            Bounds::new(0.0, 9.0)
+        );
+    }
+
+    #[test]
+    fn test_add_variables_with_bounds_rejects_invalid_bounds() {
+        let mut model = Model::new();
+        let bounds = [Bounds::new(0.0, 1.0), Bounds::new(5.0, 1.0)];
+        let result = model.add_variables_with_bounds(&bounds, false, true);
+
+        assert_eq!(
+            result,
+            Err(ModelError::InvalidVariableBounds {
+                lower: 5.0,
+                upper: 1.0
+            })
+        );
+        assert_eq!(model.num_variables(), 0);
+    }
+
+    #[test]
+    fn normalize_terms_keeps_already_sorted_unique_terms() {
+        let model = Model::new();
+        let terms = vec![
+            (VariableId::new(1), 2.0),
+            (VariableId::new(3), -4.0),
+            (VariableId::new(8), 1.5),
+        ];
+
+        assert!(super::terms_are_sorted_unique_nonzero(&terms));
+        assert_eq!(model.normalize_terms(terms.clone()), terms);
+    }
+
+    #[test]
+    fn normalize_terms_still_merges_duplicates_and_removes_zeros() {
+        let model = Model::new();
+        let terms = vec![
+            (VariableId::new(3), 1.0),
+            (VariableId::new(1), 2.0),
+            (VariableId::new(3), -1.0),
+            (VariableId::new(2), 0.0),
+        ];
+
+        assert!(!super::terms_are_sorted_unique_nonzero(&terms));
+        assert_eq!(
+            model.normalize_terms(terms),
+            vec![(VariableId::new(1), 2.0)]
+        );
     }
 
     #[test]

--- a/crates/arco-model/src/model/slack.rs
+++ b/crates/arco-model/src/model/slack.rs
@@ -68,7 +68,7 @@ impl Model {
             objective_terms.push((slack_var, objective_coeff));
         }
 
-        self.add_objective_terms(objective_terms);
+        self.add_objective_terms(objective_terms)?;
 
         tracing::debug!(
             component = "slack",

--- a/crates/arco-ops/src/execution_backends.rs
+++ b/crates/arco-ops/src/execution_backends.rs
@@ -56,6 +56,22 @@ pub(crate) fn solve_model_view_with_builtin_backend(
     registry.solve(family, model, config)
 }
 
+pub(crate) fn solve_owned_model_with_builtin_backend(
+    family: &str,
+    model: arco_model::Model,
+    config: &SolverConfig,
+) -> Result<ModelViewSolveResult, SolverError> {
+    let family = normalize_model_view_backend_family(family);
+    if family == "highs" {
+        return arco_highs::solve_owned_model(model, config);
+    }
+    #[cfg(feature = "xpress")]
+    if family == "xpress" {
+        return arco_xpress::solve_owned_model(model, config);
+    }
+    solve_model_view_with_builtin_backend(family, &model, config)
+}
+
 pub(crate) fn builtin_solver_version(family: &str) -> Option<String> {
     match normalize_model_view_backend_family(family) {
         "highs" => highs_version(),

--- a/crates/arco-ops/src/lib.rs
+++ b/crates/arco-ops/src/lib.rs
@@ -270,6 +270,18 @@ impl ArcoOps {
         crate::execution_backends::solve_model_view_with_builtin_backend(family, model, config)
     }
 
+    /// Solve an owned in-memory model through a builtin backend.
+    ///
+    /// This is intended for memory-sensitive callers that will not use the
+    /// model after solver handoff.
+    pub fn solve_owned_model_with_builtin_backend(
+        family: &str,
+        model: arco_model::Model,
+        config: &SolverConfig,
+    ) -> Result<ModelViewSolveResult, SolverError> {
+        crate::execution_backends::solve_owned_model_with_builtin_backend(family, model, config)
+    }
+
     /// Return the version for a builtin backend family when available.
     pub fn builtin_solver_version(family: &str) -> Option<String> {
         crate::execution_backends::builtin_solver_version(family)

--- a/crates/arco-solver/src/lib.rs
+++ b/crates/arco-solver/src/lib.rs
@@ -23,6 +23,7 @@ pub use conformance::{
 };
 pub use model_view_backend::{
     ModelViewBackend, ModelViewBackendRegistry, validate_model_view_solve_result,
+    validate_model_view_solve_result_with_config,
 };
 pub use preflight::{
     PreflightError, SolverRequirements, preflight_model_view, preflight_selection,

--- a/crates/arco-solver/src/model_view_backend.rs
+++ b/crates/arco-solver/src/model_view_backend.rs
@@ -75,7 +75,7 @@ impl<'a> ModelViewBackendRegistry<'a> {
             ))
         })?;
         let result = backend.solve_model_view(model, config)?;
-        validate_model_view_solve_result(model, &result)?;
+        validate_model_view_solve_result_with_config(model, &result, config)?;
         Ok(result)
     }
 }
@@ -85,17 +85,47 @@ pub fn validate_model_view_solve_result(
     model: &(impl ModelView + ?Sized),
     result: &ModelViewSolveResult,
 ) -> Result<(), SolverError> {
+    validate_model_view_solve_result_shape(model, result, false)
+}
+
+/// Validate a backend result against the supplied solver configuration.
+///
+/// Solver results normally include primal values. Callers may opt into an
+/// objective-only result with the private `arco.extract_solution=false` option
+/// to avoid large post-solve solution vectors when only status/objective
+/// metadata are needed.
+pub fn validate_model_view_solve_result_with_config(
+    model: &(impl ModelView + ?Sized),
+    result: &ModelViewSolveResult,
+    config: &SolverConfig,
+) -> Result<(), SolverError> {
+    validate_model_view_solve_result_shape(model, result, allows_omitted_primal_values(config))
+}
+
+fn validate_model_view_solve_result_shape(
+    model: &(impl ModelView + ?Sized),
+    result: &ModelViewSolveResult,
+    allow_omitted_primal_values: bool,
+) -> Result<(), SolverError> {
     let expected_fingerprint = model.fingerprint();
-    if result.fingerprint != expected_fingerprint {
+    if result.fingerprint.0 != 0 && result.fingerprint != expected_fingerprint {
         return Err(SolverError::InvalidResultShape(
             "result fingerprint does not match input model fingerprint".to_string(),
         ));
     }
-    validate_required_len(
-        "primal_values",
-        result.primal_values.len(),
-        model.num_variables(),
-    )?;
+    if allow_omitted_primal_values {
+        validate_optional_len(
+            "primal_values",
+            result.primal_values.len(),
+            model.num_variables(),
+        )?;
+    } else {
+        validate_required_len(
+            "primal_values",
+            result.primal_values.len(),
+            model.num_variables(),
+        )?;
+    }
     validate_optional_len(
         "variable_duals",
         result.variable_duals.len(),
@@ -112,6 +142,13 @@ pub fn validate_model_view_solve_result(
         model.num_constraints(),
     )?;
     Ok(())
+}
+
+fn allows_omitted_primal_values(config: &SolverConfig) -> bool {
+    config
+        .parameters
+        .get("arco.extract_solution")
+        .is_some_and(|value| value == "false")
 }
 
 fn validate_required_len(name: &str, actual: usize, expected: usize) -> Result<(), SolverError> {
@@ -138,7 +175,9 @@ mod tests {
         ModelViewBackend, ModelViewBackendRegistry, ModelViewSolveResult, SolverConfig,
         SolverError, SolverStatus,
     };
-    use arco_model::{Bounds, Model, ModelView, Objective, Sense, Variable, expr::Expr};
+    use arco_model::{
+        Bounds, Model, ModelFingerprint, ModelView, Objective, Sense, Variable, expr::Expr,
+    };
     use std::sync::Mutex;
 
     struct FixtureBackend;
@@ -233,6 +272,47 @@ mod tests {
             .expect_err("bad result shape should fail");
 
         assert!(matches!(error, SolverError::InvalidResultShape(_)));
+    }
+
+    #[test]
+    fn registry_accepts_objective_only_result_when_solution_extraction_is_disabled() {
+        let backend = BadShapeBackend;
+        let mut registry = ModelViewBackendRegistry::new();
+        registry.register(&backend);
+        let mut model = Model::new();
+        model
+            .add_variable(Variable::continuous(Bounds::new(0.0, 1.0)))
+            .expect("add variable");
+        let config = SolverConfig::new().with_parameter("arco.extract_solution", "false");
+
+        let result = registry
+            .solve("bad_shape", &model, &config)
+            .expect("objective-only result should be accepted when explicitly requested");
+
+        assert!(result.primal_values.is_empty());
+        assert!(result.objective_value.abs() <= f64::EPSILON);
+    }
+
+    #[test]
+    fn validation_accepts_zero_fingerprint_sentinel_when_lengths_match() {
+        let mut model = Model::new();
+        model
+            .add_variable(Variable::continuous(Bounds::new(0.0, 1.0)))
+            .expect("add variable");
+
+        let result = ModelViewSolveResult {
+            fingerprint: ModelFingerprint(0),
+            status: SolverStatus::Optimal,
+            objective_value: 0.0,
+            primal_values: vec![0.0],
+            variable_duals: Vec::new(),
+            row_values: Vec::new(),
+            constraint_duals: Vec::new(),
+            metadata: Default::default(),
+        };
+
+        super::validate_model_view_solve_result(&model, &result)
+            .expect("zero fingerprint sentinel should skip only fingerprint validation");
     }
 
     #[test]

--- a/crates/arco-solver/src/model_view_backend.rs
+++ b/crates/arco-solver/src/model_view_backend.rs
@@ -85,7 +85,7 @@ pub fn validate_model_view_solve_result(
     model: &(impl ModelView + ?Sized),
     result: &ModelViewSolveResult,
 ) -> Result<(), SolverError> {
-    validate_model_view_solve_result_shape(model, result, false)
+    validate_model_view_solve_result_shape(model, result, false, false)
 }
 
 /// Validate a backend result against the supplied solver configuration.
@@ -99,16 +99,27 @@ pub fn validate_model_view_solve_result_with_config(
     result: &ModelViewSolveResult,
     config: &SolverConfig,
 ) -> Result<(), SolverError> {
-    validate_model_view_solve_result_shape(model, result, allows_omitted_primal_values(config))
+    validate_model_view_solve_result_shape(
+        model,
+        result,
+        allows_omitted_primal_values(config),
+        allows_omitted_fingerprint(config),
+    )
 }
 
 fn validate_model_view_solve_result_shape(
     model: &(impl ModelView + ?Sized),
     result: &ModelViewSolveResult,
     allow_omitted_primal_values: bool,
+    allow_omitted_fingerprint: bool,
 ) -> Result<(), SolverError> {
-    let expected_fingerprint = model.fingerprint();
-    if result.fingerprint.0 != 0 && result.fingerprint != expected_fingerprint {
+    if result.fingerprint.0 == 0 {
+        if !allow_omitted_fingerprint {
+            return Err(SolverError::InvalidResultShape(
+                "result fingerprint does not match input model fingerprint".to_string(),
+            ));
+        }
+    } else if result.fingerprint != model.fingerprint() {
         return Err(SolverError::InvalidResultShape(
             "result fingerprint does not match input model fingerprint".to_string(),
         ));
@@ -148,6 +159,13 @@ fn allows_omitted_primal_values(config: &SolverConfig) -> bool {
     config
         .parameters
         .get("arco.extract_solution")
+        .is_some_and(|value| value == "false")
+}
+
+fn allows_omitted_fingerprint(config: &SolverConfig) -> bool {
+    config
+        .parameters
+        .get("arco.fingerprint")
         .is_some_and(|value| value == "false")
 }
 
@@ -294,7 +312,7 @@ mod tests {
     }
 
     #[test]
-    fn validation_accepts_zero_fingerprint_sentinel_when_lengths_match() {
+    fn validation_rejects_zero_fingerprint_without_config_opt_out() {
         let mut model = Model::new();
         model
             .add_variable(Variable::continuous(Bounds::new(0.0, 1.0)))
@@ -311,8 +329,16 @@ mod tests {
             metadata: Default::default(),
         };
 
-        super::validate_model_view_solve_result(&model, &result)
-            .expect("zero fingerprint sentinel should skip only fingerprint validation");
+        assert!(matches!(
+            super::validate_model_view_solve_result(&model, &result),
+            Err(SolverError::InvalidResultShape(_))
+        ));
+        super::validate_model_view_solve_result_with_config(
+            &model,
+            &result,
+            &SolverConfig::new().with_parameter("arco.fingerprint", "false"),
+        )
+        .expect("config opt-out permits omitted fingerprint");
     }
 
     #[test]

--- a/crates/arco-xpress/src/ffi.rs
+++ b/crates/arco-xpress/src/ffi.rs
@@ -108,6 +108,8 @@ type XPRSgetlpsolFn = unsafe extern "C" fn(
 type XPRSgetmipsolFn = unsafe extern "C" fn(XPRSprob, *mut c_double, *mut c_double) -> c_int;
 type XPRSaddmipsolFn =
     unsafe extern "C" fn(XPRSprob, c_int, *const c_double, *const c_int, *const c_char) -> c_int;
+type XPRSchgboundsFn =
+    unsafe extern "C" fn(XPRSprob, c_int, *const c_int, *const c_char, *const c_double) -> c_int;
 type XPRSsetintcontrolFn = unsafe extern "C" fn(XPRSprob, c_int, c_int) -> c_int;
 type XPRSgetintcontrolFn = unsafe extern "C" fn(XPRSprob, c_int, *mut c_int) -> c_int;
 type XPRSsetdblcontrolFn = unsafe extern "C" fn(XPRSprob, c_int, c_double) -> c_int;
@@ -256,6 +258,7 @@ pub struct Api {
     pub xprs_getlpsol: XPRSgetlpsolFn,
     pub xprs_getmipsol: XPRSgetmipsolFn,
     pub xprs_addmipsol: XPRSaddmipsolFn,
+    pub xprs_chgbounds: XPRSchgboundsFn,
     pub xprs_setintcontrol: XPRSsetintcontrolFn,
     pub xprs_getintcontrol: XPRSgetintcontrolFn,
     pub xprs_setdblcontrol: XPRSsetdblcontrolFn,
@@ -480,6 +483,7 @@ fn load_api_from_handle(handle: LibraryHandle) -> Result<Api, RuntimeLoadError> 
             XPRSaddmipsolFn,
             missing_xprs_addmipsol as XPRSaddmipsolFn
         ),
+        xprs_chgbounds: load_symbol!(handle, "XPRSchgbounds", XPRSchgboundsFn),
         xprs_setintcontrol: load_symbol!(handle, "XPRSsetintcontrol", XPRSsetintcontrolFn),
         xprs_getintcontrol: load_optional_symbol!(
             handle,

--- a/crates/arco-xpress/src/lib.rs
+++ b/crates/arco-xpress/src/lib.rs
@@ -11,5 +11,5 @@ mod status;
 pub use solution::Solution;
 pub use solver::{
     Solver, XpressModelViewBackend, detect_xpress_dir, detect_xpress_license_path,
-    solve_model_view, xpress_runtime_available,
+    solve_model_view, solve_owned_model, xpress_runtime_available,
 };

--- a/crates/arco-xpress/src/solver.rs
+++ b/crates/arco-xpress/src/solver.rs
@@ -6,7 +6,7 @@ use crate::status;
 use arco_model::{ConstraintId, ModelFingerprint, ModelView, Sense, VariableId};
 use arco_solver::{
     ModelViewBackend, ModelViewSolveResult, Solve, SolverConfig, SolverDiagnostic, SolverError,
-    SolverModelStats, validate_model_view_solve_result,
+    SolverModelStats, validate_model_view_solve_result_with_config,
 };
 use std::collections::BTreeMap;
 use std::ffi::{CStr, CString, c_char, c_int, c_void};
@@ -261,12 +261,12 @@ fn format_xpress_failure_message(action: &str, rc: c_int, last_error: Option<&st
     }
 }
 
-fn xpress_failure_error(
+fn xpress_failure_error_for_stats(
     api: &'static ffi::Api,
     prob: ffi::XPRSprob,
     action: &str,
     rc: c_int,
-    model: &(impl ModelView + ?Sized),
+    stats: &SolverModelStats,
 ) -> SolverError {
     let last_error = xprs_last_error(api, prob);
     if last_error
@@ -278,7 +278,7 @@ fn xpress_failure_error(
             operation: action.trim_start_matches("XPRS").to_ascii_lowercase(),
             return_code: rc,
             limit: 5000,
-            model: xpress_model_stats(model),
+            model: stats.clone(),
         });
     }
 
@@ -397,6 +397,7 @@ fn validate_solver_config(config: &SolverConfig) -> Result<(), SolverError> {
     ensure_non_negative_finite_setting("time_limit", config.time_limit)?;
     ensure_non_negative_finite_setting("mip_gap", config.mip_gap)?;
     ensure_non_negative_finite_setting("tolerance", config.tolerance)?;
+    let _ = lp_optimize_flags(config)?;
 
     if let Some(0) = config.threads {
         return Err(SolverError::InvalidSettings(
@@ -404,6 +405,26 @@ fn validate_solver_config(config: &SolverConfig) -> Result<(), SolverError> {
         ));
     }
     Ok(())
+}
+
+fn lp_optimize_flags(config: &SolverConfig) -> Result<Option<&'static str>, SolverError> {
+    let algorithm = config
+        .parameters
+        .get("xpress.lp_algorithm")
+        .map_or("auto", String::as_str);
+    match algorithm {
+        "auto" | "" => Ok(None),
+        "primal" | "primal_simplex" | "p" => Ok(Some("p")),
+        "dual" | "dual_simplex" | "d" => Ok(Some("d")),
+        "barrier" | "b" => Ok(Some("b")),
+        "primal_barrier" | "primal+barrier" | "pb" | "bp" => Ok(Some("pb")),
+        "dual_barrier" | "dual+barrier" | "db" | "bd" => Ok(Some("db")),
+        "primal_dual" | "primal+dual" | "pd" | "dp" => Ok(Some("pd")),
+        "all" | "pdb" | "pbd" | "dpb" | "dbp" | "bpd" | "bdp" => Ok(Some("pdb")),
+        other => Err(SolverError::InvalidSettings(format!(
+            "xpress.lp_algorithm must be one of auto, primal, dual, barrier, primal_barrier, dual_barrier, primal_dual, or all (got {other:?})"
+        ))),
+    }
 }
 
 #[allow(unsafe_code)]
@@ -479,92 +500,153 @@ struct SolveArtifacts {
     metadata: BTreeMap<String, f64>,
 }
 
-#[allow(unsafe_code)]
-fn solve_problem(
+struct PreparedModelViewSolve {
+    problem: PreparedXpressProblem,
+    fingerprint: ModelFingerprint,
+    fingerprint_seconds: f64,
+    num_variables: usize,
+    num_constraints: usize,
+}
+
+struct PreparedModelViewLoad {
+    load_data: XpressLoadData,
+    fingerprint: ModelFingerprint,
+    fingerprint_seconds: f64,
+    num_variables: usize,
+    num_constraints: usize,
+}
+
+struct PreparedXpressProblem {
+    prob_guard: ProbGuard,
+    _env_guard: XpressGuard,
+    api: &'static ffi::Api,
+    ncols: usize,
+    nrows: usize,
+    has_integer: bool,
+    stats: SolverModelStats,
+    matrix_build_seconds: f64,
+    solve_started: Instant,
+}
+
+struct XpressLoadData {
+    ncols: usize,
+    nrows: usize,
+    has_integer: bool,
+    stats: SolverModelStats,
+    sense: Sense,
+    objective_coefficients: XpressObjectiveCoefficients,
+    variable_bounds: XpressVariableBounds,
+    row_types: Vec<u8>,
+    rhs: Vec<f64>,
+    rng: Option<Vec<f64>>,
+    matrix: XpressColumnMatrix,
+    col_types: Vec<u8>,
+    int_col_indices: Vec<c_int>,
+    int_col_limits: Vec<f64>,
+    matrix_build_seconds: f64,
+    solve_started: Instant,
+}
+
+struct XpressColumnMatrix {
+    mstart: Vec<c_int>,
+    mrwind: Vec<c_int>,
+    dmatval: Vec<f64>,
+}
+
+enum XpressObjectiveCoefficients {
+    Dense(Vec<f64>),
+    Sparse(Vec<(VariableId, f64)>),
+}
+
+enum XpressVariableBounds {
+    Full {
+        lower_bounds: Vec<f64>,
+        upper_bounds: Vec<f64>,
+    },
+    DefaultNonnegativeWithUpperChanges {
+        upper_indices: Vec<c_int>,
+        upper_types: Vec<u8>,
+        upper_values: Vec<f64>,
+    },
+}
+
+impl XpressVariableBounds {
+    fn load_ptrs(&self) -> (*const f64, *const f64) {
+        match self {
+            Self::Full {
+                lower_bounds,
+                upper_bounds,
+            } => (lower_bounds.as_ptr(), upper_bounds.as_ptr()),
+            Self::DefaultNonnegativeWithUpperChanges { .. } => (std::ptr::null(), std::ptr::null()),
+        }
+    }
+
+    fn lower_bound_for_integer_column(&self, index: usize) -> Option<f64> {
+        match self {
+            Self::Full { lower_bounds, .. } => lower_bounds.get(index).copied(),
+            Self::DefaultNonnegativeWithUpperChanges { .. } => Some(0.0),
+        }
+    }
+
+    #[allow(unsafe_code)]
+    fn apply_deferred_changes(
+        self,
+        api: &'static ffi::Api,
+        prob: ffi::XPRSprob,
+        stats: &SolverModelStats,
+    ) -> Result<(), SolverError> {
+        let Self::DefaultNonnegativeWithUpperChanges {
+            upper_indices,
+            upper_types,
+            upper_values,
+        } = self
+        else {
+            return Ok(());
+        };
+        if upper_indices.is_empty() {
+            return Ok(());
+        }
+
+        ffi::check_xprs(unsafe {
+            (api.xprs_chgbounds)(
+                prob,
+                upper_indices.len() as c_int,
+                upper_indices.as_ptr(),
+                upper_types.as_ptr().cast::<c_char>(),
+                upper_values.as_ptr(),
+            )
+        })
+        .map_err(|rc| xpress_failure_error_for_stats(api, prob, "XPRSchgbounds", rc, stats))
+    }
+}
+
+impl XpressObjectiveCoefficients {
+    fn into_dense(self, ncols: usize) -> Vec<f64> {
+        match self {
+            Self::Dense(coefficients) => coefficients,
+            Self::Sparse(terms) => {
+                let mut coefficients = vec![0.0; ncols];
+                for (variable_id, coefficient) in terms {
+                    let index = variable_id.inner() as usize;
+                    if index < coefficients.len() {
+                        coefficients[index] += coefficient;
+                    }
+                }
+                coefficients
+            }
+        }
+    }
+}
+
+fn build_xpress_column_matrix(
     model: &(impl ModelView + ?Sized),
-    config: &SolverConfig,
-) -> Result<SolveArtifacts, SolverError> {
-    if model.num_variables() == 0 {
-        return Err(SolverError::EmptyModel);
-    }
-
-    let solve_started = Instant::now();
-    let ncols = model.num_variables();
-    let nrows = model.num_constraints();
-    let sense = model.objective().sense.unwrap_or(Sense::Minimize);
-
-    debug!(
-        component = "solver",
-        operation = "solve",
-        solver = "xpress",
-        variables = ncols as u64,
-        constraints = nrows as u64,
-        "Starting Xpress solve"
-    );
-
-    let mut objective_coefficients = vec![0.0; ncols];
-    for (variable_id, coefficient) in &model.objective().terms {
-        let index = variable_id.inner() as usize;
-        let variable = model
-            .variable(*variable_id)
-            .ok_or(SolverError::InvalidVariableId(variable_id.inner()))?;
-        if variable.is_active && index < objective_coefficients.len() {
-            objective_coefficients[index] += *coefficient;
-        }
-    }
-
-    let mut lower_bounds = Vec::with_capacity(ncols);
-    let mut upper_bounds = Vec::with_capacity(ncols);
-    let mut col_types = Vec::new();
-    let mut int_col_indices = Vec::new();
-    let mut int_col_limits = Vec::new();
-    let mut has_integer = false;
-
-    for index in 0..ncols {
-        let variable_id = VariableId::new(index as u32);
-        let variable = model
-            .variable(variable_id)
-            .ok_or(SolverError::InvalidVariableId(variable_id.inner()))?;
-        if variable.is_active {
-            lower_bounds.push(clamp_bound(variable.bounds.lower));
-            upper_bounds.push(clamp_bound(variable.bounds.upper));
-        } else {
-            lower_bounds.push(0.0);
-            upper_bounds.push(0.0);
-        }
-
-        if variable.is_integer && variable.is_active {
-            has_integer = true;
-            col_types.push(
-                if variable.bounds.lower >= -1e-12 && variable.bounds.upper <= 1.0 + 1e-12 {
-                    b'B'
-                } else {
-                    b'I'
-                },
-            );
-            int_col_indices.push(index as c_int);
-            int_col_limits.push(lower_bounds[index]);
-        }
-    }
-
-    let mut row_types = Vec::with_capacity(nrows);
-    let mut rhs = Vec::with_capacity(nrows);
-    let mut rng = Vec::with_capacity(nrows);
-    for index in 0..nrows {
-        let constraint = model
-            .constraint(ConstraintId::new(index as u32))
-            .ok_or_else(|| SolverError::SolverSpecific(format!("missing constraint {index}")))?;
-        let (row_type, rhs_value, range_value) =
-            bounds_to_xpress_row(constraint.bounds.lower, constraint.bounds.upper);
-        row_types.push(row_type);
-        rhs.push(rhs_value);
-        rng.push(range_value);
-    }
-
-    let matrix_build_start = Instant::now();
+    ncols: usize,
+    nrows: usize,
+    expected_coefficients: usize,
+) -> Result<XpressColumnMatrix, SolverError> {
     let mut mstart = Vec::with_capacity(ncols + 1);
-    let mut mrwind = Vec::new();
-    let mut dmatval = Vec::new();
+    let mut mrwind = Vec::with_capacity(expected_coefficients);
+    let mut dmatval = Vec::with_capacity(expected_coefficients);
     for index in 0..ncols {
         mstart.push(mrwind.len() as c_int);
         let variable_id = VariableId::new(index as u32);
@@ -585,7 +667,267 @@ fn solve_problem(
         }
     }
     mstart.push(mrwind.len() as c_int);
+    Ok(XpressColumnMatrix {
+        mstart,
+        mrwind,
+        dmatval,
+    })
+}
+
+fn build_xpress_variable_bounds(
+    model: &(impl ModelView + ?Sized),
+    ncols: usize,
+) -> Result<XpressVariableBounds, SolverError> {
+    let mut can_use_default_nonnegative_bounds = true;
+    for index in 0..ncols {
+        let variable_id = VariableId::new(index as u32);
+        let variable = model
+            .variable(variable_id)
+            .ok_or(SolverError::InvalidVariableId(variable_id.inner()))?;
+        if !variable.is_active {
+            continue;
+        }
+        if variable.is_integer || variable.bounds.lower != 0.0 {
+            can_use_default_nonnegative_bounds = false;
+            break;
+        }
+    }
+
+    if can_use_default_nonnegative_bounds {
+        let mut upper_indices = Vec::new();
+        let mut upper_values = Vec::new();
+        for index in 0..ncols {
+            let variable_id = VariableId::new(index as u32);
+            let variable = model
+                .variable(variable_id)
+                .ok_or(SolverError::InvalidVariableId(variable_id.inner()))?;
+            let upper = if variable.is_active {
+                clamp_bound(variable.bounds.upper)
+            } else {
+                0.0
+            };
+            if upper < ffi::XPRS_PLUSINFINITY {
+                upper_indices.push(index as c_int);
+                upper_values.push(upper);
+            }
+        }
+        return Ok(XpressVariableBounds::DefaultNonnegativeWithUpperChanges {
+            upper_types: vec![b'U'; upper_indices.len()],
+            upper_indices,
+            upper_values,
+        });
+    }
+
+    let mut lower_bounds = Vec::with_capacity(ncols);
+    let mut upper_bounds = Vec::with_capacity(ncols);
+    for index in 0..ncols {
+        let variable_id = VariableId::new(index as u32);
+        let variable = model
+            .variable(variable_id)
+            .ok_or(SolverError::InvalidVariableId(variable_id.inner()))?;
+        if variable.is_active {
+            lower_bounds.push(clamp_bound(variable.bounds.lower));
+            upper_bounds.push(clamp_bound(variable.bounds.upper));
+        } else {
+            lower_bounds.push(0.0);
+            upper_bounds.push(0.0);
+        }
+    }
+
+    Ok(XpressVariableBounds::Full {
+        lower_bounds,
+        upper_bounds,
+    })
+}
+
+fn dense_objective_coefficients(
+    model: &(impl ModelView + ?Sized),
+    terms: &[(VariableId, f64)],
+    ncols: usize,
+) -> Result<Vec<f64>, SolverError> {
+    let mut objective_coefficients = vec![0.0; ncols];
+    for (variable_id, coefficient) in terms {
+        let index = variable_id.inner() as usize;
+        let variable = model
+            .variable(*variable_id)
+            .ok_or(SolverError::InvalidVariableId(variable_id.inner()))?;
+        if variable.is_active && index < objective_coefficients.len() {
+            objective_coefficients[index] += *coefficient;
+        }
+    }
+    Ok(objective_coefficients)
+}
+
+fn retain_active_objective_terms(
+    model: &(impl ModelView + ?Sized),
+    terms: &mut Vec<(VariableId, f64)>,
+    ncols: usize,
+) -> Result<(), SolverError> {
+    let mut write_index = 0;
+    for read_index in 0..terms.len() {
+        let (variable_id, coefficient) = terms[read_index];
+        let index = variable_id.inner() as usize;
+        let variable = model
+            .variable(variable_id)
+            .ok_or(SolverError::InvalidVariableId(variable_id.inner()))?;
+        if variable.is_active && index < ncols {
+            terms[write_index] = (variable_id, coefficient);
+            write_index += 1;
+        }
+    }
+    terms.truncate(write_index);
+    Ok(())
+}
+
+#[allow(unsafe_code)]
+fn prepare_load_data(model: &(impl ModelView + ?Sized)) -> Result<XpressLoadData, SolverError> {
+    let ncols = model.num_variables();
+    let objective_coefficients =
+        dense_objective_coefficients(model, model.objective().terms.as_slice(), ncols)?;
+    prepare_load_data_with_objective(
+        model,
+        XpressObjectiveCoefficients::Dense(objective_coefficients),
+    )
+}
+
+#[allow(unsafe_code)]
+fn prepare_load_data_with_objective(
+    model: &(impl ModelView + ?Sized),
+    objective_coefficients: XpressObjectiveCoefficients,
+) -> Result<XpressLoadData, SolverError> {
+    if model.num_variables() == 0 {
+        return Err(SolverError::EmptyModel);
+    }
+
+    let solve_started = Instant::now();
+    let ncols = model.num_variables();
+    let nrows = model.num_constraints();
+    let stats = xpress_model_stats(model);
+    let sense = model.objective().sense.unwrap_or(Sense::Minimize);
+
+    debug!(
+        component = "solver",
+        operation = "solve",
+        solver = "xpress",
+        variables = ncols as u64,
+        constraints = nrows as u64,
+        "Starting Xpress solve"
+    );
+
+    let variable_bounds = build_xpress_variable_bounds(model, ncols)?;
+    let mut col_types = Vec::new();
+    let mut int_col_indices = Vec::new();
+    let mut int_col_limits = Vec::new();
+    let mut has_integer = false;
+
+    for index in 0..ncols {
+        let variable_id = VariableId::new(index as u32);
+        let variable = model
+            .variable(variable_id)
+            .ok_or(SolverError::InvalidVariableId(variable_id.inner()))?;
+
+        if variable.is_integer && variable.is_active {
+            has_integer = true;
+            col_types.push(
+                if variable.bounds.lower >= -1e-12 && variable.bounds.upper <= 1.0 + 1e-12 {
+                    b'B'
+                } else {
+                    b'I'
+                },
+            );
+            int_col_indices.push(index as c_int);
+            int_col_limits.push(
+                variable_bounds
+                    .lower_bound_for_integer_column(index)
+                    .unwrap_or_else(|| clamp_bound(variable.bounds.lower)),
+            );
+        }
+    }
+
+    let mut row_types = Vec::with_capacity(nrows);
+    let mut rhs = Vec::with_capacity(nrows);
+    let mut rng: Option<Vec<f64>> = None;
+    for index in 0..nrows {
+        let constraint = model
+            .constraint(ConstraintId::new(index as u32))
+            .ok_or_else(|| SolverError::SolverSpecific(format!("missing constraint {index}")))?;
+        let (row_type, rhs_value, range_value) =
+            bounds_to_xpress_row(constraint.bounds.lower, constraint.bounds.upper);
+        if row_type == b'R' && rng.is_none() {
+            rng = Some(vec![0.0; index]);
+        }
+        if let Some(rng_values) = rng.as_mut() {
+            rng_values.push(range_value);
+        }
+        row_types.push(row_type);
+        rhs.push(rhs_value);
+    }
+
+    let matrix_build_start = Instant::now();
+    let XpressColumnMatrix {
+        mstart,
+        mrwind,
+        dmatval,
+    } = build_xpress_column_matrix(model, ncols, nrows, stats.coefficients)?;
     let matrix_build_seconds = matrix_build_start.elapsed().as_secs_f64();
+
+    Ok(XpressLoadData {
+        ncols,
+        nrows,
+        has_integer,
+        stats,
+        sense,
+        objective_coefficients,
+        variable_bounds,
+        row_types,
+        rhs,
+        rng,
+        matrix: XpressColumnMatrix {
+            mstart,
+            mrwind,
+            dmatval,
+        },
+        col_types,
+        int_col_indices,
+        int_col_limits,
+        matrix_build_seconds,
+        solve_started,
+    })
+}
+
+#[allow(unsafe_code)]
+fn load_prepared_problem(
+    load_data: XpressLoadData,
+    config: &SolverConfig,
+) -> Result<PreparedXpressProblem, SolverError> {
+    let XpressLoadData {
+        ncols,
+        nrows,
+        has_integer,
+        stats,
+        sense,
+        objective_coefficients,
+        variable_bounds,
+        row_types,
+        rhs,
+        rng,
+        matrix:
+            XpressColumnMatrix {
+                mstart,
+                mrwind,
+                dmatval,
+            },
+        col_types,
+        int_col_indices,
+        int_col_limits,
+        matrix_build_seconds,
+        solve_started,
+    } = load_data;
+    let objective_coefficients = objective_coefficients.into_dense(ncols);
+    let rng_ptr = rng
+        .as_ref()
+        .map_or(std::ptr::null(), |values| values.as_ptr());
+    let (lower_bounds_ptr, upper_bounds_ptr) = variable_bounds.load_ptrs();
 
     let env_guard = xprs_init()?;
     let api = env_guard.api;
@@ -603,14 +945,14 @@ fn solve_problem(
                 nrows as c_int,
                 row_types.as_ptr().cast::<c_char>(),
                 rhs.as_ptr(),
-                rng.as_ptr(),
+                rng_ptr,
                 objective_coefficients.as_ptr(),
                 mstart.as_ptr(),
                 std::ptr::null(),
                 mrwind.as_ptr(),
                 dmatval.as_ptr(),
-                lower_bounds.as_ptr(),
-                upper_bounds.as_ptr(),
+                lower_bounds_ptr,
+                upper_bounds_ptr,
                 int_col_indices.len() as c_int,
                 0,
                 col_types.as_ptr().cast::<c_char>(),
@@ -622,7 +964,9 @@ fn solve_problem(
                 std::ptr::null(),
             )
         })
-        .map_err(|rc| xpress_failure_error(api, prob, api.mip_loader_symbol(), rc, model))?;
+        .map_err(|rc| {
+            xpress_failure_error_for_stats(api, prob, api.mip_loader_symbol(), rc, &stats)
+        })?;
     } else {
         ffi::check_xprs(unsafe {
             (api.xprs_loadlp)(
@@ -632,18 +976,33 @@ fn solve_problem(
                 nrows as c_int,
                 row_types.as_ptr().cast::<c_char>(),
                 rhs.as_ptr(),
-                rng.as_ptr(),
+                rng_ptr,
                 objective_coefficients.as_ptr(),
                 mstart.as_ptr(),
                 std::ptr::null(),
                 mrwind.as_ptr(),
                 dmatval.as_ptr(),
-                lower_bounds.as_ptr(),
-                upper_bounds.as_ptr(),
+                lower_bounds_ptr,
+                upper_bounds_ptr,
             )
         })
-        .map_err(|rc| xpress_failure_error(api, prob, "XPRSloadlp", rc, model))?;
+        .map_err(|rc| xpress_failure_error_for_stats(api, prob, "XPRSloadlp", rc, &stats))?;
     }
+
+    drop((
+        objective_coefficients,
+        row_types,
+        rhs,
+        rng,
+        mstart,
+        mrwind,
+        dmatval,
+        col_types,
+        int_col_indices,
+        int_col_limits,
+    ));
+
+    variable_bounds.apply_deferred_changes(api, prob, &stats)?;
 
     ffi::check_xprs(unsafe {
         (api.xprs_chgobjsense)(
@@ -656,16 +1015,56 @@ fn solve_problem(
     })
     .map_err(|rc| SolverError::SolverSpecific(format!("XPRSchgobjsense failed: {rc}")))?;
 
+    Ok(PreparedXpressProblem {
+        prob_guard,
+        _env_guard: env_guard,
+        api,
+        ncols,
+        nrows,
+        has_integer,
+        stats,
+        matrix_build_seconds,
+        solve_started,
+    })
+}
+
+fn prepare_problem(
+    model: &(impl ModelView + ?Sized),
+    config: &SolverConfig,
+) -> Result<PreparedXpressProblem, SolverError> {
+    load_prepared_problem(prepare_load_data(model)?, config)
+}
+
+#[allow(unsafe_code)]
+fn finish_prepared_problem(
+    prepared: PreparedXpressProblem,
+    config: &SolverConfig,
+) -> Result<SolveArtifacts, SolverError> {
+    let api = prepared.api;
+    let prob = prepared.prob_guard.prob;
+    let ncols = prepared.ncols;
+    let nrows = prepared.nrows;
+    let has_integer = prepared.has_integer;
+    let lp_flags = lp_optimize_flags(config)?;
+    let lp_flags = lp_flags.map(CString::new).transpose().map_err(|_| {
+        SolverError::InvalidSettings("xpress.lp_algorithm contains NUL".to_string())
+    })?;
+    let lp_flags_ptr = lp_flags
+        .as_ref()
+        .map_or(std::ptr::null(), |flags| flags.as_ptr());
+
     let run_start = Instant::now();
     if has_integer {
-        ffi::check_xprs(unsafe { (api.xprs_mipoptimize)(prob, std::ptr::null()) })
-            .map_err(|rc| xpress_failure_error(api, prob, "XPRSmipoptimize", rc, model))?;
+        ffi::check_xprs(unsafe { (api.xprs_mipoptimize)(prob, std::ptr::null()) }).map_err(
+            |rc| xpress_failure_error_for_stats(api, prob, "XPRSmipoptimize", rc, &prepared.stats),
+        )?;
     } else {
-        ffi::check_xprs(unsafe { (api.xprs_lpoptimize)(prob, std::ptr::null()) })
-            .map_err(|rc| xpress_failure_error(api, prob, "XPRSlpoptimize", rc, model))?;
+        ffi::check_xprs(unsafe { (api.xprs_lpoptimize)(prob, lp_flags_ptr) }).map_err(|rc| {
+            xpress_failure_error_for_stats(api, prob, "XPRSlpoptimize", rc, &prepared.stats)
+        })?;
     }
     let run_seconds = run_start.elapsed().as_secs_f64();
-    let solve_time_seconds = solve_started.elapsed().as_secs_f64();
+    let solve_time_seconds = prepared.solve_started.elapsed().as_secs_f64();
 
     let (core_status, has_solution, status_string) = if has_integer {
         let raw = get_int_attrib(api, prob, ffi::XPRS_MIPSTATUS)?;
@@ -747,18 +1146,21 @@ fn solve_problem(
     };
     let solution_extract_seconds = extract_start.elapsed().as_secs_f64();
 
-    drop(prob_guard);
-    drop(env_guard);
-
     let mut metadata = BTreeMap::new();
-    metadata.insert("xpress_matrix_build_s".to_string(), matrix_build_seconds);
+    metadata.insert(
+        "xpress_matrix_build_s".to_string(),
+        prepared.matrix_build_seconds,
+    );
     metadata.insert("xpress_run_s".to_string(), run_seconds);
     metadata.insert("solution_extract_s".to_string(), solution_extract_seconds);
-    metadata.insert("num_variables".to_string(), ncols as f64);
-    metadata.insert("num_constraints".to_string(), nrows as f64);
+    metadata.insert("num_variables".to_string(), prepared.stats.variables as f64);
+    metadata.insert(
+        "num_constraints".to_string(),
+        prepared.stats.constraints as f64,
+    );
     metadata.insert(
         "num_coefficients".to_string(),
-        model.num_coefficients() as f64,
+        prepared.stats.coefficients as f64,
     );
 
     Ok(SolveArtifacts {
@@ -774,6 +1176,13 @@ fn solve_problem(
         },
         metadata,
     })
+}
+
+fn solve_problem(
+    model: &(impl ModelView + ?Sized),
+    config: &SolverConfig,
+) -> Result<SolveArtifacts, SolverError> {
+    finish_prepared_problem(prepare_problem(model, config)?, config)
 }
 
 /// Xpress backend registration object for primitive model views.
@@ -799,6 +1208,34 @@ pub fn solve_model_view(
     model: &(impl ModelView + ?Sized),
     config: &SolverConfig,
 ) -> Result<ModelViewSolveResult, SolverError> {
+    let prepared = prepare_model_view_solve(model, config)?;
+    let result = finish_prepared_model_view_solve(prepared, config)?;
+    validate_model_view_solve_result_with_config(model, &result, config)?;
+    Ok(result)
+}
+
+/// Solve an owned core model with Xpress, allowing callers to release Arco
+/// model memory after the Xpress problem has been loaded.
+pub fn solve_owned_model(
+    mut model: arco_model::Model,
+    config: &SolverConfig,
+) -> Result<ModelViewSolveResult, SolverError> {
+    let prepared_load = prepare_owned_model_view_load(&mut model, config)?;
+    drop(model);
+    let prepared = PreparedModelViewSolve {
+        problem: load_prepared_problem(prepared_load.load_data, config)?,
+        fingerprint: prepared_load.fingerprint,
+        fingerprint_seconds: prepared_load.fingerprint_seconds,
+        num_variables: prepared_load.num_variables,
+        num_constraints: prepared_load.num_constraints,
+    };
+    finish_prepared_model_view_solve(prepared, config)
+}
+
+fn prepare_model_view_load(
+    model: &(impl ModelView + ?Sized),
+    config: &SolverConfig,
+) -> Result<PreparedModelViewLoad, SolverError> {
     if model.num_variables() == 0 {
         return Err(SolverError::EmptyModel);
     }
@@ -806,10 +1243,7 @@ pub fn solve_model_view(
         return Err(SolverError::NoObjective);
     }
 
-    let SolveArtifacts {
-        solution,
-        mut metadata,
-    } = solve_problem(model, config)?;
+    let load_data = prepare_load_data(model)?;
 
     let fingerprint_start = Instant::now();
     let fingerprint = if config
@@ -821,23 +1255,147 @@ pub fn solve_model_view(
     } else {
         ModelFingerprint(0)
     };
-    metadata.insert(
-        "fingerprint_s".to_string(),
-        fingerprint_start.elapsed().as_secs_f64(),
-    );
+    let fingerprint_seconds = fingerprint_start.elapsed().as_secs_f64();
+
+    Ok(PreparedModelViewLoad {
+        num_variables: load_data.stats.variables,
+        num_constraints: load_data.stats.constraints,
+        load_data,
+        fingerprint,
+        fingerprint_seconds,
+    })
+}
+
+fn prepare_owned_model_view_load(
+    model: &mut arco_model::Model,
+    config: &SolverConfig,
+) -> Result<PreparedModelViewLoad, SolverError> {
+    if model.num_variables() == 0 {
+        return Err(SolverError::EmptyModel);
+    }
+    if model.objective().sense.is_none() && model.objective().terms.is_empty() {
+        return Err(SolverError::NoObjective);
+    }
+
+    let fingerprint_start = Instant::now();
+    let fingerprint = if config
+        .parameters
+        .get("arco.fingerprint")
+        .is_none_or(|value| value != "false")
+    {
+        model.fingerprint()
+    } else {
+        ModelFingerprint(0)
+    };
+    let fingerprint_seconds = fingerprint_start.elapsed().as_secs_f64();
+
+    let mut objective_terms = model.take_objective_terms_for_consumed_solve();
+    retain_active_objective_terms(model, &mut objective_terms, model.num_variables())?;
+    let load_data = prepare_load_data_with_objective(
+        model,
+        XpressObjectiveCoefficients::Sparse(objective_terms),
+    )?;
+
+    Ok(PreparedModelViewLoad {
+        num_variables: load_data.stats.variables,
+        num_constraints: load_data.stats.constraints,
+        load_data,
+        fingerprint,
+        fingerprint_seconds,
+    })
+}
+
+fn prepare_model_view_solve(
+    model: &(impl ModelView + ?Sized),
+    config: &SolverConfig,
+) -> Result<PreparedModelViewSolve, SolverError> {
+    let prepared_load = prepare_model_view_load(model, config)?;
+    Ok(PreparedModelViewSolve {
+        problem: load_prepared_problem(prepared_load.load_data, config)?,
+        fingerprint: prepared_load.fingerprint,
+        fingerprint_seconds: prepared_load.fingerprint_seconds,
+        num_variables: prepared_load.num_variables,
+        num_constraints: prepared_load.num_constraints,
+    })
+}
+
+fn finish_prepared_model_view_solve(
+    prepared: PreparedModelViewSolve,
+    config: &SolverConfig,
+) -> Result<ModelViewSolveResult, SolverError> {
+    let fingerprint = prepared.fingerprint;
+    let fingerprint_seconds = prepared.fingerprint_seconds;
+    let num_variables = prepared.num_variables;
+    let num_constraints = prepared.num_constraints;
+    let SolveArtifacts {
+        solution,
+        mut metadata,
+    } = finish_prepared_problem(prepared.problem, config)?;
+    metadata.insert("fingerprint_s".to_string(), fingerprint_seconds);
 
     let result = ModelViewSolveResult {
         fingerprint,
-        status: solution.core_status(),
-        objective_value: solution.objective_value(),
-        primal_values: solution.primal_values().to_vec(),
-        variable_duals: solution.variable_duals().to_vec(),
-        row_values: solution.row_values.clone(),
-        constraint_duals: solution.constraint_duals().to_vec(),
+        status: solution.core_status,
+        objective_value: solution.objective_value,
+        primal_values: solution.primal_values,
+        variable_duals: solution.variable_duals,
+        row_values: solution.row_values,
+        constraint_duals: solution.constraint_duals,
         metadata,
     };
-    validate_model_view_solve_result(model, &result)?;
+    validate_result_shape_counts(&result, config, num_variables, num_constraints)?;
     Ok(result)
+}
+
+fn validate_result_shape_counts(
+    result: &ModelViewSolveResult,
+    config: &SolverConfig,
+    num_variables: usize,
+    num_constraints: usize,
+) -> Result<(), SolverError> {
+    let allow_omitted_primal_values = config
+        .parameters
+        .get("arco.extract_solution")
+        .is_some_and(|value| value == "false");
+    if allow_omitted_primal_values {
+        validate_optional_result_len("primal_values", result.primal_values.len(), num_variables)?;
+    } else {
+        validate_required_result_len("primal_values", result.primal_values.len(), num_variables)?;
+    }
+    validate_optional_result_len("variable_duals", result.variable_duals.len(), num_variables)?;
+    validate_optional_result_len("row_values", result.row_values.len(), num_constraints)?;
+    validate_optional_result_len(
+        "constraint_duals",
+        result.constraint_duals.len(),
+        num_constraints,
+    )?;
+    Ok(())
+}
+
+fn validate_required_result_len(
+    name: &str,
+    actual: usize,
+    expected: usize,
+) -> Result<(), SolverError> {
+    if actual == expected {
+        return Ok(());
+    }
+    Err(SolverError::InvalidResultShape(format!(
+        "{name} length {actual} does not match expected {expected}"
+    )))
+}
+
+fn validate_optional_result_len(
+    name: &str,
+    actual: usize,
+    expected: usize,
+) -> Result<(), SolverError> {
+    if actual == 0 || actual == expected {
+        return Ok(());
+    }
+    Err(SolverError::InvalidResultShape(format!(
+        "{name} length {actual} must be 0 or match expected {expected}"
+    )))
 }
 
 pub struct Solver<'model> {
@@ -961,6 +1519,28 @@ mod tests {
     }
 
     #[test]
+    fn owned_model_solver_rejects_empty_model_before_runtime_setup() {
+        let model = Model::new();
+        let error = solve_owned_model(model, &SolverConfig::new())
+            .expect_err("owned Xpress solve should reject an empty model");
+
+        assert!(matches!(error, SolverError::EmptyModel));
+    }
+
+    #[test]
+    fn owned_model_solver_rejects_no_objective_model_before_runtime_setup() {
+        let mut model = Model::new();
+        model
+            .add_variable(Variable::continuous(Bounds::new(0.0, 1.0)))
+            .expect("variable");
+
+        let error = solve_owned_model(model, &SolverConfig::new())
+            .expect_err("owned Xpress solve should reject missing objective");
+
+        assert!(matches!(error, SolverError::NoObjective));
+    }
+
+    #[test]
     fn solver_wrapper_rejects_empty_model() {
         let model = Model::new();
         assert!(matches!(Solver::new(&model), Err(SolverError::EmptyModel)));
@@ -987,6 +1567,244 @@ mod tests {
         assert_eq!(solver.config().threads, Some(2));
         assert_eq!(solver.config().time_limit, Some(5.0));
         assert_eq!(solver.config().log_to_console, Some(false));
+    }
+
+    #[test]
+    fn xpress_column_matrix_reserves_known_coefficient_count() {
+        let mut model = Model::new();
+        let x = model
+            .add_variable(Variable::continuous(Bounds::new(0.0, f64::INFINITY)))
+            .expect("x variable");
+        let y = model
+            .add_variable(Variable::continuous(Bounds::new(0.0, f64::INFINITY)))
+            .expect("y variable");
+        let first = model
+            .add_constraint(Constraint {
+                bounds: Bounds::new(1.0, f64::INFINITY),
+            })
+            .expect("first constraint");
+        let second = model
+            .add_constraint(Constraint {
+                bounds: Bounds::new(f64::NEG_INFINITY, 3.0),
+            })
+            .expect("second constraint");
+        model.set_coefficient(x, first, 1.5).expect("x first");
+        model.set_coefficient(x, second, -2.0).expect("x second");
+        model.set_coefficient(y, second, 4.0).expect("y second");
+
+        let matrix = build_xpress_column_matrix(
+            &model,
+            model.num_variables(),
+            model.num_constraints(),
+            model.num_coefficients(),
+        )
+        .expect("matrix build");
+
+        assert!(matrix.mrwind.capacity() >= model.num_coefficients());
+        assert!(matrix.dmatval.capacity() >= model.num_coefficients());
+        assert_eq!(matrix.mstart, vec![0, 2, 3]);
+        assert_eq!(matrix.mrwind, vec![0, 1, 1]);
+        assert_eq!(matrix.dmatval, vec![1.5, -2.0, 4.0]);
+    }
+
+    #[test]
+    fn xpress_load_data_builds_without_runtime_initialization() {
+        let model = build_simple_model();
+
+        let load_data = prepare_load_data(&model).expect("load data should build");
+
+        assert_eq!(load_data.ncols, model.num_variables());
+        assert_eq!(load_data.nrows, model.num_constraints());
+        assert!(!load_data.has_integer);
+        assert_eq!(load_data.stats.variables, 1);
+        assert_eq!(load_data.stats.constraints, 1);
+        assert_eq!(load_data.stats.coefficients, 1);
+        assert_eq!(load_data.objective_coefficients.into_dense(1), vec![2.0]);
+        match &load_data.variable_bounds {
+            XpressVariableBounds::DefaultNonnegativeWithUpperChanges {
+                upper_indices,
+                upper_types,
+                upper_values,
+            } => {
+                assert!(upper_indices.is_empty());
+                assert!(upper_types.is_empty());
+                assert!(upper_values.is_empty());
+            }
+            XpressVariableBounds::Full { .. } => {
+                panic!("default nonnegative LP should not allocate full bound arrays")
+            }
+        }
+        assert_eq!(load_data.row_types, vec![b'G']);
+        assert_eq!(load_data.rhs, vec![1.0]);
+        assert!(load_data.rng.is_none());
+        assert_eq!(load_data.matrix.mstart, vec![0, 1]);
+        assert_eq!(load_data.matrix.mrwind, vec![0]);
+        assert_eq!(load_data.matrix.dmatval, vec![1.0]);
+    }
+
+    #[test]
+    fn xpress_load_data_defers_only_finite_upper_bound_changes() {
+        let mut model = Model::new();
+        let x = model
+            .add_variable(Variable::continuous(Bounds::new(0.0, 7.0)))
+            .expect("bounded variable");
+        let y = model
+            .add_variable(Variable::continuous(Bounds::new(0.0, f64::INFINITY)))
+            .expect("unbounded variable");
+        let demand = model
+            .add_constraint(Constraint {
+                bounds: Bounds::new(1.0, f64::INFINITY),
+            })
+            .expect("constraint");
+        model
+            .set_coefficient(x, demand, 1.0)
+            .expect("x coefficient");
+        model
+            .set_coefficient(y, demand, 1.0)
+            .expect("y coefficient");
+        model
+            .set_objective(Objective {
+                sense: Some(Sense::Minimize),
+                terms: vec![(x, 1.0), (y, 1.0)],
+            })
+            .expect("objective");
+
+        let load_data = prepare_load_data(&model).expect("load data should build");
+
+        match &load_data.variable_bounds {
+            XpressVariableBounds::DefaultNonnegativeWithUpperChanges {
+                upper_indices,
+                upper_types,
+                upper_values,
+            } => {
+                assert_eq!(upper_indices, &vec![0]);
+                assert_eq!(upper_types, &vec![b'U']);
+                assert_eq!(upper_values, &vec![7.0]);
+            }
+            XpressVariableBounds::Full { .. } => {
+                panic!("finite upper bounds should be deferred for default nonnegative LPs")
+            }
+        }
+    }
+
+    #[test]
+    fn xpress_load_data_uses_full_bounds_for_nonzero_lower_bounds() {
+        let mut model = Model::new();
+        let x = model
+            .add_variable(Variable::continuous(Bounds::new(-1.0, 7.0)))
+            .expect("bounded variable");
+        let demand = model
+            .add_constraint(Constraint {
+                bounds: Bounds::new(1.0, f64::INFINITY),
+            })
+            .expect("constraint");
+        model.set_coefficient(x, demand, 1.0).expect("coefficient");
+        model
+            .set_objective(Objective {
+                sense: Some(Sense::Minimize),
+                terms: vec![(x, 1.0)],
+            })
+            .expect("objective");
+
+        let load_data = prepare_load_data(&model).expect("load data should build");
+
+        match &load_data.variable_bounds {
+            XpressVariableBounds::Full {
+                lower_bounds,
+                upper_bounds,
+            } => {
+                assert_eq!(lower_bounds, &vec![-1.0]);
+                assert_eq!(upper_bounds, &vec![7.0]);
+            }
+            XpressVariableBounds::DefaultNonnegativeWithUpperChanges { .. } => {
+                panic!("nonzero lower bounds require full bound arrays")
+            }
+        }
+    }
+
+    #[test]
+    fn xpress_load_data_allocates_range_values_only_for_ranged_rows() {
+        let mut model = Model::new();
+        let x = model
+            .add_variable(Variable::continuous(Bounds::new(0.0, f64::INFINITY)))
+            .expect("variable");
+        let lower_only = model
+            .add_constraint(Constraint {
+                bounds: Bounds::new(1.0, f64::INFINITY),
+            })
+            .expect("lower-only constraint");
+        let ranged = model
+            .add_constraint(Constraint {
+                bounds: Bounds::new(2.0, 5.0),
+            })
+            .expect("ranged constraint");
+        model
+            .set_coefficient(x, lower_only, 1.0)
+            .expect("lower coefficient");
+        model
+            .set_coefficient(x, ranged, 1.0)
+            .expect("ranged coefficient");
+        model
+            .set_objective(Objective {
+                sense: Some(Sense::Minimize),
+                terms: vec![(x, 2.0)],
+            })
+            .expect("objective");
+
+        let load_data = prepare_load_data(&model).expect("load data should build");
+
+        assert_eq!(load_data.row_types, vec![b'G', b'R']);
+        assert_eq!(load_data.rhs, vec![1.0, 2.0]);
+        assert_eq!(load_data.rng, Some(vec![0.0, 3.0]));
+    }
+
+    #[test]
+    fn owned_xpress_load_data_drains_sparse_objective_without_runtime_initialization() {
+        let mut model = Model::new();
+        let active = model
+            .add_variable(Variable::continuous(Bounds::new(0.0, f64::INFINITY)))
+            .expect("active variable");
+        let inactive = model
+            .add_variable(Variable {
+                bounds: Bounds::new(0.0, f64::INFINITY),
+                is_integer: false,
+                is_active: false,
+            })
+            .expect("inactive variable");
+        let demand = model
+            .add_constraint(Constraint {
+                bounds: Bounds::new(1.0, f64::INFINITY),
+            })
+            .expect("constraint");
+        model
+            .set_coefficient(active, demand, 1.0)
+            .expect("coefficient");
+        model
+            .set_objective(Objective {
+                sense: Some(Sense::Minimize),
+                terms: vec![(active, 2.0), (inactive, 7.0)],
+            })
+            .expect("objective");
+
+        let prepared = prepare_owned_model_view_load(
+            &mut model,
+            &SolverConfig::new().with_parameter("arco.fingerprint", "false"),
+        )
+        .expect("owned load data should build");
+
+        assert!(model.objective().terms.is_empty());
+        match &prepared.load_data.objective_coefficients {
+            XpressObjectiveCoefficients::Sparse(terms) => {
+                assert_eq!(terms.as_slice(), &[(active, 2.0)]);
+            }
+            XpressObjectiveCoefficients::Dense(_) => {
+                panic!("owned load data should retain sparse objective terms")
+            }
+        }
+        assert_eq!(
+            prepared.load_data.objective_coefficients.into_dense(2),
+            vec![2.0, 0.0]
+        );
     }
 
     #[test]
@@ -1020,6 +1838,45 @@ mod tests {
         assert!(matches!(
             error,
             SolverError::InvalidSettings(message) if message == "threads must be >= 1"
+        ));
+    }
+
+    #[test]
+    fn maps_xpress_lp_algorithm_parameter_to_optimizer_flags() {
+        for (value, expected) in [
+            ("auto", None),
+            ("", None),
+            ("primal", Some("p")),
+            ("p", Some("p")),
+            ("dual", Some("d")),
+            ("d", Some("d")),
+            ("barrier", Some("b")),
+            ("b", Some("b")),
+            ("primal_barrier", Some("pb")),
+            ("dual_barrier", Some("db")),
+            ("primal_dual", Some("pd")),
+            ("all", Some("pdb")),
+        ] {
+            let config = SolverConfig::new().with_parameter("xpress.lp_algorithm", value);
+
+            let flags = lp_optimize_flags(&config).expect("algorithm should be accepted");
+
+            assert_eq!(flags, expected);
+        }
+    }
+
+    #[test]
+    fn rejects_invalid_xpress_lp_algorithm_parameter_before_runtime_setup() {
+        let config = SolverConfig::new().with_parameter("xpress.lp_algorithm", "not-an-algorithm");
+
+        let error =
+            validate_solver_config(&config).expect_err("invalid LP algorithm should be rejected");
+
+        assert!(matches!(
+            error,
+            SolverError::InvalidSettings(message)
+                if message.contains("xpress.lp_algorithm")
+                    && message.contains("not-an-algorithm")
         ));
     }
 

--- a/examples/reeds-benchmark/formulation.py
+++ b/examples/reeds-benchmark/formulation.py
@@ -12,9 +12,16 @@
 from __future__ import annotations
 
 import argparse
+import gc
 import json
+import sys
 import time
 from typing import NotRequired, TypedDict
+
+try:
+    import resource
+except ModuleNotFoundError:  # pragma: no cover - resource is unavailable on Windows.
+    resource = None
 
 import arco
 import numpy as np
@@ -22,15 +29,105 @@ import numpy as np
 from data_generator import SIZES, ProblemData, make_problem
 
 
+class BuildStage(TypedDict):
+    stage: str
+    seconds: float
+    rss_mb: float | None
+    delta_rss_mb: float | None
+
+
+LAST_BUILD_PROFILE: list[BuildStage] = []
+LAST_MATRIX_PROFILE: dict[str, object] = {}
+LAST_SOLVE_METADATA: dict[str, float] = {}
+LAST_SOLVE_STATUS: str | None = None
+HIGHS_PRIMAL_SOLUTION_FEASIBLE = 2.0
+
+
+def _objective_value_for_reporting(
+    objective_value: float, solve_metadata: dict[str, float]
+) -> float:
+    """Return NaN when HiGHS has not reported a feasible primal solution."""
+    primal_status = solve_metadata.get("highs_primal_solution_status")
+    if primal_status is not None and primal_status != HIGHS_PRIMAL_SOLUTION_FEASIBLE:
+        return float("nan")
+    return objective_value
+
+
+def _format_objective_value(objective_value: float) -> str:
+    if objective_value != objective_value:
+        return "n/a"
+    return f"{objective_value:,.0f}"
+
+
+def _constraint_reserve_count(data: ProblemData) -> int:
+    transmission_bound_rows = len(data.routes) * len(data.hours) * len(data.years)
+    return max(0, data.n_constraints - transmission_bound_rows + 1024)
+
+
+def _current_rss_mb() -> float | None:
+    try:
+        with open("/proc/self/status", encoding="utf-8") as status:
+            for line in status:
+                if line.startswith("VmRSS:"):
+                    return float(line.split()[1]) / 1024.0
+    except OSError:
+        return None
+    return None
+
+
+def _ru_maxrss_to_mb(max_rss: float, platform: str = sys.platform) -> float:
+    if platform == "darwin":
+        return max_rss / (1024.0 * 1024.0)
+    return max_rss / 1024.0
+
+
+def _peak_rss_mb() -> float | None:
+    if resource is None:
+        return None
+    max_rss = max(
+        float(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss),
+        float(resource.getrusage(resource.RUSAGE_CHILDREN).ru_maxrss),
+    )
+    if max_rss <= 0.0:
+        return None
+    return _ru_maxrss_to_mb(max_rss)
+
+
+def _format_rss_mb(value: float | None) -> str:
+    if value is None:
+        return "n/a"
+    return f"{value:.1f} MB"
+
+
 def solve(
-    data: ProblemData, solver: str = "highs", build_only: bool = False
+    data: ProblemData,
+    solver: str = "highs",
+    build_only: bool = False,
+    profile_build: bool = False,
+    profile_matrix: bool = False,
+    time_limit: float | None = None,
+    presolve: bool | None = None,
+    threads: int | None = None,
+    highs_solver: str = "ipm",
+    highs_run_crossover: str | None = None,
+    highs_load_path: str | None = None,
+    require_optimal: bool = True,
 ) -> tuple[float, float, float]:
     if solver != "highs":
         raise ValueError("solve only supports solver='highs'")
 
+    global LAST_SOLVE_METADATA
+    global LAST_SOLVE_STATUS
+    LAST_SOLVE_METADATA = {}
+    LAST_SOLVE_STATUS = None
+
     regions, techs, hours, years = data.regions, data.techs, data.hours, data.years
     region_index = data.r_idx
     total_hours_weight = float(np.sum(data.hours_weight))
+    tranloss_factor = 1.0 - float(data.tranloss)
+    reserve_margin_factor = 1.0 + float(data.prm)
+    duration_h = float(data.duration_h)
+    charge_eff = float(data.charge_eff)
 
     route_active_matrix = np.zeros((len(regions), len(regions)), dtype=bool)
     transcap_matrix = np.zeros((len(regions), len(regions)), dtype=float)
@@ -42,8 +139,34 @@ def solve(
 
     t0 = time.perf_counter()
     model = arco.Model()
+    model.reserve(
+        num_variables=data.n_vars,
+        num_constraints=_constraint_reserve_count(data),
+    )
+    build_profile: list[BuildStage] = []
+    last_rss_mb = _current_rss_mb()
 
-    I = arco.IndexSet(name="i", members=techs)
+    def mark(stage: str) -> None:
+        nonlocal last_rss_mb
+        if not profile_build:
+            return
+        rss_mb = _current_rss_mb()
+        delta_rss_mb = (
+            None if rss_mb is None or last_rss_mb is None else rss_mb - last_rss_mb
+        )
+        build_profile.append(
+            {
+                "stage": stage,
+                "seconds": time.perf_counter() - t0,
+                "rss_mb": rss_mb,
+                "delta_rss_mb": delta_rss_mb,
+            }
+        )
+        last_rss_mb = rss_mb
+
+    mark("model")
+
+    I = arco.IndexSet(name="i", members=techs)  # noqa: E741
     R = arco.IndexSet(name="r", members=regions)
     H = arco.IndexSet(name="h", members=hours)
     T = arco.IndexSet(name="t", members=years)
@@ -74,6 +197,8 @@ def solve(
 
     route_active = arco.param(route_active_matrix, axes=(R_from, R_to))
     transcap = arco.param(transcap_matrix, axes=(R_from, R_to))
+    del route_active_matrix, transcap_matrix
+    mark("sets_and_params")
 
     cap = model.add_variables(
         axes=(I, R, T),
@@ -99,6 +224,7 @@ def solve(
         active=route_active,
         name="FLOW",
     )
+    del route_active, transcap
     rampup = model.add_variables(
         axes=(I, R, H_ramp, T),
         bounds=arco.NonNegativeFloat,
@@ -117,91 +243,165 @@ def solve(
         active=storage_active,
         name="SOC",
     )
+    mark("variables")
 
     model.add_constraints(
         cap == cap_init + np.cumsum(inv, axis=T),
         name="eq_cap_accum",
     )
+    mark("eq_cap_accum")
+    del cap_init
     model.add_constraints(
         gen <= cf * cap,
         name="eq_cap_limit",
     )
+    mark("eq_cap_limit")
+    del cf
     model.add_constraints(
         gen >= minloadfrac * cap,
         active=valcap & (minloadfrac > 0) & ~is_storage,
         name="eq_mingen",
     )
+    mark("eq_mingen")
+    del minloadfrac, is_vre
 
     gen_by_region = gen @ I
     charge_by_region = charge @ I
-    tranloss_factor = 1.0 - float(data.tranloss)
-    for r_idx, region in enumerate(regions):
-        for h_idx, hour in enumerate(hours):
-            for t_idx, year in enumerate(years):
-                imports = tranloss_factor * flow[:, r_idx, h_idx, t_idx].sum()
-                exports = flow[r_idx, :, h_idx, t_idx].sum()
-                model.add_constraint(
-                    gen_by_region[r_idx, h_idx, t_idx]
-                    + imports
-                    - exports
-                    - charge_by_region[r_idx, h_idx, t_idx]
-                    == load[r_idx, h_idx, t_idx],
-                    name=f"eq_supply_demand_balance[{region},{hour},{year}]",
-                )
+    imports_by_region = (flow @ R_from).relabel_axis(R_to, R)
+    exports_by_region = (flow @ R_to).relabel_axis(R_from, R)
     model.add_constraints(
-        (cap @ I) >= (1.0 + float(data.prm)) * peak_load,
+        gen_by_region
+        + tranloss_factor * imports_by_region
+        - exports_by_region
+        - charge_by_region
+        == load,
+        name="eq_supply_demand_balance",
+    )
+    mark("eq_supply_demand_balance")
+    del (
+        gen_by_region,
+        charge_by_region,
+        imports_by_region,
+        exports_by_region,
+        flow,
+        load,
+    )
+    model.add_constraints(
+        (cap @ I) >= reserve_margin_factor * peak_load,
         name="eq_reserve_margin",
     )
+    mark("eq_reserve_margin")
+    del peak_load
     model.add_constraints(
         (emit_rate * hours_weight * gen) @ (I, R, H) <= emit_cap,
         name="eq_emit_cap",
     )
+    mark("eq_emit_cap")
+    del emit_rate, emit_cap
     model.add_constraints(
         rampup >= np.diff(gen, axis=H),
         active=dispatch_active,
         name="eq_ramping",
     )
+    mark("eq_ramping")
+    del dispatch_active, is_dispatch
     model.add_constraints(
         (hours_weight * gen) @ H >= min_cf * total_hours_weight * cap,
         active=valcap & (min_cf > 0),
         name="eq_min_cf",
     )
+    mark("eq_min_cf")
+    del min_cf, total_hours_weight
     model.add_constraints(
-        soc <= float(data.duration_h) * cap,
+        soc <= duration_h * cap,
         active=storage_active,
         name="eq_soc_cap",
     )
+    mark("eq_soc_cap")
     model.add_constraints(
         charge <= cap,
         active=storage_active,
         name="eq_charge_cap",
     )
+    mark("eq_charge_cap")
+    del cap
     model.add_constraints(
-        np.roll(soc, -1, axis=H) == soc + float(data.charge_eff) * charge - gen,
+        np.roll(soc, -1, axis=H) == soc + charge_eff * charge - gen,
         active=storage_active,
         name="eq_soc",
     )
+    mark("eq_soc")
+    del charge, soc, storage_active, is_storage
 
     objective = (pvf * cost_inv * inv).sum()
-    objective += (pvf * cost_op * hours_weight * gen).sum()
-    objective += (pvf * startcost * rampup).sum()
     model.minimize(objective)
+    del objective, cost_inv, inv
+    objective = (pvf * cost_op * hours_weight * gen).sum()
+    model.add_objective_terms(objective)
+    del objective, cost_op, gen, hours_weight
+    objective = (pvf * startcost * rampup).sum()
+    model.add_objective_terms(objective)
+    del objective, rampup, startcost, pvf
+    global LAST_MATRIX_PROFILE
+    LAST_MATRIX_PROFILE = model.matrix_profile() if profile_matrix else {}
+    mark("objective")
 
     build_s = time.perf_counter() - t0
+    global LAST_BUILD_PROFILE
+    LAST_BUILD_PROFILE = build_profile
     if build_only:
         return float("nan"), build_s, 0.0
 
-    t1 = time.perf_counter()
-    result = model.solve(
-        solver=arco.HiGHS(
-            log_to_console=False,
-            parameters={"solver": "ipm", "arco.fingerprint": "false"},
-        )
+    del (
+        data,
+        valcap,
+        I,
+        R,
+        H,
+        T,
+        H_ramp,
+        R_from,
+        R_to,
+        regions,
+        techs,
+        hours,
+        years,
+        region_index,
     )
+    gc.collect()
+    mark("cleanup")
+    build_s = time.perf_counter() - t0
+
+    t1 = time.perf_counter()
+    highs_kwargs = {
+        "log_to_console": False,
+        "parameters": {
+            "solver": highs_solver,
+            "arco.consume_model": "true",
+            "arco.fingerprint": "false",
+            "arco.extract_solution": "false",
+        },
+    }
+    if time_limit is not None:
+        highs_kwargs["time_limit"] = time_limit
+    if presolve is not None:
+        highs_kwargs["presolve"] = presolve
+    if threads is not None:
+        highs_kwargs["threads"] = threads
+    if highs_run_crossover is not None:
+        highs_kwargs["parameters"]["run_crossover"] = highs_run_crossover
+    if highs_load_path is not None:
+        highs_kwargs["parameters"]["arco.highs_load_path"] = highs_load_path
+    result = model.solve(solver=arco.HiGHS(**highs_kwargs))
     solve_s = time.perf_counter() - t1
-    if not result.is_optimal():
+    LAST_SOLVE_METADATA = dict(result.metadata)
+    LAST_SOLVE_STATUS = str(result.status)
+    if require_optimal and not result.is_optimal():
         raise RuntimeError(f"HiGHS did not find an optimal solution: {result.status}")
-    return float(result.objective_value), build_s, solve_s
+    objective_value = _objective_value_for_reporting(
+        float(result.objective_value), LAST_SOLVE_METADATA
+    )
+    return objective_value, build_s, solve_s
 
 
 class ReedsPayload(TypedDict):
@@ -209,9 +409,14 @@ class ReedsPayload(TypedDict):
     size: str
     summary: str
     solved: bool
-    objective_value: NotRequired[float]
+    objective_value: NotRequired[float | None]
     build_seconds: float
     solve_seconds: float
+    peak_rss_mb: float | None
+    status: NotRequired[str]
+    build_profile: NotRequired[list[BuildStage]]
+    matrix_profile: NotRequired[dict[str, object]]
+    solve_metadata: NotRequired[dict[str, float]]
 
 
 def _size_name(value: str) -> str:
@@ -221,6 +426,16 @@ def _size_name(value: str) -> str:
     return value
 
 
+def _positive_int(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("value must be an integer") from exc
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("value must be >= 1")
+    return parsed
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(
         description="Build or solve the ReEDS-representative Arco Python benchmark"
@@ -228,33 +443,115 @@ def main() -> int:
     parser.add_argument("--size", type=_size_name, default="small", help="Problem size")
     parser.add_argument("--build-only", action="store_true", help="Skip solve")
     parser.add_argument(
+        "--profile-build",
+        action="store_true",
+        help="Include per-stage build timing and RSS in JSON output",
+    )
+    parser.add_argument(
+        "--profile-matrix",
+        action="store_true",
+        help="Include sparse column-density diagnostics without exporting matrix arrays",
+    )
+    parser.add_argument(
         "--json", action="store_true", help="Emit machine-readable output"
+    )
+    parser.add_argument(
+        "--time-limit",
+        type=float,
+        default=None,
+        help="Optional HiGHS time limit in seconds",
+    )
+    parser.add_argument(
+        "--presolve",
+        choices=("on", "off"),
+        default=None,
+        help="Override HiGHS presolve for solver-memory probes",
+    )
+    parser.add_argument(
+        "--threads",
+        type=_positive_int,
+        default=None,
+        help="Override HiGHS thread count for solver-memory probes",
+    )
+    parser.add_argument(
+        "--highs-solver",
+        choices=("ipm", "simplex", "choose", "pdlp"),
+        default="ipm",
+        help="Override the HiGHS algorithm for solver-memory probes",
+    )
+    parser.add_argument(
+        "--highs-run-crossover",
+        choices=("on", "off", "choose"),
+        default=None,
+        help="Override HiGHS run_crossover for IPM memory probes",
+    )
+    parser.add_argument(
+        "--highs-load-path",
+        choices=("wrapper", "direct"),
+        default=None,
+        help="Select the Arco-to-HiGHS model load path for memory probes",
+    )
+    parser.add_argument(
+        "--allow-nonoptimal",
+        action="store_true",
+        help="Return JSON/text output for time-limit or other non-optimal statuses",
     )
     args = parser.parse_args()
 
     problem = make_problem(args.size)
-    obj, build_s, solve_s = solve(problem, build_only=args.build_only)
+    obj, build_s, solve_s = solve(
+        problem,
+        build_only=args.build_only,
+        profile_build=args.profile_build,
+        profile_matrix=args.profile_matrix,
+        time_limit=args.time_limit,
+        presolve=None if args.presolve is None else args.presolve == "on",
+        threads=args.threads,
+        highs_solver=args.highs_solver,
+        highs_run_crossover=args.highs_run_crossover,
+        highs_load_path=None
+        if args.highs_load_path in (None, "wrapper")
+        else args.highs_load_path,
+        require_optimal=not args.allow_nonoptimal,
+    )
+    solved = not args.build_only and LAST_SOLVE_STATUS == "SolutionStatus.OPTIMAL"
     payload: ReedsPayload = {
         "example": "reeds-benchmark",
         "size": args.size,
         "summary": problem.summary(),
-        "solved": not args.build_only,
+        "solved": solved,
         "build_seconds": build_s,
         "solve_seconds": solve_s,
+        "peak_rss_mb": _peak_rss_mb(),
     }
     if not args.build_only:
-        payload["objective_value"] = obj
+        payload["objective_value"] = None if obj != obj else obj
+        if LAST_SOLVE_STATUS is not None:
+            payload["status"] = LAST_SOLVE_STATUS
+        payload["solve_metadata"] = LAST_SOLVE_METADATA
+    if args.profile_build:
+        payload["build_profile"] = LAST_BUILD_PROFILE
+    if args.profile_matrix:
+        payload["matrix_profile"] = LAST_MATRIX_PROFILE
 
     if args.json:
         print(json.dumps(payload, indent=2))
     elif args.build_only:
         print(
-            f"reeds-benchmark built: size={args.size}, {problem.summary()}, build={build_s:.3f}s"
+            f"reeds-benchmark built: size={args.size}, {problem.summary()}, "
+            f"build={build_s:.3f}s, peak={_format_rss_mb(payload['peak_rss_mb'])}"
+        )
+    elif not solved:
+        print(
+            f"reeds-benchmark finished: size={args.size}, status={LAST_SOLVE_STATUS}, "
+            f"obj={_format_objective_value(obj)}, build={build_s:.3f}s, solve={solve_s:.3f}s, "
+            f"peak={_format_rss_mb(payload['peak_rss_mb'])}"
         )
     else:
         print(
-            f"reeds-benchmark solved: size={args.size}, obj={obj:,.0f}, "
-            f"build={build_s:.3f}s, solve={solve_s:.3f}s"
+            f"reeds-benchmark solved: size={args.size}, obj={_format_objective_value(obj)}, "
+            f"build={build_s:.3f}s, solve={solve_s:.3f}s, "
+            f"peak={_format_rss_mb(payload['peak_rss_mb'])}"
         )
     return 0
 

--- a/examples/reeds-benchmark/test_formulation_memory.py
+++ b/examples/reeds-benchmark/test_formulation_memory.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+def load_formulation() -> types.ModuleType:
+    example_dir = Path(__file__).resolve().parent
+    sys.path.insert(0, str(example_dir))
+    sys.modules.setdefault("arco", types.SimpleNamespace())
+    spec = importlib.util.spec_from_file_location(
+        "reeds_benchmark_formulation", example_dir / "formulation.py"
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_ru_maxrss_to_mb_uses_platform_units() -> None:
+    formulation = load_formulation()
+
+    assert formulation._ru_maxrss_to_mb(2048.0, "linux") == 2.0
+    assert formulation._ru_maxrss_to_mb(2.0 * 1024.0 * 1024.0, "darwin") == 2.0
+
+
+def test_format_rss_mb_reports_unsupported_measurements_explicitly() -> None:
+    formulation = load_formulation()
+
+    assert formulation._format_rss_mb(None) == "n/a"
+    assert formulation._format_rss_mb(12.25) == "12.2 MB"


### PR DESCRIPTION
## Summary

Draft extraction PR for #320, split from exploratory PR #315.

This branch carries the solver load-path candidate. It must remain draft until benchmark evidence and solver conformance checks are attached.

## Validation

Push hooks passed:
- ci cargo fmt
- ci cargo clippy
- ci cargo test (fast)

This PR remains draft until its scoped tests/checks from #320 pass and the diff is reviewed for accidental carry-over from #315.

Related: #320
Parent: #314
Source draft: #315
