### PR TITLE
fix(ci): avoid ad hoc tree-sitter install

### DIFF
--- a/.github/workflows/kdl-overlay.yaml
+++ b/.github/workflows/kdl-overlay.yaml
@@ -33,14 +33,15 @@ jobs:
         with:
           node-version: "22"
 
-      - name: Install tree-sitter CLI
-        run: npm install --global tree-sitter-cli
-
-      - name: Regenerate generated parser artifacts from grammar source
+      - name: Install tree-sitter dependencies
         working-directory: tools/tree-sitter-arco-kdl
         run: |
           npm ci
-          npx tree-sitter generate
+          echo "$PWD/node_modules/.bin" >> "$GITHUB_PATH"
+
+      - name: Regenerate generated parser artifacts from grammar source
+        working-directory: tools/tree-sitter-arco-kdl
+        run: tree-sitter generate
 
       - uses: j178/prek-action@dec4adcd2fa1db9d50a39668b22112a37235e730
         with:


### PR DESCRIPTION
## Summary

- remove the global `npm install --global tree-sitter-cli` step from the KDL overlay workflow
- install Tree-sitter dependencies from `tools/tree-sitter-arco-kdl/package-lock.json`
- add the local `node_modules/.bin` path to `GITHUB_PATH` so later workflow steps can run `tree-sitter`

## Why

`zizmor --pedantic` flags the global npm install as an ad-hoc package installation outside a lockfile. The CLI is already declared in `tools/tree-sitter-arco-kdl/package-lock.json`, so the workflow can use that pinned dependency instead while still making the binary available to the later `prek` KDL overlay check.

## Validation

- `just workflow-quality`
- `uvx --from actionlint-py actionlint .github/workflows/*.yaml`
- `npm ci && PATH="$PWD/node_modules/.bin:$PATH" tree-sitter generate && cd ../.. && PATH="$PWD/tools/tree-sitter-arco-kdl/node_modules/.bin:$PATH" just kdl-overlay-check` from `tools/tree-sitter-arco-kdl`
- commit hooks: trailing whitespace, added-large-files, EOF fixer, YAML check, typos, prettier, zizmor, commitizen
- pre-push hooks: cargo fmt, cargo clippy, cargo test (fast)