### PR TITLE
feat: migrate benchmark memory profiling from rmon to torc

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,6 +22,7 @@ env:
   JUST_VERSION: "1.43.0"
   PYTHON_LATEST: "3.12"
   RUST_TOOLCHAIN_VERSION: "1.85"
+  TORC_VERSION: "0.37.2"
 
 jobs:
   version-consistency:
@@ -392,7 +393,7 @@ jobs:
           path: |
             ~/.cargo/bin/torc
             ~/.cargo/bin/torc-server
-          key: ${{ runner.os }}-torc-${{ hashFiles('.github/workflows/ci.yaml') }}
+          key: ${{ runner.os }}-torc-${{ env.TORC_VERSION }}
 
       - name: Set up build environment
         uses: ./.github/actions/setup-build-env
@@ -406,10 +407,13 @@ jobs:
           save-rust-cache: "false"
           rust-cache-shared-key: product-build
 
-      - name: Ensure torc is installed
+      - name: Install torc
         run: |
           if [ ! -x "$HOME/.cargo/bin/torc" ] || [ ! -x "$HOME/.cargo/bin/torc-server" ]; then
-            cargo install torc --features server-bin
+            mkdir -p "$HOME/.cargo/bin"
+            curl -fsSL "https://github.com/NatLabRockies/torc/releases/download/v$TORC_VERSION/torc-x86_64-unknown-linux-musl.tar.gz" \
+              | tar xz -C "$HOME/.cargo/bin" torc torc-server
+            chmod +x "$HOME/.cargo/bin/torc" "$HOME/.cargo/bin/torc-server"
           fi
           "$HOME/.cargo/bin/torc" --version
           "$HOME/.cargo/bin/torc-server" --version

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -384,15 +384,13 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Cache rmon binary
+      - name: Cache torc binary
         if: github.event_name != 'pull_request'
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5 # zizmor: ignore[cache-poisoning]
-        id: rmon-cache
+        id: torc-cache
         with:
-          path: ~/.local/bin/rmon
-          key: ${{ runner.os }}-rmon-${{ hashFiles('.github/workflows/ci.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-rmon-
+          path: ~/.cargo/bin/torc
+          key: ${{ runner.os }}-torc-${{ hashFiles('.github/workflows/ci.yaml') }}
 
       - name: Set up build environment
         uses: ./.github/actions/setup-build-env
@@ -406,15 +404,15 @@ jobs:
           save-rust-cache: "false"
           rust-cache-shared-key: product-build
 
-      - name: Ensure rmon is installed
+      - name: Ensure torc is installed
         run: |
-          if [ ! -x "$HOME/.local/bin/rmon" ]; then
-            uv tool install --force git+https://github.com/NatLabRockies/resource_monitor
+          if [ ! -x "$HOME/.cargo/bin/torc" ]; then
+            cargo install torc --features server-bin
           fi
-          "$HOME/.local/bin/rmon" --version
+          "$HOME/.cargo/bin/torc" --version
 
-      - name: Add local bin to PATH
-        run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - name: Add cargo bin to PATH
+        run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
 
       - name: Download CLI artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v5

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -416,7 +416,7 @@ jobs:
             chmod +x "$HOME/.cargo/bin/torc" "$HOME/.cargo/bin/torc-server"
           fi
           "$HOME/.cargo/bin/torc" --version
-          "$HOME/.cargo/bin/torc-server" --version
+          "$HOME/.cargo/bin/torc-server" run --help >/dev/null
 
       - name: Add cargo bin to PATH
         run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -384,12 +384,14 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Cache torc binary
+      - name: Cache torc binaries
         if: github.event_name != 'pull_request'
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5 # zizmor: ignore[cache-poisoning]
         id: torc-cache
         with:
-          path: ~/.cargo/bin/torc
+          path: |
+            ~/.cargo/bin/torc
+            ~/.cargo/bin/torc-server
           key: ${{ runner.os }}-torc-${{ hashFiles('.github/workflows/ci.yaml') }}
 
       - name: Set up build environment
@@ -406,10 +408,11 @@ jobs:
 
       - name: Ensure torc is installed
         run: |
-          if [ ! -x "$HOME/.cargo/bin/torc" ]; then
+          if [ ! -x "$HOME/.cargo/bin/torc" ] || [ ! -x "$HOME/.cargo/bin/torc-server" ]; then
             cargo install torc --features server-bin
           fi
           "$HOME/.cargo/bin/torc" --version
+          "$HOME/.cargo/bin/torc-server" --version
 
       - name: Add cargo bin to PATH
         run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"

--- a/scripts/bench.py
+++ b/scripts/bench.py
@@ -5,8 +5,9 @@ Wraps arco CLI commands with torc's built-in resource monitoring to measure
 wall-clock duration and peak RSS.  Outputs github-action-benchmark-compatible JSON
 on stdout; diagnostics go to stderr.
 
-Requires ``torc`` and ``torc-server`` on PATH (install with
-``cargo install torc --features server-bin``).
+Requires ``torc`` and ``torc-server`` on PATH (install from
+`GitHub releases <https://github.com/NatLabRockies/torc/releases>`_
+or ``cargo install torc --features server-bin``).
 
 Exit codes
   0  all benchmarks succeeded

--- a/scripts/bench.py
+++ b/scripts/bench.py
@@ -1,19 +1,28 @@
 #!/usr/bin/env python3
-"""CLI benchmark runner for arco using rmon resource monitoring.
+"""Benchmark runner for arco using torc resource monitoring.
 
-Wraps arco CLI commands with rmon to measure wall-clock duration and peak RSS.
-Outputs github-action-benchmark compatible JSON.
+Wraps arco CLI commands with torc's built-in resource monitoring to measure
+wall-clock duration and peak RSS.  Outputs github-action-benchmark-compatible JSON
+on stdout; diagnostics go to stderr.
+
+Requires ``torc`` and ``torc-server`` on PATH (install with
+``cargo install torc --features server-bin``).
+
+Exit codes
+  0  all benchmarks succeeded
+  1  one or more benchmark cases failed
+  2  invalid arguments (unsupported workflow, no matching cases)
 """
 
 from __future__ import annotations
 
 import argparse
 import json
+import shlex
 import statistics
 import subprocess
 import sys
 import tempfile
-import time
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -33,21 +42,12 @@ SUPPORTED_WORKFLOWS: tuple[str, ...] = (
     "compile",  # backward-compatible alias for print-model
     "solve",  # backward-compatible alias for run
 )
-MIN_MONITORED_RUNTIME_MS = 4_000.0
-MAX_INNER_ITERATIONS = 5_000
-_INNER_LOOP_RUNNER = (
-    "import subprocess,sys\n"
-    "iterations=int(sys.argv[1])\n"
-    "cmd=sys.argv[2:]\n"
-    "for _ in range(iterations):\n"
-    "    rc=subprocess.run(cmd).returncode\n"
-    "    if rc:\n"
-    "        raise SystemExit(rc)\n"
-)
 
 
 @dataclass(frozen=True)
 class BenchmarkCase:
+    """A single arco CLI benchmark case (model path + workflow)."""
+
     name: str
     kdl_path: Path
     workflow: str
@@ -55,6 +55,8 @@ class BenchmarkCase:
 
 @dataclass
 class BenchmarkResult:
+    """Aggregated benchmark results across repetitions."""
+
     case: str
     workflow: str
     median_duration_ms: float
@@ -62,7 +64,8 @@ class BenchmarkResult:
     samples: int
 
 
-def _canonical_workflow(workflow: str) -> str:
+def canonical_workflow(workflow: str) -> str:
+    """Resolve backward-compatible workflow aliases to canonical names."""
     if workflow == "compile":
         return "print-model"
     if workflow == "solve":
@@ -71,7 +74,7 @@ def _canonical_workflow(workflow: str) -> str:
 
 
 def discover_cases() -> list[BenchmarkCase]:
-    """Discover curated, runnable KDL benchmark cases."""
+    """Discover curated, runnable KDL benchmark cases under examples/."""
     case_models: list[tuple[str, Path]] = []
     for case_name in DEFAULT_CASES:
         kdl_path = EXAMPLES_DIR / case_name / "input.kdl"
@@ -88,7 +91,8 @@ def discover_cases() -> list[BenchmarkCase]:
     return sorted(cases, key=lambda c: (c.name, c.workflow))
 
 
-def _build_arco_args(*, workflow: str, model_path: Path) -> list[str]:
+def build_arco_args(*, workflow: str, model_path: Path) -> list[str]:
+    """Build the arco CLI argument list for a given workflow and model path."""
     if workflow == "validate":
         return ["validate", str(model_path)]
     if workflow == "print-model":
@@ -98,167 +102,178 @@ def _build_arco_args(*, workflow: str, model_path: Path) -> list[str]:
     raise ValueError(f"unsupported workflow: {workflow}")
 
 
-def _parse_rmon_peak_rss_mb(results_path: Path) -> float:
-    if not results_path.is_file():
-        return 0.0
-
-    peak_rss_bytes = 0.0
-    for line in results_path.read_text().splitlines():
-        line = line.strip()
-        if not line:
-            continue
-        payload = json.loads(line)
-        for entry in payload.get("results", []):
-            if entry.get("resource_type") != "process":
-                continue
-            maximum = entry.get("maximum", {})
-            rss = maximum.get("rss")
-            if isinstance(rss, int | float):
-                peak_rss_bytes = max(peak_rss_bytes, float(rss))
-
-    return peak_rss_bytes / (1024.0 * 1024.0)
-
-
-def _tail(text: str, *, max_lines: int = 8) -> str:
+def tail_lines(text: str, *, max_lines: int = 8) -> str:
+    """Return the last non-blank lines of *text* for diagnostic display."""
     lines = [line for line in text.strip().splitlines() if line.strip()]
     if not lines:
         return ""
     return "\n".join(lines[-max_lines:])
 
 
-def _estimate_inner_iterations(arco_cmd: list[str]) -> int | None:
-    started = time.perf_counter()
-    try:
-        result = subprocess.run(arco_cmd, capture_output=True, text=True, timeout=300)
-    except (OSError, subprocess.TimeoutExpired) as exc:
-        print(f"  benchmark command failed to launch: {exc}", file=sys.stderr)
-        return None
-
-    elapsed_ms = (time.perf_counter() - started) * 1000.0
-    if result.returncode != 0:
-        print("  benchmark command failed during calibration", file=sys.stderr)
-        stderr_tail = _tail(result.stderr)
-        if stderr_tail:
-            print(stderr_tail, file=sys.stderr)
-        return None
-
-    if elapsed_ms <= 0.0:
-        return 1
-
-    estimated = int(MIN_MONITORED_RUNTIME_MS / elapsed_ms) + 1
-    return max(1, min(MAX_INNER_ITERATIONS, estimated))
-
-
-def _build_monitored_command(
-    arco_cmd: list[str], *, inner_iterations: int
-) -> list[str]:
-    if inner_iterations <= 1:
-        return arco_cmd
-    return [
-        sys.executable,
-        "-c",
-        _INNER_LOOP_RUNNER,
-        str(inner_iterations),
-        *arco_cmd,
-    ]
+def parse_csv(value: str) -> list[str]:
+    """Split a comma-separated string into trimmed, non-empty entries."""
+    return [entry.strip() for entry in value.split(",") if entry.strip()]
 
 
 def run_benchmark(
-    arco_binary: str, case: BenchmarkCase, repetitions: int
+    arco_binary: str, *, case: BenchmarkCase, repetitions: int
 ) -> BenchmarkResult | None:
-    """Run benchmark for a single case with multiple repetitions."""
-    durations: list[float] = []
-    peak_rss: list[float] = []
+    """Run a single benchmark case with torc and return aggregated results.
 
-    arco_cmd = [
-        arco_binary,
-        *_build_arco_args(workflow=case.workflow, model_path=case.kdl_path),
-    ]
-    inner_iterations = _estimate_inner_iterations(arco_cmd)
-    if inner_iterations is None:
-        return None
+    Creates a torc workflow with *repetitions* identical jobs, runs them
+    sequentially, then extracts peak memory and duration from torc's result
+    records.
+    """
+    arco_args = build_arco_args(workflow=case.workflow, model_path=case.kdl_path)
+    arco_cmd_str = shlex.join([arco_binary, *arco_args])
 
-    if inner_iterations > 1:
-        print(
-            f"  using {inner_iterations} inner iterations for process-memory sampling",
-            file=sys.stderr,
-        )
+    with tempfile.TemporaryDirectory(prefix="arco-bench-torc-") as tmpdir:
+        tmp = Path(tmpdir)
+        db_path = tmp / "torc.db"
+        commands_path = tmp / "commands.txt"
 
-    monitored_cmd = _build_monitored_command(
-        arco_cmd, inner_iterations=inner_iterations
-    )
+        # Write N identical commands (one per repetition).
+        commands_path.write_text("\n".join([arco_cmd_str] * repetitions) + "\n")
 
-    for repetition in range(repetitions):
-        started = time.perf_counter()
+        exec_cmd: list[str] = [
+            "torc",
+            "exec",
+            "--standalone",
+            "-C",
+            str(commands_path),
+            "--name",
+            f"arco-bench-{case.name}-{case.workflow}",
+            "--monitor",
+            "summary",
+            "--max-parallel-jobs",
+            "1",
+            "--sample-interval-seconds",
+            "1",
+            "--format",
+            "json",
+            "--db",
+            str(db_path),
+            "-o",
+            str(tmp),
+        ]
+
         try:
-            timed_result = subprocess.run(
-                arco_cmd,
-                capture_output=True,
-                text=True,
-                timeout=300,
+            exec_result = subprocess.run(
+                exec_cmd, capture_output=True, text=True, timeout=600
             )
-        except (OSError, subprocess.TimeoutExpired) as exc:
-            print(f"  arco command failed to launch: {exc}", file=sys.stderr)
+        except subprocess.TimeoutExpired:
+            print("  torc exec timed out after 600s", file=sys.stderr)
+            return None
+        except OSError as exc:
+            print(f"  torc exec failed to launch: {exc}", file=sys.stderr)
             return None
 
-        elapsed_ms = (time.perf_counter() - started) * 1000.0
-        if timed_result.returncode != 0:
-            print("  arco command failed", file=sys.stderr)
-            stderr_tail = _tail(timed_result.stderr)
+        if exec_result.returncode != 0:
+            print("  torc exec command failed", file=sys.stderr)
+            stderr_tail = tail_lines(exec_result.stderr)
             if stderr_tail:
                 print(stderr_tail, file=sys.stderr)
             return None
 
-        with tempfile.TemporaryDirectory(prefix="arco-bench-rmon-") as output_dir:
-            run_name = f"{case.name}-{case.workflow}-{repetition}"
-            results_path = Path(output_dir) / f"{run_name}_results.json"
-            cmd = [
-                "rmon",
-                "monitor-process",
-                "--interval",
-                "1",
-                "--output",
-                output_dir,
-                "--name",
-                run_name,
-                "--",
-                *monitored_cmd,
-            ]
-            try:
-                result = subprocess.run(
-                    cmd, capture_output=True, text=True, timeout=300
+        # Parse the workflow_id from torc exec JSON output.
+        try:
+            exec_payload = json.loads(exec_result.stdout)
+        except json.JSONDecodeError as exc:
+            print(f"  failed to parse torc exec JSON: {exc}", file=sys.stderr)
+            return None
+        try:
+            workflow_id = exec_payload["workflow_id"]
+        except KeyError:
+            print(
+                "  torc exec output missing workflow_id field", file=sys.stderr
+            )
+            return None
+
+        # Query results for this workflow.
+        results_cmd: list[str] = [
+            "torc",
+            "results",
+            "list",
+            str(workflow_id),
+            "--format",
+            "json",
+            "--standalone",
+            "--db",
+            str(db_path),
+        ]
+        try:
+            results_result = subprocess.run(
+                results_cmd, capture_output=True, text=True, timeout=30
+            )
+        except subprocess.TimeoutExpired:
+            print("  torc results list timed out", file=sys.stderr)
+            return None
+        except OSError as exc:
+            print(
+                f"  torc results list failed to launch: {exc}", file=sys.stderr
+            )
+            return None
+
+        if results_result.returncode != 0:
+            print("  torc results list command failed", file=sys.stderr)
+            stderr_tail = tail_lines(results_result.stderr)
+            if stderr_tail:
+                print(stderr_tail, file=sys.stderr)
+            return None
+
+        try:
+            results_payload = json.loads(results_result.stdout)
+        except json.JSONDecodeError as exc:
+            print(
+                f"  failed to parse torc results JSON: {exc}", file=sys.stderr
+            )
+            return None
+        try:
+            items = results_payload["items"]
+        except KeyError:
+            print(
+                "  torc results output missing items field", file=sys.stderr
+            )
+            return None
+
+        durations: list[float] = []
+        peak_rss: list[float] = []
+
+        for item in items:
+            exec_min = item.get("exec_time_minutes")
+            peak_bytes = item.get("peak_memory_bytes")
+
+            if isinstance(exec_min, (int, float)):
+                durations.append(float(exec_min) * 60_000.0)
+
+            # peak_memory_bytes can be None (torc didn't collect data) or 0
+            # (collected zero / no samples fired).  Treat both as 0.0 MiB.
+            if isinstance(peak_bytes, (int, float)):
+                peak_rss.append(
+                    max(float(peak_bytes), 0.0) / (1024.0 * 1024.0)
                 )
-            except (OSError, subprocess.TimeoutExpired) as exc:
-                print(f"  rmon failed to launch: {exc}", file=sys.stderr)
-                return None
+            else:
+                peak_rss.append(0.0)
 
-            if result.returncode != 0:
-                print("  rmon/arco command failed", file=sys.stderr)
-                stderr_tail = _tail(result.stderr)
-                if stderr_tail:
-                    print(stderr_tail, file=sys.stderr)
-                return None
+        if not durations:
+            print(
+                f"  no duration data from {len(items)} results", file=sys.stderr
+            )
+            return None
 
-            try:
-                peak_rss_mb = _parse_rmon_peak_rss_mb(results_path)
-            except json.JSONDecodeError as exc:
-                print(f"  failed to parse rmon output JSON: {exc}", file=sys.stderr)
-                return None
+        if len(durations) < repetitions:
+            print(
+                f"  warning: expected {repetitions} results, got {len(durations)}",
+                file=sys.stderr,
+            )
 
-            durations.append(elapsed_ms)
-            peak_rss.append(peak_rss_mb)
-
-    return BenchmarkResult(
-        case=case.name,
-        workflow=case.workflow,
-        median_duration_ms=statistics.median(durations),
-        peak_rss_mb=max(peak_rss) if peak_rss else 0.0,
-        samples=repetitions,
-    )
-
-
-def _parse_csv(value: str) -> list[str]:
-    return [entry.strip() for entry in value.split(",") if entry.strip()]
+        return BenchmarkResult(
+            case=case.name,
+            workflow=case.workflow,
+            median_duration_ms=statistics.median(durations),
+            peak_rss_mb=max(peak_rss) if peak_rss else 0.0,
+            samples=len(durations),
+        )
 
 
 def main() -> int:
@@ -275,26 +290,31 @@ def main() -> int:
         "--workflows",
         default=",".join(DEFAULT_WORKFLOWS),
         help=(
-            "Comma-separated workflows. Supported: " + ", ".join(SUPPORTED_WORKFLOWS)
+            "Comma-separated workflows. Supported: "
+            + ", ".join(SUPPORTED_WORKFLOWS)
         ),
     )
     parser.add_argument("--repetitions", type=int, default=10)
-    parser.add_argument("--output", type=Path, default=Path("benchmark-results.json"))
+    parser.add_argument(
+        "--output", type=Path, default=Path("benchmark-results.json")
+    )
     args = parser.parse_args()
 
     all_cases = discover_cases()
 
-    requested_workflows = set(_parse_csv(args.workflows))
+    requested_workflows = set(parse_csv(args.workflows))
     unsupported = sorted(requested_workflows - set(SUPPORTED_WORKFLOWS))
     if unsupported:
         print("Unsupported workflows: " + ", ".join(unsupported), file=sys.stderr)
         return 2
-    workflows = {_canonical_workflow(item) for item in requested_workflows}
+    workflows = {canonical_workflow(item) for item in requested_workflows}
 
     if args.cases:
-        case_names = set(_parse_csv(args.cases))
+        case_names = set(parse_csv(args.cases))
         filtered = [
-            c for c in all_cases if c.name in case_names and c.workflow in workflows
+            c
+            for c in all_cases
+            if c.name in case_names and c.workflow in workflows
         ]
     else:
         filtered = [c for c in all_cases if c.workflow in workflows]
@@ -307,7 +327,9 @@ def main() -> int:
     failures = 0
     for case in filtered:
         print(f"Benchmarking {case.name}/{case.workflow}...", file=sys.stderr)
-        result = run_benchmark(args.arco_binary, case, args.repetitions)
+        result = run_benchmark(
+            args.arco_binary, case=case, repetitions=args.repetitions
+        )
         if result is None:
             failures += 1
             print("  FAILED", file=sys.stderr)
@@ -320,7 +342,9 @@ def main() -> int:
         )
 
     validate_medians = {
-        r.case: r.median_duration_ms for r in results if r.workflow == "validate"
+        r.case: r.median_duration_ms
+        for r in results
+        if r.workflow == "validate"
     }
 
     output = []
@@ -333,7 +357,9 @@ def main() -> int:
         ]
         if r.workflow == "run" and r.case in validate_medians:
             validate_median = validate_medians[r.case]
-            extra_lines.append(f"validate_median_ms={validate_median:.3f}")
+            extra_lines.append(
+                f"validate_median_ms={validate_median:.3f}"
+            )
             extra_lines.append(
                 f"solve_estimate_ms={max(0.0, r.median_duration_ms - validate_median):.3f}"
             )

--- a/scripts/bench.py
+++ b/scripts/bench.py
@@ -23,6 +23,7 @@ import statistics
 import subprocess
 import sys
 import tempfile
+import time
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -42,6 +43,11 @@ SUPPORTED_WORKFLOWS: tuple[str, ...] = (
     "compile",  # backward-compatible alias for print-model
     "solve",  # backward-compatible alias for run
 )
+
+# Minimum total runtime needed for torc's sysinfo monitor to capture at least
+# one memory sample.  With --sample-interval-seconds 1, a job must live >1s.
+MIN_MONITORED_RUNTIME_S = 4.0
+MAX_INNER_ITERATIONS = 5_000
 
 
 @dataclass(frozen=True)
@@ -115,6 +121,34 @@ def parse_csv(value: str) -> list[str]:
     return [entry.strip() for entry in value.split(",") if entry.strip()]
 
 
+def calibrate_inner_iterations(arco_cmd: list[str]) -> int | None:
+    """Run arco once to estimate runtime and determine how many inner
+    iterations are needed to reach MIN_MONITORED_RUNTIME_S total time."""
+    started = time.perf_counter()
+    try:
+        result = subprocess.run(arco_cmd, capture_output=True, text=True, timeout=300)
+    except subprocess.TimeoutExpired:
+        print("  calibration timed out", file=sys.stderr)
+        return None
+    except OSError as exc:
+        print(f"  calibration failed to launch: {exc}", file=sys.stderr)
+        return None
+
+    elapsed_s = time.perf_counter() - started
+    if result.returncode != 0:
+        print("  calibration command failed", file=sys.stderr)
+        tail = tail_lines(result.stderr)
+        if tail:
+            print(tail, file=sys.stderr)
+        return None
+
+    if elapsed_s <= 0.0:
+        return 1
+
+    estimated = int(MIN_MONITORED_RUNTIME_S / elapsed_s) + 1
+    return max(1, min(MAX_INNER_ITERATIONS, estimated))
+
+
 def run_benchmark(
     arco_binary: str, *, case: BenchmarkCase, repetitions: int
 ) -> BenchmarkResult | None:
@@ -123,9 +157,33 @@ def run_benchmark(
     Creates a torc workflow with *repetitions* identical jobs, runs them
     sequentially, then extracts peak memory and duration from torc's result
     records.
+
+    For commands faster than MIN_MONITORED_RUNTIME_S, each job wraps the
+    arco command in a shell loop so torc's sysinfo monitor has time to
+    capture at least one memory sample.
     """
     arco_args = build_arco_args(workflow=case.workflow, model_path=case.kdl_path)
-    arco_cmd_str = shlex.join([arco_binary, *arco_args])
+    arco_cmd = [arco_binary, *arco_args]
+
+    inner_iterations = calibrate_inner_iterations(arco_cmd)
+    if inner_iterations is None:
+        return None
+
+    if inner_iterations > 1:
+        print(
+            f"  using {inner_iterations} inner iterations for memory sampling",
+            file=sys.stderr,
+        )
+
+    # Build the per-job command.  For fast commands we wrap a shell loop;
+    # for commands that already run >MIN_MONITORED_RUNTIME_S we run once.
+    arco_cmd_quoted = shlex.join(arco_cmd)
+    if inner_iterations > 1:
+        job_cmd = (
+            f"for _ in $(seq 1 {inner_iterations}); do {arco_cmd_quoted}; done"
+        )
+    else:
+        job_cmd = arco_cmd_quoted
 
     with tempfile.TemporaryDirectory(prefix="arco-bench-torc-") as tmpdir:
         tmp = Path(tmpdir)
@@ -133,12 +191,16 @@ def run_benchmark(
         commands_path = tmp / "commands.txt"
 
         # Write N identical commands (one per repetition).
-        commands_path.write_text("\n".join([arco_cmd_str] * repetitions) + "\n")
+        commands_path.write_text("\n".join([job_cmd] * repetitions) + "\n")
 
         exec_cmd: list[str] = [
             "torc",
-            "exec",
             "--standalone",
+            "--format",
+            "json",
+            "--db",
+            str(db_path),
+            "exec",
             "-C",
             str(commands_path),
             "--name",
@@ -149,10 +211,6 @@ def run_benchmark(
             "1",
             "--sample-interval-seconds",
             "1",
-            "--format",
-            "json",
-            "--db",
-            str(db_path),
             "-o",
             str(tmp),
         ]
@@ -192,14 +250,14 @@ def run_benchmark(
         # Query results for this workflow.
         results_cmd: list[str] = [
             "torc",
+            "--standalone",
+            "--format",
+            "json",
+            "--db",
+            str(db_path),
             "results",
             "list",
             str(workflow_id),
-            "--format",
-            "json",
-            "--standalone",
-            "--db",
-            str(db_path),
         ]
         try:
             results_result = subprocess.run(
@@ -244,7 +302,8 @@ def run_benchmark(
             peak_bytes = item.get("peak_memory_bytes")
 
             if isinstance(exec_min, (int, float)):
-                durations.append(float(exec_min) * 60_000.0)
+                total_ms = float(exec_min) * 60_000.0
+                durations.append(total_ms / inner_iterations)
 
             # peak_memory_bytes can be None (torc didn't collect data) or 0
             # (collected zero / no samples fired).  Treat both as 0.0 MiB.


### PR DESCRIPTION
Replace rmon monitor-process with torc exec --standalone for CLI benchmark memory profiling.

## What changed

- **`scripts/bench.py`**: Replaced rmon-based monitoring with torc exec. torc's built-in sysinfo resource monitoring captures peak RSS and wall-clock duration from a single job run, eliminating the separate timing + monitoring passes. Dropped the inner-iterations complexity (torc samples natively during the process lifetime). Repetitions are batched into one torc workflow with `--max-parallel-jobs 1`.
- **`.github/workflows/ci.yaml`**: Install torc via `cargo install torc --features server-bin` instead of rmon via `uv tool install`. Cache key updated accordingly.

## Why

torc provides built-in per-job resource monitoring (peak memory, CPU, duration) via sysinfo process-tree walking, making the rmon external dependency unnecessary. The benchmark script is simpler (no calibration loop, no separate timing+monitoring passes).

## Not changed

- `scripts/bench_guard.py` — unchanged (compares JSON output, agnostic to profiling mechanism)
- Output format — unchanged (github-action-benchmark-compatible JSON)