### PR TITLE
perf: expose ReEDS matrix profiling

### DIFF
--- a/examples/reeds-benchmark/README.md
+++ b/examples/reeds-benchmark/README.md
@@ -18,3 +18,14 @@ For comparison, the Python benchmark remains available:
 ```bash
 uv run examples/reeds-benchmark/formulation.py --size small --json
 ```
+
+To capture build-stage RSS and sparse matrix diagnostics for memory regression
+work:
+
+```bash
+uv run examples/reeds-benchmark/formulation.py --size small --json --profile-build --profile-matrix
+```
+
+Memory fields report `null` in JSON, or `n/a` in text output, when a platform
+does not expose the measurement. They do not use `0.0` as an unavailable-memory
+sentinel.

--- a/examples/reeds-benchmark/formulation.py
+++ b/examples/reeds-benchmark/formulation.py
@@ -36,6 +36,7 @@ class BuildStage(TypedDict):
 
 
 LAST_BUILD_PROFILE: list[BuildStage] = []
+LAST_MATRIX_PROFILE: dict[str, object] = {}
 LAST_SOLVE_METADATA: dict[str, float] = {}
 LAST_SOLVE_STATUS: str | None = None
 HIGHS_PRIMAL_SOLUTION_FEASIBLE = 2.0
@@ -107,6 +108,13 @@ def solve(
 ) -> tuple[float, float, float]:
     if solver != "highs":
         raise ValueError("solve only supports solver='highs'")
+
+    global LAST_MATRIX_PROFILE
+    global LAST_SOLVE_METADATA
+    global LAST_SOLVE_STATUS
+    LAST_MATRIX_PROFILE = {}
+    LAST_SOLVE_METADATA = {}
+    LAST_SOLVE_STATUS = None
 
     regions, techs, hours, years = data.regions, data.techs, data.hours, data.years
     region_index = data.r_idx
@@ -301,6 +309,7 @@ def solve(
     objective += (pvf * cost_op * hours_weight * gen).sum()
     objective += (pvf * startcost * rampup).sum()
     model.minimize(objective)
+    LAST_MATRIX_PROFILE = model.matrix_profile() if profile_matrix else {}
     mark("objective")
 
     build_s = time.perf_counter() - t0
@@ -329,8 +338,6 @@ def solve(
         highs_kwargs["parameters"]["arco.highs_load_path"] = highs_load_path
     result = model.solve(solver=arco.HiGHS(**highs_kwargs))
     solve_s = time.perf_counter() - t1
-    global LAST_SOLVE_METADATA
-    global LAST_SOLVE_STATUS
     LAST_SOLVE_METADATA = dict(getattr(result, "metadata", {}))
     LAST_SOLVE_STATUS = str(result.status)
     if require_optimal and not result.is_optimal():
@@ -352,6 +359,7 @@ class ReedsPayload(TypedDict):
     peak_rss_mb: float | None
     status: NotRequired[str]
     build_profile: NotRequired[list[BuildStage]]
+    matrix_profile: NotRequired[dict[str, object]]
     solve_metadata: NotRequired[dict[str, float]]
 
 
@@ -386,7 +394,7 @@ def main() -> int:
     parser.add_argument(
         "--profile-matrix",
         action="store_true",
-        help="Accepted for compatibility; matrix profiling is unavailable in this slice",
+        help="Include sparse matrix column-density diagnostics in JSON output",
     )
     parser.add_argument(
         "--json", action="store_true", help="Emit machine-readable output"
@@ -465,6 +473,8 @@ def main() -> int:
         payload["solve_metadata"] = LAST_SOLVE_METADATA
     if args.profile_build:
         payload["build_profile"] = LAST_BUILD_PROFILE
+    if args.profile_matrix:
+        payload["matrix_profile"] = LAST_MATRIX_PROFILE
 
     if args.json:
         print(json.dumps(payload, indent=2))

--- a/examples/reeds-benchmark/test_formulation_memory.py
+++ b/examples/reeds-benchmark/test_formulation_memory.py
@@ -1,9 +1,26 @@
 from __future__ import annotations
 
+import importlib.util
 import json
 import subprocess
+import sys
+import types
 from pathlib import Path
 from typing import Any
+
+
+def load_formulation() -> types.ModuleType:
+    example_dir = Path(__file__).resolve().parent
+    sys.path.insert(0, str(example_dir))
+    sys.modules.setdefault("arco", types.SimpleNamespace())
+    spec = importlib.util.spec_from_file_location(
+        "reeds_benchmark_formulation", example_dir / "formulation.py"
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 def run_formulation(*args: str) -> subprocess.CompletedProcess[str]:
@@ -41,6 +58,13 @@ def test_build_profile_json_reports_memory_without_zero_fallbacks() -> None:
         rss_mb = stage["rss_mb"]
         assert rss_mb is None or rss_mb > 0.0
 
+    matrix_profile = payload["matrix_profile"]
+    assert matrix_profile["num_variables"] > 0
+    assert matrix_profile["num_constraints"] > 0
+    assert matrix_profile["num_coefficients"] > 0
+    assert "column_nnz_buckets" in matrix_profile
+    assert "top_columns" in matrix_profile
+
 
 def test_build_only_text_output_reports_unavailable_memory_explicitly() -> None:
     result = run_formulation("--size", "small", "--build-only")
@@ -48,3 +72,17 @@ def test_build_only_text_output_reports_unavailable_memory_explicitly() -> None:
     assert "reeds-benchmark built:" in result.stdout
     assert "peak=" in result.stdout
     assert "peak=0.0 MB" not in result.stdout
+
+
+def test_ru_maxrss_to_mb_uses_platform_units() -> None:
+    formulation = load_formulation()
+
+    assert formulation._ru_maxrss_to_mb(2048.0, "linux") == 2.0
+    assert formulation._ru_maxrss_to_mb(2.0 * 1024.0 * 1024.0, "darwin") == 2.0
+
+
+def test_format_rss_mb_reports_unsupported_measurements_explicitly() -> None:
+    formulation = load_formulation()
+
+    assert formulation._format_rss_mb(None) == "n/a"
+    assert formulation._format_rss_mb(12.25) == "12.2 MB"


### PR DESCRIPTION
## Summary
- emit `matrix_profile` in ReEDS benchmark JSON when `--profile-matrix` is requested
- reset benchmark globals per run so build-only and solve outputs do not inherit stale status/metadata
- document the memory profiling command and RSS unavailable-value behavior

Part of #314. Addresses the observability slice in #316.

## Evidence
- `uv run --no-project --with ruff ruff format --check examples/reeds-benchmark/formulation.py examples/reeds-benchmark/test_formulation_memory.py`
- `uv run --no-project --with ruff ruff check examples/reeds-benchmark/formulation.py examples/reeds-benchmark/test_formulation_memory.py`
- `uv run --with pytest --with numpy pytest examples/reeds-benchmark/test_formulation_memory.py -q` -> 4 passed in 114.23s
- `uv run examples/reeds-benchmark/formulation.py --size small --json --profile-build --profile-matrix` -> solved optimal, build_seconds=0.005867s, solve_seconds=0.055678s, peak_rss_mb=49.125, matrix_profile num_variables=2310 num_constraints=1588 num_coefficients=6720
- `just docs-test` -> 104 passed
- pre-push hooks: clippy and fast cargo tests passed

## Notes
- This intentionally keeps the broader direct solver load path and memory-load changes out of scope for later extraction PRs.