### PR TITLE
feat(kdl): improve formatter and VS Code tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,8 @@ $ arco kdl fmt input.kdl
 `arco kdl fmt` prints Arco authoring syntax by default, including readable
 algebra blocks. Use `--kdl-compatible` when tooling needs normalized strict KDL
 with algebra stored as `expression=` properties or `formula "..."` children.
+Existing `arco kdl fmt --check` gates may need one committed formatting pass;
+see the [KDL formatting migration note](./docs/migration/kdl-formatting.md).
 
 Install the local VS Code helper extension with highlighting, diagnostics,
 formatting, and status-bar actions:

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ relentless about minimizing memory usage so more systems can run real workloads.
 <p align="center">
   <a href="#quickstart">Quickstart</a> ·
   <a href="#installation">Installation</a> ·
+  <a href="#vs-code-extension">VS Code</a> ·
   <a href="#kdl-language">KDL Language</a> ·
   <a href="#cli-reference">CLI Reference</a> ·
   <a href="#language-bindings">Language Bindings</a> ·
@@ -190,6 +191,43 @@ just py-dev
 # Run full local CI-equivalent checks
 just ci
 ```
+
+### VS Code Extension
+
+The local VS Code extension provides `.kdl` highlighting, diagnostics,
+formatting, format-on-save support, and an `arco KDL` status bar action. It
+uses the canonical `arco` CLI for validation and formatting, so the editor sees
+the same diagnostics as the command line.
+
+Install it from the repository root:
+
+```bash
+npm --prefix tools/vscode-arco-kdl run install:local
+```
+
+or, when using the repository `just` workflow:
+
+```bash
+just vscode-extension-install
+```
+
+For standard VS Code installs, no manual `VSCODE_CLI` setting is required. The
+installer uses `code` on PATH when available and also checks common app
+locations such as `/Applications`, `~/Applications`, and `~/User Apps` on
+macOS. Set `VSCODE_CLI` only when VS Code is installed somewhere custom.
+
+To configure the `arco` binary used by diagnostics and formatting, leave
+`arco.kdl.command` empty when `arco --version` works from your environment, or
+set it to an absolute path:
+
+```json
+{
+  "arco.kdl.command": "/Users/me/.local/bin/arco"
+}
+```
+
+For format-on-save and troubleshooting broken CLI paths, see the
+[VS Code extension guide](./tools/vscode-arco-kdl/README.md).
 
 ## KDL Language
 
@@ -526,7 +564,7 @@ Performance & Tooling
 - Memory diagnostics — built-in tracking of allocations
 - Block orchestration — DAG-based composition for multi-stage problems
 - Python bindings — programmatic access with NumPy integration
-- Editor support — tree-sitter grammar for syntax highlighting
+- Editor support — VS Code extension and tree-sitter grammar for KDL authoring
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ arco <command> [options]
 | `arco run <file>`           | Compile and solve a `.kdl` formulation                    |
 | `arco validate <file>`      | Validate a `.kdl` file without solving                    |
 | `arco kdl check <file>`     | Validate KDL, with JSON and optional data materialization |
+| `arco kdl fmt [paths]`      | Format KDL files or stdin                                 |
 | `arco --version`            | Print the installed Arco CLI version                      |
 | `arco self update`          | Update a standalone installer build                       |
 | `arco inspect <file>`       | Inspect semantic model (sets, variables, parameters)      |
@@ -322,11 +323,22 @@ $ arco kdl check input.kdl --format json --materialize-data
 {"valid":true,"diagnostics":[]}
 ```
 
-Install the local VS Code helper extension:
+Format KDL:
 
 ```bash
-cd tools/vscode-arco-kdl
-npm run install:local
+$ arco kdl fmt input.kdl
+1 file(s) reformatted
+```
+
+`arco kdl fmt` prints Arco authoring syntax by default, including readable
+algebra blocks. Use `--kdl-compatible` when tooling needs normalized strict KDL
+with algebra stored as `expression=` properties or `formula "..."` children.
+
+Install the local VS Code helper extension with highlighting, diagnostics,
+formatting, and status-bar actions:
+
+```bash
+npm --prefix tools/vscode-arco-kdl run install:local
 ```
 
 Print CLI version:

--- a/crates/arco-cli/src/main.rs
+++ b/crates/arco-cli/src/main.rs
@@ -9,7 +9,7 @@ use arco_cli::driver::{
     render_plain_driver_error, run_file_json_with_options_and_config, validate_file_only,
 };
 use arco_cli::self_update;
-use arco_ops::{ArcoOps, OpsExportFormat};
+use arco_ops::{ArcoOps, OpsExportFormat, OpsKdlFormatMode};
 use clap::{ArgAction, Args, Parser, Subcommand, ValueEnum};
 use miette::IntoDiagnostic;
 use similar::TextDiff;
@@ -132,6 +132,9 @@ struct KdlFmtArgs {
     /// Optional display name for stdin source (used in diff headers)
     #[arg(long)]
     stdin_filename: Option<String>,
+    /// Emit normalized strict KDL instead of Arco surface syntax
+    #[arg(long)]
+    kdl_compatible: bool,
 }
 
 #[derive(Subcommand)]
@@ -319,8 +322,12 @@ fn handle_solver_action(action: SolverAction) -> miette::Result<()> {
     Ok(())
 }
 
-fn format_kdl_text(input: &str, path: Option<&Path>) -> miette::Result<String> {
-    ArcoOps::format_kdl_text(input).map_err(|error| {
+fn format_kdl_text(
+    input: &str,
+    path: Option<&Path>,
+    mode: OpsKdlFormatMode,
+) -> miette::Result<String> {
+    ArcoOps::format_kdl_text_with_mode(input, mode).map_err(|error| {
         if let Some(path) = path {
             miette::miette!(
                 "Failed to parse KDL document: {} ({})",
@@ -373,12 +380,14 @@ fn print_unified_diff(label: &str, before: &str, after: &str) -> miette::Result<
 }
 
 fn run_kdl_fmt(args: KdlFmtArgs) -> miette::Result<()> {
+    let mode = kdl_format_mode(&args);
+
     if args.stdin || args.paths.iter().any(|path| path == Path::new("-")) {
         let mut input = String::new();
         std::io::stdin()
             .read_to_string(&mut input)
             .into_diagnostic()?;
-        let formatted = format_kdl_text(&input, None)?;
+        let formatted = format_kdl_text(&input, None, mode)?;
 
         if args.check || args.diff {
             if input != formatted {
@@ -410,7 +419,7 @@ fn run_kdl_fmt(args: KdlFmtArgs) -> miette::Result<()> {
 
     for file in files {
         let input = fs::read_to_string(&file).into_diagnostic()?;
-        let formatted = format_kdl_text(&input, Some(&file))?;
+        let formatted = format_kdl_text(&input, Some(&file), mode)?;
         if input == formatted {
             continue;
         }
@@ -439,6 +448,14 @@ fn run_kdl_fmt(args: KdlFmtArgs) -> miette::Result<()> {
     }
 
     Ok(())
+}
+
+fn kdl_format_mode(args: &KdlFmtArgs) -> OpsKdlFormatMode {
+    if args.kdl_compatible {
+        OpsKdlFormatMode::KdlCompatible
+    } else {
+        OpsKdlFormatMode::ArcoSurface
+    }
 }
 
 fn init_tracing(verbose: u8, force_warnings: bool) {

--- a/crates/arco-cli/tests/example_cli_commands.rs
+++ b/crates/arco-cli/tests/example_cli_commands.rs
@@ -1,5 +1,6 @@
+use std::io::Write;
 use std::path::PathBuf;
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::{
     fs,
     time::{SystemTime, UNIX_EPOCH},
@@ -26,6 +27,38 @@ fn run_cli(args: &[&str]) -> std::process::Output {
 }
 
 fn run_cli_with_env(args: &[&str], envs: &[(&str, &str)]) -> std::process::Output {
+    let (mut command, config_root) = configured_cli_command(args, envs);
+
+    let output = command.output().expect("failed to execute arco binary");
+    if let Some(root) = config_root {
+        let _ = fs::remove_dir_all(root);
+    }
+    output
+}
+
+fn run_cli_with_stdin(args: &[&str], stdin: &str) -> std::process::Output {
+    let (mut command, config_root) = configured_cli_command(args, &[]);
+    command
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    let mut child = command.spawn().expect("failed to execute arco binary");
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin should be piped")
+        .write_all(stdin.as_bytes())
+        .expect("write stdin");
+    let output = child.wait_with_output().expect("wait for arco binary");
+
+    if let Some(root) = config_root {
+        let _ = fs::remove_dir_all(root);
+    }
+    output
+}
+
+fn configured_cli_command(args: &[&str], envs: &[(&str, &str)]) -> (Command, Option<PathBuf>) {
     let mut command = Command::new(env!("CARGO_BIN_EXE_arco"));
     command.args(args);
 
@@ -45,11 +78,7 @@ fn run_cli_with_env(args: &[&str], envs: &[(&str, &str)]) -> std::process::Outpu
         command.env(key, value);
     }
 
-    let output = command.output().expect("failed to execute arco binary");
-    if let Some(root) = config_root {
-        let _ = fs::remove_dir_all(root);
-    }
-    output
+    (command, config_root)
 }
 
 fn unique_temp_dir(prefix: &str) -> PathBuf {
@@ -967,6 +996,109 @@ fn kdl_fmt_diff_prints_unified_diff() {
     assert!(stdout.contains("+++"));
 
     let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn kdl_fmt_formats_stdin_with_display_filename() {
+    let fixture_path = cli_fixture_path("format/unformatted.kdl");
+    let input = fs::read_to_string(&fixture_path).expect("read unformatted fixture");
+
+    let output = run_cli_with_stdin(
+        &[
+            "kdl",
+            "fmt",
+            "--stdin",
+            "--stdin-filename",
+            "format/unformatted.kdl",
+        ],
+        &input,
+    );
+
+    assert!(
+        output.status.success(),
+        "stdin format should succeed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("node"));
+    assert!(stdout.contains("key=1"));
+    assert!(
+        !stdout.contains('\t'),
+        "formatted stdout should not contain tabs: {stdout}"
+    );
+}
+
+#[test]
+fn kdl_fmt_formats_quoted_formula_as_surface_block() {
+    let fixture_path = cli_fixture_path("format/power-balance-quoted-formula.kdl");
+    let input = fs::read_to_string(&fixture_path).expect("read quoted formula fixture");
+
+    let output = run_cli_with_stdin(&["kdl", "fmt", "--stdin"], &input);
+
+    assert!(
+        output.status.success(),
+        "stdin format should succeed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("// Formatter regression fixture for generated algebra blocks."),
+        "surface formatter should preserve leading comments:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("model dcopf"),
+        "surface formatter should preserve model arguments:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("constraint power_balance"),
+        "surface formatter should preserve constraint arguments:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("index b"),
+        "surface formatter should preserve index arguments:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("in bus"),
+        "surface formatter should preserve domain arguments:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("formula \"sum(pg[g]"),
+        "surface formatter should not keep quoted formula wrapper:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("sum(pg[g] for g in generators if connected[b,g] > 0)\n"),
+        "surface formatter should keep the left-hand sum on its own line:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("- pd[b] / 100\n"),
+        "surface formatter should split top-level subtraction:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("= sum(incidence[l,b] * flow[l] for l in lines)\n"),
+        "surface formatter should split top-level equality:\n{stdout}"
+    );
+}
+
+#[test]
+fn kdl_fmt_kdl_compatible_keeps_quoted_formula() {
+    let fixture_path = cli_fixture_path("format/power-balance-quoted-formula.kdl");
+    let input = fs::read_to_string(&fixture_path).expect("read quoted formula fixture");
+
+    let output = run_cli_with_stdin(&["kdl", "fmt", "--stdin", "--kdl-compatible"], &input);
+
+    assert!(
+        output.status.success(),
+        "stdin format should succeed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("formula \"sum(pg[g] for g in generators if connected[b,g] > 0) - pd[b] / 100 = sum(incidence[l,b] * flow[l] for l in lines)\""),
+        "KDL-compatible formatter should retain strict formula child syntax:\n{stdout}"
+    );
 }
 
 #[test]

--- a/crates/arco-cli/tests/example_cli_commands.rs
+++ b/crates/arco-cli/tests/example_cli_commands.rs
@@ -1082,6 +1082,39 @@ fn kdl_fmt_formats_quoted_formula_as_surface_block() {
 }
 
 #[test]
+fn kdl_fmt_preserves_multiline_block_comment_prose() {
+    let fixture_path = cli_fixture_path("format/multiline-block-comment.kdl");
+    let input = fs::read_to_string(&fixture_path).expect("read block comment fixture");
+
+    let output = run_cli_with_stdin(&["kdl", "fmt", "--stdin"], &input);
+
+    assert!(
+        output.status.success(),
+        "stdin format should succeed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("This middle line used to be dropped by the surface renderer."),
+        "surface formatter should preserve block comment prose:\n{stdout}"
+    );
+
+    let second_output = run_cli_with_stdin(&["kdl", "fmt", "--stdin"], &stdout);
+    assert!(
+        second_output.status.success(),
+        "second stdin format should succeed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&second_output.stdout),
+        String::from_utf8_lossy(&second_output.stderr)
+    );
+    assert_eq!(
+        stdout,
+        String::from_utf8_lossy(&second_output.stdout),
+        "surface formatter should be idempotent after preserving block comments"
+    );
+}
+
+#[test]
 fn kdl_fmt_kdl_compatible_keeps_quoted_formula() {
     let fixture_path = cli_fixture_path("format/power-balance-quoted-formula.kdl");
     let input = fs::read_to_string(&fixture_path).expect("read quoted formula fixture");

--- a/crates/arco-cli/tests/fixtures/format/multiline-block-comment.kdl
+++ b/crates/arco-cli/tests/fixtures/format/multiline-block-comment.kdl
@@ -1,0 +1,7 @@
+/* Formatter must preserve prose inside block comments.
+   This middle line used to be dropped by the surface renderer.
+*/
+model comment_fixture {
+  control x lower=0
+  minimize total_cost { x }
+}

--- a/crates/arco-cli/tests/fixtures/format/power-balance-quoted-formula.kdl
+++ b/crates/arco-cli/tests/fixtures/format/power-balance-quoted-formula.kdl
@@ -1,0 +1,15 @@
+// Formatter regression fixture for generated algebra blocks.
+model dcopf {
+  constraint "power_balance" {
+    index b { in bus }
+    expression {
+      formula "sum(pg[g] for g in generators if connected[b,g] > 0) - pd[b] / 100 = sum(incidence[l,b] * flow[l] for l in lines)"
+    }
+  }
+
+  expression GenerationCost {
+    formula "sum(pg[g] * b[g] * 100 for g in generators)"
+  }
+
+  minimize OF expression=GenerationCost
+}

--- a/crates/arco-cli/tests/fixtures/format/unformatted.kdl
+++ b/crates/arco-cli/tests/fixtures/format/unformatted.kdl
@@ -1,0 +1,1 @@
+node	key=1

--- a/crates/arco-kdl/src/source/mod.rs
+++ b/crates/arco-kdl/src/source/mod.rs
@@ -7,4 +7,7 @@ mod surface;
 
 pub use ast::*;
 pub use error::*;
-pub use parser::{format_program_text, parse_program_file, parse_program_text};
+pub use parser::{
+    KdlFormatMode, format_program_text, format_program_text_with_mode, parse_program_file,
+    parse_program_text,
+};

--- a/crates/arco-kdl/src/source/parser.rs
+++ b/crates/arco-kdl/src/source/parser.rs
@@ -13,7 +13,7 @@ use crate::source::parser_helpers::{
     parse_constraint_index_binding, parse_optimize, parse_optional_filter_expression, parse_reduce,
     positional_value, property_string, unsupported_declaration_error,
 };
-use crate::source::surface::normalize_surface_syntax;
+use crate::source::surface::{format_surface_document, normalize_surface_syntax};
 use kdl::{KdlDocument, KdlError, KdlNode, KdlValue};
 use miette::NamedSource;
 use std::fs;
@@ -94,11 +94,24 @@ pub fn parse_program_file(path: &Path) -> Result<ParsedSource, SourceError> {
     parse_program_file_with_base(path, base_dir, true)
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KdlFormatMode {
+    ArcoSurface,
+    KdlCompatible,
+}
+
 pub fn format_program_text(text: &str) -> Result<String, KdlError> {
+    format_program_text_with_mode(text, KdlFormatMode::ArcoSurface)
+}
+
+pub fn format_program_text_with_mode(text: &str, mode: KdlFormatMode) -> Result<String, KdlError> {
     let normalized = normalize_surface_syntax(text);
     let mut document: KdlDocument = normalized.parse()?;
     document.autoformat();
-    Ok(document.to_string())
+    match mode {
+        KdlFormatMode::ArcoSurface => Ok(format_surface_document(&document)),
+        KdlFormatMode::KdlCompatible => Ok(document.to_string()),
+    }
 }
 
 pub fn parse_program_text(text: &str, path: &Path) -> Result<ParsedSource, SourceError> {

--- a/crates/arco-kdl/src/source/surface.rs
+++ b/crates/arco-kdl/src/source/surface.rs
@@ -144,25 +144,135 @@ fn render_leading_comments(node: &KdlNode, indent: usize, output: &mut String) {
         return;
     };
 
-    let mut saw_comment = false;
-    for line in format.leading.lines() {
-        let trimmed = line.trim();
-        if is_comment_line(trimmed) {
-            push_indent(indent, output);
-            output.push_str(trimmed);
-            output.push('\n');
-            saw_comment = true;
-        } else if saw_comment && trimmed.is_empty() {
-            output.push('\n');
+    let mut rendered_comment = false;
+    let mut pending_blank_line = false;
+    for comment in leading_comments(&format.leading) {
+        match comment {
+            LeadingComment::BlankLine if rendered_comment => {
+                pending_blank_line = true;
+            }
+            LeadingComment::BlankLine => {}
+            LeadingComment::Comment(span) => {
+                if pending_blank_line {
+                    output.push('\n');
+                    pending_blank_line = false;
+                }
+                render_comment_span(span, indent, output);
+                rendered_comment = true;
+            }
         }
     }
 }
 
-fn is_comment_line(line: &str) -> bool {
-    line.starts_with("//")
-        || line.starts_with("/*")
-        || line.starts_with('*')
-        || line.starts_with("*/")
+enum LeadingComment<'a> {
+    BlankLine,
+    Comment(&'a str),
+}
+
+fn leading_comments(text: &str) -> Vec<LeadingComment<'_>> {
+    let mut comments = Vec::new();
+    let mut index = 0usize;
+    let mut newlines_since_comment = 0usize;
+
+    while index < text.len() {
+        let Some(remaining) = text.get(index..) else {
+            break;
+        };
+
+        if remaining.starts_with("//") {
+            if newlines_since_comment > 1 {
+                comments.push(LeadingComment::BlankLine);
+            }
+            let end = line_comment_end(text, index);
+            if let Some(span) = text.get(index..end) {
+                comments.push(LeadingComment::Comment(span));
+            }
+            index = end;
+            newlines_since_comment = 0;
+            continue;
+        }
+
+        if remaining.starts_with("/*") {
+            if newlines_since_comment > 1 {
+                comments.push(LeadingComment::BlankLine);
+            }
+            let end = block_comment_end(text, index);
+            if let Some(span) = text.get(index..end) {
+                comments.push(LeadingComment::Comment(span));
+            }
+            index = end;
+            newlines_since_comment = 0;
+            continue;
+        }
+
+        let Some(character) = remaining.chars().next() else {
+            break;
+        };
+        if character == '\n' {
+            newlines_since_comment += 1;
+        } else if !character.is_whitespace() {
+            newlines_since_comment = 0;
+        }
+        index += character.len_utf8();
+    }
+
+    comments
+}
+
+fn line_comment_end(text: &str, start: usize) -> usize {
+    text.get(start..)
+        .and_then(|remaining| remaining.find('\n'))
+        .map_or(text.len(), |offset| start + offset)
+}
+
+fn block_comment_end(text: &str, start: usize) -> usize {
+    let search_start = start + "/*".len();
+    text.get(search_start..)
+        .and_then(|remaining| remaining.find("*/"))
+        .map_or(text.len(), |offset| search_start + offset + "*/".len())
+}
+
+fn render_comment_span(span: &str, indent: usize, output: &mut String) {
+    let lines = span.lines().collect::<Vec<_>>();
+    let common_indent = common_following_line_indent(&lines);
+    for (index, line) in lines.into_iter().enumerate() {
+        push_indent(indent, output);
+        let rendered = if index == 0 {
+            line
+        } else {
+            strip_leading_whitespace(line, common_indent)
+        };
+        output.push_str(rendered.trim_end());
+        output.push('\n');
+    }
+}
+
+fn common_following_line_indent(lines: &[&str]) -> usize {
+    lines
+        .iter()
+        .skip(1)
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| leading_whitespace_width(line))
+        .min()
+        .unwrap_or(0)
+}
+
+fn leading_whitespace_width(line: &str) -> usize {
+    line.chars()
+        .take_while(|character| character.is_whitespace() && *character != '\n')
+        .map(char::len_utf8)
+        .sum()
+}
+
+fn strip_leading_whitespace(line: &str, width: usize) -> &str {
+    let mut remaining = width;
+    for (index, character) in line.char_indices() {
+        if remaining == 0 || !character.is_whitespace() || character == '\n' {
+            return line.get(index..).unwrap_or("");
+        }
+        remaining = remaining.saturating_sub(character.len_utf8());
+    }
+    if remaining == 0 { line } else { "" }
 }
 
 fn render_entry(entry: &KdlEntry) -> String {

--- a/crates/arco-kdl/src/source/surface.rs
+++ b/crates/arco-kdl/src/source/surface.rs
@@ -1,3 +1,5 @@
+use kdl::{KdlDocument, KdlEntry, KdlNode, KdlValue};
+
 pub(super) fn normalize_surface_syntax(text: &str) -> String {
     let mut normalized = String::with_capacity(text.len());
     let bytes = text.as_bytes();
@@ -13,6 +15,379 @@ pub(super) fn normalize_surface_syntax(text: &str) -> String {
         index += 1;
     }
     normalized
+}
+
+pub(super) fn format_surface_document(document: &KdlDocument) -> String {
+    let mut rendered = String::new();
+    for node in document.nodes() {
+        render_node(node, 0, &mut rendered);
+    }
+    rendered
+}
+
+fn render_node(node: &KdlNode, indent: usize, output: &mut String) {
+    if promotes_expression_property(node.name().value()) {
+        if let Some(expression) = expression_property(node) {
+            render_expression_property_node(node, expression, indent, output);
+            return;
+        }
+    }
+
+    if node.name().value() == "expression" {
+        if let Some((formula_index, formula)) = formula_child(node) {
+            render_expression_formula_node(node, formula_index, formula, indent, output);
+            return;
+        }
+    }
+
+    render_generic_node(node, indent, output);
+}
+
+fn render_expression_property_node(
+    node: &KdlNode,
+    expression: &str,
+    indent: usize,
+    output: &mut String,
+) {
+    render_header(node, indent, Some("expression"), output);
+    output.push_str(" {\n");
+
+    if let Some(children) = node.children() {
+        for child in children.nodes() {
+            render_node(child, indent + 2, output);
+        }
+        render_named_algebra_block("expression", expression, indent + 2, output);
+    } else {
+        render_algebra(expression, indent + 2, output);
+    }
+
+    push_indent(indent, output);
+    output.push_str("}\n");
+}
+
+fn render_expression_formula_node(
+    node: &KdlNode,
+    formula_index: usize,
+    formula: &str,
+    indent: usize,
+    output: &mut String,
+) {
+    render_header(node, indent, None, output);
+    output.push_str(" {\n");
+
+    let Some(children) = node.children() else {
+        render_algebra(formula, indent + 2, output);
+        push_indent(indent, output);
+        output.push_str("}\n");
+        return;
+    };
+
+    if children.nodes().len() == 1 {
+        render_algebra(formula, indent + 2, output);
+    } else {
+        for (index, child) in children.nodes().iter().enumerate() {
+            if index != formula_index {
+                render_node(child, indent + 2, output);
+            }
+        }
+        render_named_algebra_block("expression", formula, indent + 2, output);
+    }
+
+    push_indent(indent, output);
+    output.push_str("}\n");
+}
+
+fn render_named_algebra_block(name: &str, expression: &str, indent: usize, output: &mut String) {
+    push_indent(indent, output);
+    output.push_str(name);
+    output.push_str(" {\n");
+    render_algebra(expression, indent + 2, output);
+    push_indent(indent, output);
+    output.push_str("}\n");
+}
+
+fn render_generic_node(node: &KdlNode, indent: usize, output: &mut String) {
+    render_header(node, indent, None, output);
+    if let Some(children) = node.children() {
+        output.push_str(" {\n");
+        for child in children.nodes() {
+            render_node(child, indent + 2, output);
+        }
+        push_indent(indent, output);
+        output.push_str("}\n");
+    } else {
+        output.push('\n');
+    }
+}
+
+fn render_header(
+    node: &KdlNode,
+    indent: usize,
+    excluded_property: Option<&str>,
+    output: &mut String,
+) {
+    render_leading_comments(node, indent, output);
+    push_indent(indent, output);
+    output.push_str(node.name().value());
+    for entry in node.entries() {
+        if excluded_property.is_some() && entry.name().map(|name| name.value()) == excluded_property
+        {
+            continue;
+        }
+        output.push(' ');
+        output.push_str(&render_entry(entry));
+    }
+}
+
+fn render_leading_comments(node: &KdlNode, indent: usize, output: &mut String) {
+    let Some(format) = node.format() else {
+        return;
+    };
+
+    let mut saw_comment = false;
+    for line in format.leading.lines() {
+        let trimmed = line.trim();
+        if is_comment_line(trimmed) {
+            push_indent(indent, output);
+            output.push_str(trimmed);
+            output.push('\n');
+            saw_comment = true;
+        } else if saw_comment && trimmed.is_empty() {
+            output.push('\n');
+        }
+    }
+}
+
+fn is_comment_line(line: &str) -> bool {
+    line.starts_with("//")
+        || line.starts_with("/*")
+        || line.starts_with('*')
+        || line.starts_with("*/")
+}
+
+fn render_entry(entry: &KdlEntry) -> String {
+    let mut rendered = String::new();
+    if let Some(name) = entry.name() {
+        rendered.push_str(name.value());
+        rendered.push('=');
+    }
+    if let Some(ty) = entry.ty() {
+        rendered.push('(');
+        rendered.push_str(ty.value());
+        rendered.push(')');
+    }
+    let value = entry.value().to_string();
+    if value.is_empty() {
+        if let Some(format) = entry.format() {
+            rendered.push_str(format.value_repr.trim());
+        }
+    } else {
+        rendered.push_str(&value);
+    }
+    rendered
+}
+
+fn render_algebra(expression: &str, indent: usize, output: &mut String) {
+    for line in format_algebra_lines(expression) {
+        push_indent(indent, output);
+        output.push_str(&line);
+        output.push('\n');
+    }
+}
+
+fn format_algebra_lines(expression: &str) -> Vec<String> {
+    let normalized = expression.split_whitespace().collect::<Vec<_>>().join(" ");
+    let splits = split_top_level_operators(&normalized);
+    if splits.len() <= 1 {
+        return vec![normalized];
+    }
+
+    splits
+        .into_iter()
+        .enumerate()
+        .map(|(index, line)| {
+            if index == 0 {
+                line
+            } else {
+                format!("  {line}")
+            }
+        })
+        .collect()
+}
+
+fn split_top_level_operators(expression: &str) -> Vec<String> {
+    let mut lines = Vec::new();
+    let mut segment_start = 0usize;
+    let mut pending_operator: Option<&str> = None;
+    let mut state = OperatorScanState::default();
+    let mut skip_until = 0usize;
+
+    for (index, character) in expression.char_indices() {
+        if index < skip_until {
+            continue;
+        }
+        if state.advance(character) {
+            continue;
+        }
+        if state.is_nested() {
+            continue;
+        }
+
+        let operator = top_level_operator_at(expression, index);
+        let Some(operator) = operator else {
+            continue;
+        };
+
+        let segment = expression[segment_start..index].trim();
+        if !segment.is_empty() {
+            lines.push(format_segment(pending_operator, segment));
+        }
+        pending_operator = Some(operator);
+        segment_start = index + operator.len();
+        skip_until = segment_start;
+    }
+
+    let segment = expression[segment_start..].trim();
+    if !segment.is_empty() {
+        lines.push(format_segment(pending_operator, segment));
+    }
+
+    lines
+}
+
+fn top_level_operator_at(expression: &str, index: usize) -> Option<&'static str> {
+    let remaining = expression.get(index..)?;
+    if remaining.starts_with("<=") {
+        return Some("<=");
+    }
+    if remaining.starts_with(">=") {
+        return Some(">=");
+    }
+    if remaining.starts_with("==") {
+        return Some("==");
+    }
+    if remaining.starts_with('=') {
+        return Some("=");
+    }
+
+    let operator = remaining.chars().next()?;
+    if matches!(operator, '+' | '-') && has_space_around(expression, index) {
+        return Some(if operator == '+' { "+" } else { "-" });
+    }
+
+    None
+}
+
+fn has_space_around(expression: &str, index: usize) -> bool {
+    let Some(previous) = expression[..index].chars().next_back() else {
+        return false;
+    };
+    let Some(next) = expression[index + 1..].chars().next() else {
+        return false;
+    };
+    previous.is_ascii_whitespace() && next.is_ascii_whitespace()
+}
+
+fn format_segment(operator: Option<&str>, segment: &str) -> String {
+    if let Some(operator) = operator {
+        format!("{operator} {segment}")
+    } else {
+        segment.to_string()
+    }
+}
+
+#[derive(Default)]
+struct OperatorScanState {
+    paren_depth: usize,
+    bracket_depth: usize,
+    brace_depth: usize,
+    in_string: bool,
+    escaped: bool,
+}
+
+impl OperatorScanState {
+    fn advance(&mut self, character: char) -> bool {
+        if self.in_string {
+            if self.escaped {
+                self.escaped = false;
+            } else if character == '\\' {
+                self.escaped = true;
+            } else if character == '"' {
+                self.in_string = false;
+            }
+            return true;
+        }
+
+        match character {
+            '"' => {
+                self.in_string = true;
+                true
+            }
+            '(' => {
+                self.paren_depth += 1;
+                true
+            }
+            ')' => {
+                self.paren_depth = self.paren_depth.saturating_sub(1);
+                true
+            }
+            '[' => {
+                self.bracket_depth += 1;
+                true
+            }
+            ']' => {
+                self.bracket_depth = self.bracket_depth.saturating_sub(1);
+                true
+            }
+            '{' => {
+                self.brace_depth += 1;
+                true
+            }
+            '}' => {
+                self.brace_depth = self.brace_depth.saturating_sub(1);
+                true
+            }
+            _ => false,
+        }
+    }
+
+    fn is_nested(&self) -> bool {
+        self.paren_depth > 0 || self.bracket_depth > 0 || self.brace_depth > 0
+    }
+}
+
+fn expression_property(node: &KdlNode) -> Option<&str> {
+    node.get("expression").and_then(KdlValue::as_string)
+}
+
+fn formula_child(node: &KdlNode) -> Option<(usize, &str)> {
+    node.children()?
+        .nodes()
+        .iter()
+        .enumerate()
+        .find_map(|(index, child)| {
+            if child.name().value() == "formula" {
+                child
+                    .get(0)
+                    .and_then(KdlValue::as_string)
+                    .map(|value| (index, value))
+            } else {
+                None
+            }
+        })
+}
+
+fn promotes_expression_property(name: &str) -> bool {
+    matches!(
+        name,
+        "constraint" | "expression" | "filter" | "if" | "lower" | "maximize" | "minimize" | "upper"
+    )
+}
+
+fn push_indent(indent: usize, output: &mut String) {
+    for _ in 0..indent {
+        output.push(' ');
+    }
 }
 
 fn rewrite_math_block_at(text: &str, start: usize) -> Option<(String, usize)> {
@@ -189,7 +564,7 @@ fn encode_kdl_string(value: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::normalize_surface_syntax;
+    use super::{format_algebra_lines, normalize_surface_syntax};
 
     #[test]
     fn rewrites_inline_math_bodies_to_expression_properties() {
@@ -215,5 +590,20 @@ constraint "ramp" {
         let normalized = normalize_surface_syntax(input);
         assert!(normalized.contains("index g"));
         assert!(normalized.contains("expression {"));
+    }
+
+    #[test]
+    fn splits_top_level_algebra_operators() {
+        let lines = format_algebra_lines(
+            "sum(pg[g] for g in generators if connected[b,g] > 0) - pd[b] / 100 = sum(incidence[l,b] * flow[l] for l in lines)",
+        );
+        assert_eq!(
+            lines,
+            vec![
+                "sum(pg[g] for g in generators if connected[b,g] > 0)",
+                "  - pd[b] / 100",
+                "  = sum(incidence[l,b] * flow[l] for l in lines)",
+            ]
+        );
     }
 }

--- a/crates/arco-kdl/src/source/surface.rs
+++ b/crates/arco-kdl/src/source/surface.rs
@@ -26,97 +26,97 @@ pub(super) fn format_surface_document(document: &KdlDocument) -> String {
 }
 
 fn render_node(node: &KdlNode, indent: usize, output: &mut String) {
-    if promotes_expression_property(node.name().value()) {
-        if let Some(expression) = expression_property(node) {
-            render_expression_property_node(node, expression, indent, output);
-            return;
-        }
+    if let Some(expression) =
+        expression_property(node).filter(|_| promotes_expression_property(node.name().value()))
+    {
+        let algebra = if node.children().is_some() {
+            AlgebraBlock::Named("expression", expression)
+        } else {
+            AlgebraBlock::Bare(expression)
+        };
+        render_block_node(
+            node,
+            indent,
+            Some("expression"),
+            None,
+            Some(algebra),
+            output,
+        );
+        return;
     }
 
     if node.name().value() == "expression" {
         if let Some((formula_index, formula)) = formula_child(node) {
-            render_expression_formula_node(node, formula_index, formula, indent, output);
+            let algebra = if node
+                .children()
+                .is_some_and(|children| children.nodes().len() == 1)
+            {
+                AlgebraBlock::Bare(formula)
+            } else {
+                AlgebraBlock::Named("expression", formula)
+            };
+            render_block_node(
+                node,
+                indent,
+                None,
+                Some(formula_index),
+                Some(algebra),
+                output,
+            );
             return;
         }
     }
 
-    render_generic_node(node, indent, output);
+    render_block_node(node, indent, None, None, None, output);
 }
 
-fn render_expression_property_node(
+#[derive(Clone, Copy)]
+enum AlgebraBlock<'a> {
+    Bare(&'a str),
+    Named(&'static str, &'a str),
+}
+
+fn render_block_node(
     node: &KdlNode,
-    expression: &str,
     indent: usize,
+    excluded_property: Option<&str>,
+    skipped_child: Option<usize>,
+    algebra: Option<AlgebraBlock<'_>>,
     output: &mut String,
 ) {
-    render_header(node, indent, Some("expression"), output);
+    render_header(node, indent, excluded_property, output);
+    if node.children().is_none() && algebra.is_none() {
+        output.push('\n');
+        return;
+    }
     output.push_str(" {\n");
 
     if let Some(children) = node.children() {
-        for child in children.nodes() {
-            render_node(child, indent + 2, output);
-        }
-        render_named_algebra_block("expression", expression, indent + 2, output);
-    } else {
-        render_algebra(expression, indent + 2, output);
-    }
-
-    push_indent(indent, output);
-    output.push_str("}\n");
-}
-
-fn render_expression_formula_node(
-    node: &KdlNode,
-    formula_index: usize,
-    formula: &str,
-    indent: usize,
-    output: &mut String,
-) {
-    render_header(node, indent, None, output);
-    output.push_str(" {\n");
-
-    let Some(children) = node.children() else {
-        render_algebra(formula, indent + 2, output);
-        push_indent(indent, output);
-        output.push_str("}\n");
-        return;
-    };
-
-    if children.nodes().len() == 1 {
-        render_algebra(formula, indent + 2, output);
-    } else {
         for (index, child) in children.nodes().iter().enumerate() {
-            if index != formula_index {
+            if Some(index) != skipped_child {
                 render_node(child, indent + 2, output);
             }
         }
-        render_named_algebra_block("expression", formula, indent + 2, output);
+    }
+    if let Some(algebra) = algebra {
+        render_algebra_block(algebra, indent + 2, output);
     }
 
     push_indent(indent, output);
     output.push_str("}\n");
 }
 
-fn render_named_algebra_block(name: &str, expression: &str, indent: usize, output: &mut String) {
-    push_indent(indent, output);
-    output.push_str(name);
-    output.push_str(" {\n");
-    render_algebra(expression, indent + 2, output);
-    push_indent(indent, output);
-    output.push_str("}\n");
-}
-
-fn render_generic_node(node: &KdlNode, indent: usize, output: &mut String) {
-    render_header(node, indent, None, output);
-    if let Some(children) = node.children() {
-        output.push_str(" {\n");
-        for child in children.nodes() {
-            render_node(child, indent + 2, output);
+fn render_algebra_block(algebra: AlgebraBlock<'_>, indent: usize, output: &mut String) {
+    match algebra {
+        AlgebraBlock::Bare(expression) => render_algebra(expression, indent, output),
+        AlgebraBlock::Named(name, expression) => {
+            push_indent(indent, output);
+            output.push_str(name);
+            output.push_str(" {\n");
+            render_algebra(expression, indent + 2, output);
+            push_indent(indent, output);
+            output.push_str("}\n");
         }
-        push_indent(indent, output);
-        output.push_str("}\n");
-    } else {
-        output.push('\n');
     }
 }
 
@@ -257,17 +257,10 @@ fn split_top_level_operators(expression: &str) -> Vec<String> {
 
 fn top_level_operator_at(expression: &str, index: usize) -> Option<&'static str> {
     let remaining = expression.get(index..)?;
-    if remaining.starts_with("<=") {
-        return Some("<=");
-    }
-    if remaining.starts_with(">=") {
-        return Some(">=");
-    }
-    if remaining.starts_with("==") {
-        return Some("==");
-    }
-    if remaining.starts_with('=') {
-        return Some("=");
+    for operator in ["<=", ">=", "==", "="] {
+        if remaining.starts_with(operator) {
+            return Some(operator);
+        }
     }
 
     let operator = remaining.chars().next()?;
@@ -298,9 +291,7 @@ fn format_segment(operator: Option<&str>, segment: &str) -> String {
 
 #[derive(Default)]
 struct OperatorScanState {
-    paren_depth: usize,
-    bracket_depth: usize,
-    brace_depth: usize,
+    nesting_depth: usize,
     in_string: bool,
     escaped: bool,
 }
@@ -323,28 +314,12 @@ impl OperatorScanState {
                 self.in_string = true;
                 true
             }
-            '(' => {
-                self.paren_depth += 1;
+            '(' | '[' | '{' => {
+                self.nesting_depth += 1;
                 true
             }
-            ')' => {
-                self.paren_depth = self.paren_depth.saturating_sub(1);
-                true
-            }
-            '[' => {
-                self.bracket_depth += 1;
-                true
-            }
-            ']' => {
-                self.bracket_depth = self.bracket_depth.saturating_sub(1);
-                true
-            }
-            '{' => {
-                self.brace_depth += 1;
-                true
-            }
-            '}' => {
-                self.brace_depth = self.brace_depth.saturating_sub(1);
+            ')' | ']' | '}' => {
+                self.nesting_depth = self.nesting_depth.saturating_sub(1);
                 true
             }
             _ => false,
@@ -352,7 +327,7 @@ impl OperatorScanState {
     }
 
     fn is_nested(&self) -> bool {
-        self.paren_depth > 0 || self.bracket_depth > 0 || self.brace_depth > 0
+        self.nesting_depth > 0
     }
 }
 

--- a/crates/arco-ops/src/lib.rs
+++ b/crates/arco-ops/src/lib.rs
@@ -41,7 +41,10 @@ use arco_kdl as kdl;
 #[cfg(feature = "compile")]
 use arco_kdl::PrimitiveBuildError;
 #[cfg(feature = "compile")]
-use arco_kdl::source::{ParsedSource, SourceError, format_program_text, parse_program_file};
+use arco_kdl::source::{
+    KdlFormatMode, ParsedSource, SourceError, format_program_text, format_program_text_with_mode,
+    parse_program_file,
+};
 /// Stable model-facing vocabulary exposed through the ops seam.
 pub mod modeling {
     pub use arco_model::{
@@ -165,6 +168,26 @@ pub enum OpsExportFormat {
     Mps,
 }
 
+/// KDL formatting output style supported by the operations facade.
+#[cfg(feature = "compile")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OpsKdlFormatMode {
+    /// Prefer Arco authoring syntax, including bare algebra blocks.
+    ArcoSurface,
+    /// Emit strict KDL-compatible syntax after surface normalization.
+    KdlCompatible,
+}
+
+#[cfg(feature = "compile")]
+impl From<OpsKdlFormatMode> for KdlFormatMode {
+    fn from(value: OpsKdlFormatMode) -> Self {
+        match value {
+            OpsKdlFormatMode::ArcoSurface => Self::ArcoSurface,
+            OpsKdlFormatMode::KdlCompatible => Self::KdlCompatible,
+        }
+    }
+}
+
 /// Thin operations facade used by interaction surfaces.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub struct ArcoOps;
@@ -185,6 +208,12 @@ impl ArcoOps {
     #[cfg(feature = "compile")]
     pub fn format_kdl_text(text: &str) -> Result<String, String> {
         format_program_text(text).map_err(|error| error.to_string())
+    }
+
+    /// Format KDL source text through the canonical formatter with an explicit mode.
+    #[cfg(feature = "compile")]
+    pub fn format_kdl_text_with_mode(text: &str, mode: OpsKdlFormatMode) -> Result<String, String> {
+        format_program_text_with_mode(text, mode.into()).map_err(|error| error.to_string())
     }
 
     /// Check a KDL model file through semantic validation.

--- a/docs/dev/kdl-tooling.md
+++ b/docs/dev/kdl-tooling.md
@@ -6,11 +6,11 @@ compiler.
 
 ## Ownership
 
-| Tool                         | Responsibility                                                       | Not responsible for                         |
-| ---------------------------- | -------------------------------------------------------------------- | ------------------------------------------- |
-| `crates/arco-kdl`            | Canonical parse, semantic validation, and compiler input model       | Editor highlighting                         |
-| `tools/tree-sitter-arco-kdl` | Fast editor parse for structure, highlighting, and injection ranges  | Semantic validation or full algebra parsing |
-| `tools/vscode-arco-kdl`      | VS Code language registration and diagnostics from the canonical CLI | Reimplementing KDL validation               |
+| Tool                         | Responsibility                                                                    | Not responsible for                         |
+| ---------------------------- | --------------------------------------------------------------------------------- | ------------------------------------------- |
+| `crates/arco-kdl`            | Canonical parse, semantic validation, and compiler input model                    | Editor highlighting                         |
+| `tools/tree-sitter-arco-kdl` | Fast editor parse for structure, highlighting, and injection ranges               | Semantic validation or full algebra parsing |
+| `tools/vscode-arco-kdl`      | VS Code language registration, diagnostics, and formatting from the canonical CLI | Reimplementing KDL validation or formatting |
 
 ## Canonical validation
 
@@ -83,20 +83,50 @@ expression investment_by_area_tech {
 
 It must not duplicate semantic checks from `crates/arco-kdl`.
 
+## Canonical formatting
+
+Use the CLI for formatting:
+
+```sh
+arco kdl fmt path/to/input.kdl
+```
+
+The default formatter emits Arco surface syntax for authoring, so algebra is
+rendered as readable blocks instead of quoted `formula` strings. Use
+`--kdl-compatible` when a tool needs normalized strict KDL output.
+
+Editor integrations should request stdin formatting instead of reading or
+writing files directly:
+
+```sh
+arco kdl fmt --stdin --stdin-filename path/to/input.kdl
+```
+
 ## VS Code extension
 
-The VS Code helper validates files by running the canonical CLI and converting
-JSON diagnostics into editor diagnostics. The extension auto-detects the CLI
-from `arco.kdl.checkCommand`, `ARCO_CLI`, workspace `target/{debug,release}`
-binaries, then PATH. If no CLI is found, it reports a warning with setup actions
-instead of guessing silently.
+The VS Code helper validates and formats files by running the canonical CLI. It
+converts JSON check output into editor diagnostics and converts formatter stdout
+into VS Code document edits. Its primary in-editor UX is the `arco KDL` status
+bar item, which exposes validate, format, CLI selection, and setup help without
+requiring users to discover commands or settings first.
+
+The extension auto-detects the CLI from `arco.kdl.command`, `ARCO_CLI`, PATH,
+common user install paths such as `~/.local/bin/arco` and `~/.cargo/bin/arco`,
+then runnable workspace `target/{debug,release}` binaries. Auto-detected
+commands must run `arco --version` successfully so a workspace development
+binary with missing dynamic solver libraries does not shadow a working installed
+CLI. `arco.kdl.checkCommand` remains a legacy fallback. If no CLI is found, it
+reports a warning with setup actions instead of guessing silently.
 
 Local install for VS Code users should stay one command:
 
 ```sh
-cd tools/vscode-arco-kdl
-npm run install:local
+npm --prefix tools/vscode-arco-kdl run install:local
 ```
+
+The local installer should use `code` on PATH when available and auto-detect
+standard VS Code app bundle locations on macOS, including `~/User Apps`.
+`VSCODE_CLI` is only an escape hatch for non-standard installs.
 
 ## Checks
 
@@ -106,5 +136,5 @@ Use these checks for KDL tooling changes:
 cargo test -p arco-cli kdl_check_json --test example_cli_commands
 cd tools/tree-sitter-arco-kdl && npx tree-sitter test
 scripts/check-kdl-overlay.sh
-cd tools/vscode-arco-kdl && npm run check
+bash scripts/ci_vscode_extension_check.sh
 ```

--- a/docs/dev/kdl-tooling.md
+++ b/docs/dev/kdl-tooling.md
@@ -94,6 +94,9 @@ arco kdl fmt path/to/input.kdl
 The default formatter emits Arco surface syntax for authoring, so algebra is
 rendered as readable blocks instead of quoted `formula` strings. Use
 `--kdl-compatible` when a tool needs normalized strict KDL output.
+Projects with existing `arco kdl fmt --check` gates may need one committed
+formatting pass after adopting the Arco surface formatter, or can keep strict
+KDL output with `--kdl-compatible`.
 
 Editor integrations should request stdin formatting instead of reading or
 writing files directly:

--- a/docs/migration/README.md
+++ b/docs/migration/README.md
@@ -7,6 +7,7 @@ working across pre-1.0 snapshots.
 | Note                                           | Scope                                  |
 | ---------------------------------------------- | -------------------------------------- |
 | [API UX Contract Changes](api-ux-contracts.md) | Python modeling and result-access APIs |
+| [KDL Formatting Defaults](kdl-formatting.md)   | CLI formatter and VS Code settings     |
 
 ---
 

--- a/docs/migration/kdl-formatting.md
+++ b/docs/migration/kdl-formatting.md
@@ -1,0 +1,52 @@
+# KDL Formatting Defaults
+
+The default `arco kdl fmt` output is now Arco surface syntax. This keeps KDL
+models in the authoring form used throughout the repository, including readable
+algebra blocks instead of strict-KDL `formula "..."` wrappers.
+
+## What changed
+
+Before this change, `arco kdl fmt` emitted the KDL crate's normalized strict KDL
+representation. Now it emits the Arco authoring surface by default:
+
+```bash
+arco kdl fmt path/to/model.kdl
+```
+
+Use `--kdl-compatible` when a downstream tool needs strict normalized KDL:
+
+```bash
+arco kdl fmt --kdl-compatible path/to/model.kdl
+```
+
+## CI and pre-commit checks
+
+Existing projects that run `arco kdl fmt --check` may see failures the first
+time they adopt this formatter version because committed files need one
+formatting pass. Choose one path:
+
+- Run `arco kdl fmt <paths>` once and commit the resulting formatting changes.
+- Change the check to `arco kdl fmt --check --kdl-compatible <paths>` when the
+  strict-KDL representation is required.
+
+After the files are updated, `arco kdl fmt --check` remains stable and
+idempotent.
+
+## VS Code setting rename
+
+The VS Code extension uses `arco.kdl.command` for the `arco` CLI path used by
+diagnostics and formatting. Existing `arco.kdl.checkCommand` settings still
+work as a legacy fallback, but new configurations should use:
+
+```json
+{
+  "arco.kdl.command": "/Users/me/.local/bin/arco"
+}
+```
+
+See the [VS Code extension guide](../../tools/vscode-arco-kdl/README.md) for
+install, format-on-save, and troubleshooting details.
+
+---
+
+[Back to migration notes](README.md)

--- a/examples/capacity-expansion/input.kdl
+++ b/examples/capacity-expansion/input.kdl
@@ -1,10 +1,11 @@
 data assets_data source="data/all_assets.csv" {
-  map asset_id from="asset_name"
-
-  set asset_id alias="a"
+  map asset_id from=asset_name
+  set asset_id alias=a
   set candidate_assets {
     in asset_id
-    filter { is_candidate > 0 }
+    filter {
+      is_candidate > 0
+    }
   }
   param existing_capacity_mw {
     index asset_id
@@ -22,76 +23,77 @@ data assets_data source="data/all_assets.csv" {
     index asset_id
   }
 }
-
 data demand_data source="data/demand.csv" {
   set t
   param demand {
     index t
   }
 }
-
 data voll_data source="data/voll.csv" {
   set t
   param voll {
     index t
   }
 }
-
 model capacity_expansion {
-  set time alias="t"
-
+  set time alias=t
   control dispatch {
     index asset_id
     index time
   }
-
   control expansion {
     index asset_id
   }
-
   control unserved_energy {
     index time
   }
-
   expression investment_cost {
     sum(build_cost[asset] * expansion[asset] for asset in candidate_assets)
   }
-
   expression operating_cost {
     sum(variable_cost[asset] * dispatch[asset,t] for asset in asset_id for t in time)
   }
-
   expression penalty_cost {
     sum(voll[t] * unserved_energy[t] for t in time)
   }
-
   constraint dispatch_limit {
-    index asset { in asset_id }
-    index t { in time }
+    index asset {
+      in asset_id
+    }
+    index t {
+      in time
+    }
     expression {
-      dispatch[asset,t] <= existing_capacity_mw[asset] + expansion[asset]
+      dispatch[asset,t]
+        <= existing_capacity_mw[asset]
+        + expansion[asset]
     }
   }
-
   constraint candidate_build_limit {
-    index asset { in asset_id }
+    index asset {
+      in asset_id
+    }
     expression {
-      expansion[asset] <= max_build_mw[asset] * is_candidate[asset]
+      expansion[asset]
+        <= max_build_mw[asset] * is_candidate[asset]
     }
   }
-
   constraint balance {
-    index t { in time }
+    index t {
+      in time
+    }
     expression {
-      sum(dispatch[asset,t] for asset in asset_id) + unserved_energy[t] = demand[t]
+      sum(dispatch[asset,t] for asset in asset_id)
+        + unserved_energy[t]
+        = demand[t]
     }
   }
-
   minimize expansion_cost {
-    investment_cost + operating_cost + penalty_cost
+    investment_cost
+      + operating_cost
+      + penalty_cost
   }
 }
-
 scenario expansion_case {
   use capacity_expansion
 }

--- a/examples/dcopf-angle/input.kdl
+++ b/examples/dcopf-angle/input.kdl
@@ -2,120 +2,112 @@
 // Soroudi, Alireza. Power System Optimization Modeling in GAMS. Springer, 2017.
 // DOI: doi.org/10.1007/978-3-319-62350-4
 // Source: https://www.gams.com/latest/psoptlib_ml/libhtml/psoptlib_OPF3bus.html
-
 data bus_data source="data/buses.csv" {
-  map bus from="bus"
-
-  set bus alias="b"
-
-  param pd index="bus"
-  param is_slack index="bus"
+  map bus from=bus
+  set bus alias=b
+  param pd index=bus
+  param is_slack index=bus
 }
-
 data generator_data source="data/generators.csv" {
-  map generators from="generator"
-
-  set generators alias="g"
-
-  param b index="generators"
-  param pmin index="generators"
-  param pmax index="generators"
+  map generators from=generator
+  set generators alias=g
+  param b index=generators
+  param pmin index=generators
+  param pmax index=generators
 }
-
 data gen_bus_data source="data/gen_bus.csv" {
-  map generators from="generator"
-
+  map generators from=generator
   set bus
   set generators
-
   param connected {
     index bus
     index generators
   }
 }
-
 data line_data source="data/lines.csv" {
-  map lines from="line"
-
-  set lines alias="l"
-
-  param bij index="lines"
-  param limit_mw index="lines"
+  map lines from=line
+  set lines alias=l
+  param bij index=lines
+  param limit_mw index=lines
 }
-
 data incidence_data source="data/incidence.csv" {
-  map lines from="line"
-  map bus from="bus"
-
+  map lines from=line
+  map bus from=bus
   set lines
   set bus
-
   param incidence {
     index lines
     index bus
   }
 }
-
 model DCOPFAngle {
   control pg lower=0 {
     index generators
   }
-
   control delta lower=-3.1415926536 upper=3.1415926536 {
     index bus
   }
-
   control flow {
     index lines
   }
-
   constraint flow_definition {
-    index l { in lines }
+    index l {
+      in lines
+    }
     expression {
-      flow[l] = bij[l] * sum(incidence[l,b] * delta[b] for b in bus)
+      flow[l]
+        = bij[l] * sum(incidence[l,b] * delta[b] for b in bus)
     }
   }
-
   constraint nodal_balance {
-    index b { in bus }
+    index b {
+      in bus
+    }
     expression {
       sum(pg[g] for g in generators if connected[b,g] > 0)
-      - pd[b] / 100
-      = sum(incidence[l,b] * flow[l] for l in lines)
+        - pd[b] / 100
+        = sum(incidence[l,b] * flow[l] for l in lines)
     }
   }
-
   constraint generator_bounds {
-    index g { in generators }
+    index g {
+      in generators
+    }
     expression {
-      pmin[g] / 100 <= pg[g] <= pmax[g] / 100
+      pmin[g] / 100
+        <= pg[g]
+        <= pmax[g] / 100
     }
   }
-
   constraint line_bounds {
-    index l { in lines }
+    index l {
+      in lines
+    }
     expression {
-      -limit_mw[l] / 100 <= flow[l] <= limit_mw[l] / 100
+      -limit_mw[l] / 100
+        <= flow[l]
+        <= limit_mw[l] / 100
     }
   }
-
   constraint slack_angle {
-    index b { in bus }
-    if { is_slack[b] > 0 }
+    index b {
+      in bus
+    }
+    if {
+      is_slack[b] > 0
+    }
     expression {
-      delta[b] = 0
+      delta[b]
+        = 0
     }
   }
-
   expression GenerationCost {
     sum(pg[g] * b[g] * 100 for g in generators)
   }
-
   minimize OF {
     GenerationCost
   }
 }
-
 scenario DCOPFAngleCase {
   use DCOPFAngle
   report GenerationCost

--- a/examples/dcopf-ptdf/input.kdl
+++ b/examples/dcopf-ptdf/input.kdl
@@ -3,108 +3,92 @@
 // Soroudi, Alireza. Power System Optimization Modeling in GAMS. Springer, 2017.
 // DOI: doi.org/10.1007/978-3-319-62350-4
 // Source: https://www.gams.com/latest/psoptlib_ml/libhtml/psoptlib_OPF3bus.html
-
 data bus_data source="data/buses.csv" {
-  map bus from="bus"
-
-  set bus alias="b"
-
-  param pd index="bus"
-  param is_slack index="bus"
+  map bus from=bus
+  set bus alias=b
+  param pd index=bus
+  param is_slack index=bus
 }
-
 data generator_data source="data/generators.csv" {
-  map generators from="generator"
-
-  set generators alias="g"
-
-  param b index="generators"
-  param pmin index="generators"
-  param pmax index="generators"
+  map generators from=generator
+  set generators alias=g
+  param b index=generators
+  param pmin index=generators
+  param pmax index=generators
 }
-
 data gen_bus_data source="data/gen_bus.csv" {
-  map generators from="generator"
-
+  map generators from=generator
   set bus
   set generators
-
   param connected {
     index bus
     index generators
   }
 }
-
 data line_data source="data/lines.csv" {
-  map lines from="line"
-
-  set lines alias="l"
-
-  param limit_mw index="lines"
+  map lines from=line
+  set lines alias=l
+  param limit_mw index=lines
 }
-
 data ptdf_data source="data/ptdf.csv" {
-  map lines from="line"
-  map bus from="bus"
-
+  map lines from=line
+  map bus from=bus
   set lines
   set bus
-
   param ptdf {
     index lines
     index bus
   }
 }
-
 model DCOPFPTDF {
   control pg lower=0 {
     index generators
   }
-
   control flow {
     index lines
   }
-
   constraint system_balance {
     expression {
-      sum(pg[g] for g in generators) = sum(pd[b] / 100 for b in bus)
+      sum(pg[g] for g in generators)
+        = sum(pd[b] / 100 for b in bus)
     }
   }
-
   constraint flow_definition_ptdf {
-    index l { in lines }
+    index l {
+      in lines
+    }
     expression {
-      flow[l] = sum(
-        ptdf[l,b]
-        * (sum(pg[g] for g in generators if connected[b,g] > 0) - pd[b] / 100)
-        for b in bus
-      )
+      flow[l]
+        = sum( ptdf[l,b] * (sum(pg[g] for g in generators if connected[b,g] > 0) - pd[b] / 100) for b in bus )
     }
   }
-
   constraint generator_bounds {
-    index g { in generators }
+    index g {
+      in generators
+    }
     expression {
-      pmin[g] / 100 <= pg[g] <= pmax[g] / 100
+      pmin[g] / 100
+        <= pg[g]
+        <= pmax[g] / 100
     }
   }
-
   constraint line_bounds {
-    index l { in lines }
+    index l {
+      in lines
+    }
     expression {
-      -limit_mw[l] / 100 <= flow[l] <= limit_mw[l] / 100
+      -limit_mw[l] / 100
+        <= flow[l]
+        <= limit_mw[l] / 100
     }
   }
-
   expression GenerationCost {
     sum(pg[g] * b[g] * 100 for g in generators)
   }
-
   minimize OF {
     GenerationCost
   }
 }
-
 scenario DCOPFPTDFCase {
   use DCOPFPTDF
   report GenerationCost

--- a/examples/ded-ess-wind-qcp/input.kdl
+++ b/examples/ded-ess-wind-qcp/input.kdl
@@ -3,193 +3,228 @@
 // plus a wind-curtailment penalty. Solves with the IPOPT NLP backend.
 //   minimize  sum_t  VWC * p_wind_curtail[t]
 //           + sum_{g,t} a[g]*p[g,t]^2 + b[g]*p[g,t] + c[g]
-
 data gendata source="data/gendata.csv" {
-  map generators from="g"
-
-  set generators alias="g"
-
-  param a index="generators"
-  param b index="generators"
-  param c index="generators"
-  param d index="generators"
-  param e index="generators"
-  param f index="generators"
-  param p_min index="generators"
-  param p_max index="generators"
-  param ru index="generators"
-  param rd index="generators"
+  map generators from=g
+  set generators alias=g
+  param a index=generators
+  param b index=generators
+  param c index=generators
+  param d index=generators
+  param e index=generators
+  param f index=generators
+  param p_min index=generators
+  param p_max index=generators
+  param ru index=generators
+  param rd index=generators
 }
-
 data storage_data source="data/storage.csv" {
-  map storage from="asset"
-
-  set storage alias="s"
-
-  param power_mw index="storage"
-  param energy_mwh index="storage"
-  param charge_efficiency index="storage"
-  param discharge_efficiency index="storage"
-  param initial_soc_mwh index="storage"
-  param terminal_soc_mwh index="storage"
+  map storage from=asset
+  set storage alias=s
+  param power_mw index=storage
+  param energy_mwh index=storage
+  param charge_efficiency index=storage
+  param discharge_efficiency index=storage
+  param initial_soc_mwh index=storage
+  param terminal_soc_mwh index=storage
 }
-
 data timeseries source="data/timeseries.csv" {
   set t
-
-  param lambda index="t"
-  param load index="t"
-  param wind index="t"
+  param lambda index=t
+  param load index=t
+  param wind index=t
 }
-
 model DEDESSWindLinearized {
-  set time alias="t"
-
+  set time alias=t
   control p {
     index generators
     index time
   }
-
   control soc {
     index storage
     index time
   }
-
   control p_charge lower=0 {
     index storage
     index time
   }
-
   control p_discharge lower=0 {
     index storage
     index time
   }
-
   control p_wind lower=0 {
     index time
   }
-
   control p_wind_curtail lower=0 {
     index time
   }
-
   expression ThermalCost {
-    sum(
-      a[g] * p[g,t] * p[g,t] + b[g] * p[g,t] + c[g]
-      for g in generators for t in time
-    )
+    sum( a[g] * p[g,t] * p[g,t] + b[g] * p[g,t] + c[g] for g in generators for t in time )
   }
-
   expression WindCurtailmentPenalty {
     sum(50 * p_wind_curtail[t] for t in time)
   }
-
   expression TotalCost {
-    ThermalCost + WindCurtailmentPenalty
+    ThermalCost
+      + WindCurtailmentPenalty
   }
-
   constraint thermal_output_bounds {
-    index g { in generators }
-    index t { in time }
+    index g {
+      in generators
+    }
+    index t {
+      in time
+    }
     expression {
-      p_min[g] <= p[g,t] <= p_max[g]
+      p_min[g]
+        <= p[g,t]
+        <= p_max[g]
     }
   }
-
   constraint ramp_up {
-    index g { in generators }
-    index t { in time }
-    if { t > 1 }
+    index g {
+      in generators
+    }
+    index t {
+      in time
+    }
+    if {
+      t > 1
+    }
     expression {
-      p[g,t] - p[g,t-1] <= ru[g]
+      p[g,t]
+        - p[g,t-1]
+        <= ru[g]
     }
   }
-
   constraint ramp_down {
-    index g { in generators }
-    index t { in time }
-    if { t > 1 }
+    index g {
+      in generators
+    }
+    index t {
+      in time
+    }
+    if {
+      t > 1
+    }
     expression {
-      p[g,t-1] - p[g,t] <= rd[g]
+      p[g,t-1]
+        - p[g,t]
+        <= rd[g]
     }
   }
-
   constraint soc_initial {
-    index s { in storage }
+    index s {
+      in storage
+    }
     expression {
-      soc[s,1] = initial_soc_mwh[s] + charge_efficiency[s] * p_charge[s,1] - p_discharge[s,1] / discharge_efficiency[s]
+      soc[s,1]
+        = initial_soc_mwh[s]
+        + charge_efficiency[s] * p_charge[s,1]
+        - p_discharge[s,1] / discharge_efficiency[s]
     }
   }
-
   constraint soc_balance {
-    index s { in storage }
-    index t { in time }
-    if { t > 1 }
+    index s {
+      in storage
+    }
+    index t {
+      in time
+    }
+    if {
+      t > 1
+    }
     expression {
-      soc[s,t] = soc[s,t-1] + charge_efficiency[s] * p_charge[s,t] - p_discharge[s,t] / discharge_efficiency[s]
+      soc[s,t]
+        = soc[s,t-1]
+        + charge_efficiency[s] * p_charge[s,t]
+        - p_discharge[s,t] / discharge_efficiency[s]
     }
   }
-
   constraint soc_bounds {
-    index s { in storage }
-    index t { in time }
+    index s {
+      in storage
+    }
+    index t {
+      in time
+    }
     expression {
-      0.2 * energy_mwh[s] <= soc[s,t] <= energy_mwh[s]
+      0.2 * energy_mwh[s]
+        <= soc[s,t]
+        <= energy_mwh[s]
     }
   }
-
   constraint soc_terminal {
-    index s { in storage }
-    index t { in time }
-    if { t == 24 }
+    index s {
+      in storage
+    }
+    index t {
+      in time
+    }
+    if {
+      t
+        == 24
+    }
     expression {
-      soc[s,t] = terminal_soc_mwh[s]
+      soc[s,t]
+        = terminal_soc_mwh[s]
     }
   }
-
   constraint charge_limit {
-    index s { in storage }
-    index t { in time }
+    index s {
+      in storage
+    }
+    index t {
+      in time
+    }
     expression {
-      p_charge[s,t] <= power_mw[s]
+      p_charge[s,t]
+        <= power_mw[s]
     }
   }
-
   constraint discharge_limit {
-    index s { in storage }
-    index t { in time }
+    index s {
+      in storage
+    }
+    index t {
+      in time
+    }
     expression {
-      p_discharge[s,t] <= power_mw[s]
+      p_discharge[s,t]
+        <= power_mw[s]
     }
   }
-
   constraint wind_split {
-    index t { in time }
+    index t {
+      in time
+    }
     expression {
-      p_wind[t] + p_wind_curtail[t] = wind[t]
+      p_wind[t]
+        + p_wind_curtail[t]
+        = wind[t]
     }
   }
-
   constraint balance {
-    index t { in time }
+    index t {
+      in time
+    }
     expression {
-      p_wind[t] + sum(p[g,t] for g in generators) + sum(p_discharge[s,t] for s in storage) >= load[t] + sum(p_charge[s,t] for s in storage)
+      p_wind[t]
+        + sum(p[g,t] for g in generators)
+        + sum(p_discharge[s,t] for s in storage)
+        >= load[t]
+        + sum(p_charge[s,t] for s in storage)
     }
   }
-
   minimize OF {
     TotalCost
   }
 }
-
 scenario DEDESSWindLinearizedDay {
   use DEDESSWindLinearized
-
   report OF
   report TotalCost
   report ThermalCost
   report WindCurtailmentPenalty
-
   report p
   report soc
   report p_charge

--- a/examples/dense-lp/input.kdl
+++ b/examples/dense-lp/input.kdl
@@ -1,50 +1,53 @@
 data dense_lp_rows source="data/indices.csv" {
-  map rows from="index"
-
-  set rows alias="row"
-  param row_value from="value" {
+  map rows from=index
+  set rows alias=row
+  param row_value from=value {
     index rows
   }
 }
-
 data dense_lp_cols source="data/indices.csv" {
-  map cols from="index"
-
-  set cols alias="col"
+  map cols from=index
+  set cols alias=col
 }
-
 model dense_lp {
   control x lower=-1e20 upper=1e20 {
     index rows
     index cols
   }
-
   control y lower=-1e20 upper=1e20 {
     index rows
     index cols
   }
-
   constraint difference_floor {
-    index row { in rows }
-    index col { in cols }
+    index row {
+      in rows
+    }
+    index col {
+      in cols
+    }
     expression {
-      x[row,col] - y[row,col] >= row_value[row]
+      x[row,col]
+        - y[row,col]
+        >= row_value[row]
     }
   }
-
   constraint balance_floor {
-    index row { in rows }
-    index col { in cols }
+    index row {
+      in rows
+    }
+    index col {
+      in cols
+    }
     expression {
-      x[row,col] + y[row,col] >= 0
+      x[row,col]
+        + y[row,col]
+        >= 0
     }
   }
-
   minimize total_cost {
     sum((2 * x[row,col]) + y[row,col] for row in rows for col in cols)
   }
 }
-
 scenario dense_lp_case {
   use dense_lp
 }

--- a/examples/generator-allocation/input.kdl
+++ b/examples/generator-allocation/input.kdl
@@ -1,43 +1,43 @@
 data units source="data/units.csv" {
-  map asset_id from="asset"
-
-  set asset_id alias="a"
-  param variable_cost index="asset_id"
+  map asset_id from=asset
+  set asset_id alias=a
+  param variable_cost index=asset_id
 }
-
 data demand_data source="data/demand.csv" {
   set t
-  param demand index="t"
+  param demand index=t
 }
-
 model generator_allocation {
-  set time alias="t"
-
+  set time alias=t
   control dispatch lower=0 {
     index asset_id
     index time
   }
-
   constraint capacity_limit {
-    index asset { in asset_id }
-    index t { in time }
+    index asset {
+      in asset_id
+    }
+    index t {
+      in time
+    }
     expression {
-      dispatch[asset,t] <= 10
+      dispatch[asset,t]
+        <= 10
     }
   }
-
   constraint balance {
-    index t { in time }
+    index t {
+      in time
+    }
     expression {
-      sum(dispatch[asset,t] for asset in asset_id) = demand[t]
+      sum(dispatch[asset,t] for asset in asset_id)
+        = demand[t]
     }
   }
-
   minimize total_cost {
     sum(variable_cost[asset] * dispatch[asset,t] for asset in asset_id for t in time)
   }
 }
-
 scenario generator_allocationDay {
   use generator_allocation
 }

--- a/examples/multi-period-optimal-power-flow/ac-opf-24bus-wind-load-shedding/input.kdl
+++ b/examples/multi-period-optimal-power-flow/ac-opf-24bus-wind-load-shedding/input.kdl
@@ -1,493 +1,539 @@
 // Multi-period AC-OPF (NLP) for IEEE 24-bus with wind, curtailment, and load shedding.
 // Translated from Soroudi Gcode6.7 structure into Arco KDL.
-
 data bus_data source="data/buses.csv" {
-  map bus from="bus"
-
-  set bus alias="i"
-
-  param pd_mw index="bus"
-  param qd_mvar index="bus"
-  param is_slack index="bus"
-  param wcap_mw index="bus"
+  map bus from=bus
+  set bus alias=i
+  param pd_mw index=bus
+  param qd_mvar index=bus
+  param is_slack index=bus
+  param wcap_mw index=bus
 }
-
 data generator_data source="data/generators.csv" {
-  map generators from="generator"
-
-  set generators alias="g"
-
-  param pmax index="generators"
-  param pmin index="generators"
-  param b index="generators"
-  param qmax index="generators"
-  param qmin index="generators"
-  param vg index="generators"
-  param ru index="generators"
-  param rd index="generators"
+  map generators from=generator
+  set generators alias=g
+  param pmax index=generators
+  param pmin index=generators
+  param b index=generators
+  param qmax index=generators
+  param qmin index=generators
+  param vg index=generators
+  param ru index=generators
+  param rd index=generators
 }
-
 data gen_bus_data source="data/gen_bus.csv" {
-  map generators from="generator"
-
+  map generators from=generator
   set bus
   set generators
-
   param connected {
     index bus
     index generators
   }
 }
-
 data line_data source="data/lines.csv" {
-  map lines from="line"
-
-  set lines alias="l"
-
-  param r index="lines"
-  param x index="lines"
-  param b_line from="b" index="lines"
-  param limit_mw index="lines"
+  map lines from=line
+  set lines alias=l
+  param r index=lines
+  param x index=lines
+  param b_line from=b index=lines
+  param limit_mw index=lines
 }
-
 data line_endpoint_data source="data/line_endpoints.csv" {
-  map lines from="line"
-  map bus from="bus"
-
+  map lines from=line
+  map bus from=bus
   set lines
   set bus
-
   param from_w {
     index lines
     index bus
   }
-
   param to_w {
     index lines
     index bus
   }
 }
-
 data temporal_sets source="data/temporal_sets.csv" {
   set t
-  set taf { in t }
-  param t_next from="taf" index="t"
+  set taf {
+    in t
+  }
+  param t_next from=taf index=t
 }
-
 data profile_data source="data/profiles.csv" {
-  param wind_cf from="w" index="t"
-  param demand_scale from="d" index="t"
+  param wind_cf from=w index=t
+  param demand_scale from=d index=t
 }
-
 model MultiPeriod24BusACOPF {
   param sbase 100
   param voll 10000
   param volw 50
-
   control pg {
     index g
     index t
     bounds {
-      lower { pmin[g] / sbase }
-      upper { pmax[g] / sbase }
+      lower {
+        pmin[g] / sbase
+      }
+      upper {
+        pmax[g] / sbase
+      }
     }
   }
-
   control qg {
     index g
     index t
     bounds {
-      lower { qmin[g] / sbase }
-      upper { qmax[g] / sbase }
+      lower {
+        qmin[g] / sbase
+      }
+      upper {
+        qmax[g] / sbase
+      }
     }
   }
-
   control v {
     index i
     index t
     bounds {
-      lower { 0.9 }
-      upper { 1.1 }
+      lower {
+        0.9
+      }
+      upper {
+        1.1
+      }
     }
   }
-
   control va {
     index i
     index t
     bounds {
-      lower { -1.5707963268 * (1 - is_slack[i]) }
-      upper {  1.5707963268 * (1 - is_slack[i]) }
+      lower {
+        -1.5707963268 * (1 - is_slack[i])
+      }
+      upper {
+        1.5707963268 * (1 - is_slack[i])
+      }
     }
   }
-
   control pw {
     index i
     index t
     bounds {
-      lower { 0 }
-      upper { wind_cf[t] * wcap_mw[i] / sbase }
+      lower {
+        0
+      }
+      upper {
+        wind_cf[t] * wcap_mw[i] / sbase
+      }
     }
   }
-
   control pc {
     index i
     index t
     bounds {
-      lower { 0 }
-      upper { wind_cf[t] * wcap_mw[i] / sbase }
+      lower {
+        0
+      }
+      upper {
+        wind_cf[t] * wcap_mw[i] / sbase
+      }
     }
   }
-
   control lsh {
     index i
     index t
     bounds {
-      lower { 0 }
-      upper { demand_scale[t] * pd_mw[i] / sbase }
+      lower {
+        0
+      }
+      upper {
+        demand_scale[t] * pd_mw[i] / sbase
+      }
     }
   }
-
   // Directed arc flows Pij(i,j,t), Qij(i,j,t) as in GAMS.
   // For non-connected pairs bounds collapse to 0, effectively fixing them.
+
   control pij {
-    index i { in bus }
-    index j { in bus }
-    index tt { in t }
+    index i {
+      in bus
+    }
+    index j {
+      in bus
+    }
+    index tt {
+      in t
+    }
     bounds {
       lower {
-        -sum(
-          (from_w[l,i] * to_w[l,j] + from_w[l,j] * to_w[l,i]) * limit_mw[l]
-          for l in lines
-        ) / sbase
+        -sum( (from_w[l,i] * to_w[l,j] + from_w[l,j] * to_w[l,i]) * limit_mw[l] for l in lines ) / sbase
       }
       upper {
-        sum(
-          (from_w[l,i] * to_w[l,j] + from_w[l,j] * to_w[l,i]) * limit_mw[l]
-          for l in lines
-        ) / sbase
+        sum( (from_w[l,i] * to_w[l,j] + from_w[l,j] * to_w[l,i]) * limit_mw[l] for l in lines ) / sbase
       }
     }
   }
-
   control qij {
-    index i { in bus }
-    index j { in bus }
-    index tt { in t }
+    index i {
+      in bus
+    }
+    index j {
+      in bus
+    }
+    index tt {
+      in t
+    }
     bounds {
       lower {
-        -sum(
-          (from_w[l,i] * to_w[l,j] + from_w[l,j] * to_w[l,i]) * limit_mw[l]
-          for l in lines
-        ) / sbase
+        -sum( (from_w[l,i] * to_w[l,j] + from_w[l,j] * to_w[l,i]) * limit_mw[l] for l in lines ) / sbase
       }
       upper {
-        sum(
-          (from_w[l,i] * to_w[l,j] + from_w[l,j] * to_w[l,i]) * limit_mw[l]
-          for l in lines
-        ) / sbase
+        sum( (from_w[l,i] * to_w[l,j] + from_w[l,j] * to_w[l,i]) * limit_mw[l] for l in lines ) / sbase
       }
     }
   }
-
   // Eq1 / Eq2: AC branch flows over connected bus pairs cx(i,j).
+
   constraint active_flow_definition {
-    index i { in bus }
-    index j { in bus }
-    index tt { in t }
+    index i {
+      in bus
+    }
+    index j {
+      in bus
+    }
+    index tt {
+      in t
+    }
     if {
-      sum(from_w[l,i] * to_w[l,j] + from_w[l,j] * to_w[l,i] for l in lines) == 1
+      sum(from_w[l,i] * to_w[l,j] + from_w[l,j] * to_w[l,i] for l in lines)
+        == 1
     }
     expression {
       pij[i,j,tt]
-      = (
-        v[i,tt] * v[i,tt]
-          * cos(sum(
-            (from_w[l,i] * to_w[l,j] + from_w[l,j] * to_w[l,i]) * atan(x[l] / r[l])
-            for l in lines
-          ))
-        - v[i,tt] * v[j,tt]
-          * cos(
-            va[i,tt] - va[j,tt]
-            + sum(
-              (from_w[l,i] * to_w[l,j] + from_w[l,j] * to_w[l,i]) * atan(x[l] / r[l])
-              for l in lines
-            )
-          )
-      ) / sum(
-        (from_w[l,i] * to_w[l,j] + from_w[l,j] * to_w[l,i])
-          * sqrt(x[l] * x[l] + r[l] * r[l])
-        for l in lines
-      )
+        = ( v[i,tt] * v[i,tt] * cos(sum( (from_w[l,i] * to_w[l,j] + from_w[l,j] * to_w[l,i]) * atan(x[l] / r[l]) for l in lines )) - v[i,tt] * v[j,tt] * cos( va[i,tt] - va[j,tt] + sum( (from_w[l,i] * to_w[l,j] + from_w[l,j] * to_w[l,i]) * atan(x[l] / r[l]) for l in lines ) ) ) / sum( (from_w[l,i] * to_w[l,j] + from_w[l,j] * to_w[l,i]) * sqrt(x[l] * x[l] + r[l] * r[l]) for l in lines )
     }
   }
-
   constraint reactive_flow_definition {
-    index i { in bus }
-    index j { in bus }
-    index tt { in t }
+    index i {
+      in bus
+    }
+    index j {
+      in bus
+    }
+    index tt {
+      in t
+    }
     if {
-      sum(from_w[l,i] * to_w[l,j] + from_w[l,j] * to_w[l,i] for l in lines) == 1
+      sum(from_w[l,i] * to_w[l,j] + from_w[l,j] * to_w[l,i] for l in lines)
+        == 1
     }
     expression {
       qij[i,j,tt]
-      = (
-        v[i,tt] * v[i,tt]
-          * sin(sum(
-            (from_w[l,i] * to_w[l,j] + from_w[l,j] * to_w[l,i]) * atan(x[l] / r[l])
-            for l in lines
-          ))
-        - v[i,tt] * v[j,tt]
-          * sin(
-            va[i,tt] - va[j,tt]
-            + sum(
-              (from_w[l,i] * to_w[l,j] + from_w[l,j] * to_w[l,i]) * atan(x[l] / r[l])
-              for l in lines
-            )
-          )
-      ) / sum(
-        (from_w[l,i] * to_w[l,j] + from_w[l,j] * to_w[l,i])
-          * sqrt(x[l] * x[l] + r[l] * r[l])
-        for l in lines
-      )
-      - (
-          sum(
-            (from_w[l,i] * to_w[l,j] + from_w[l,j] * to_w[l,i]) * b_line[l]
-            for l in lines
-          )
-        ) * v[i,tt] * v[i,tt] / 2
+        = ( v[i,tt] * v[i,tt] * sin(sum( (from_w[l,i] * to_w[l,j] + from_w[l,j] * to_w[l,i]) * atan(x[l] / r[l]) for l in lines )) - v[i,tt] * v[j,tt] * sin( va[i,tt] - va[j,tt] + sum( (from_w[l,i] * to_w[l,j] + from_w[l,j] * to_w[l,i]) * atan(x[l] / r[l]) for l in lines ) ) ) / sum( (from_w[l,i] * to_w[l,j] + from_w[l,j] * to_w[l,i]) * sqrt(x[l] * x[l] + r[l] * r[l]) for l in lines )
+        - ( sum( (from_w[l,i] * to_w[l,j] + from_w[l,j] * to_w[l,i]) * b_line[l] for l in lines ) ) * v[i,tt] * v[i,tt] / 2
     }
   }
-
   // Eq3 active balance with generation, wind, shedding.
+
   constraint power_balance {
-    index i { in bus }
-    index tt { in t }
+    index i {
+      in bus
+    }
+    index tt {
+      in t
+    }
     expression {
       sum(connected[i,g] * pg[g,tt] for g in generators)
-      + pw[i,tt]
-      + lsh[i,tt]
-      - demand_scale[tt] * pd_mw[i] / sbase
-      = sum(
-          pij[i,j,tt]
-          for j in bus
-          if sum(from_w[l,j] * to_w[l,i] + from_w[l,i] * to_w[l,j] for l in lines) == 1
-        )
+        + pw[i,tt]
+        + lsh[i,tt]
+        - demand_scale[tt] * pd_mw[i] / sbase
+        = sum( pij[i,j,tt] for j in bus if sum(from_w[l,j] * to_w[l,i] + from_w[l,i] * to_w[l,j] for l in lines) == 1 )
     }
   }
-
   // Eq4 reactive balance.
+
   constraint reactive_power_balance {
-    index i { in bus }
-    index tt { in t }
+    index i {
+      in bus
+    }
+    index tt {
+      in t
+    }
     expression {
       sum(connected[i,g] * qg[g,tt] for g in generators)
-      - demand_scale[tt] * qd_mvar[i] / sbase
-      = sum(
-          qij[i,j,tt]
-          for j in bus
-          if sum(from_w[l,j] * to_w[l,i] + from_w[l,i] * to_w[l,j] for l in lines) == 1
-        )
+        - demand_scale[tt] * qd_mvar[i] / sbase
+        = sum( qij[i,j,tt] for j in bus if sum(from_w[l,j] * to_w[l,i] + from_w[l,i] * to_w[l,j] for l in lines) == 1 )
     }
   }
-
   // Eq6 / Eq7 ramping with temporal successor map.
+
   constraint ramp_up {
-    index g { in generators }
-    index tp { in t }
-    index tt { in t }
-    if { t_next[tp] == tt }
+    index g {
+      in generators
+    }
+    index tp {
+      in t
+    }
+    index tt {
+      in t
+    }
+    if {
+      t_next[tp]
+        == tt
+    }
     expression {
-      pg[g,tt] - pg[g,tp] <= ru[g] / sbase
+      pg[g,tt]
+        - pg[g,tp]
+        <= ru[g] / sbase
     }
   }
-
   constraint ramp_down {
-    index g { in generators }
-    index tp { in t }
-    index tt { in t }
-    if { t_next[tp] == tt }
+    index g {
+      in generators
+    }
+    index tp {
+      in t
+    }
+    index tt {
+      in t
+    }
+    if {
+      t_next[tp]
+        == tt
+    }
     expression {
-      pg[g,tp] - pg[g,tt] <= rd[g] / sbase
+      pg[g,tp]
+        - pg[g,tt]
+        <= rd[g] / sbase
     }
   }
-
   // Eq8 curtailment definition.
+
   constraint curtailment_definition {
-    index i { in bus }
-    index tt { in t }
+    index i {
+      in bus
+    }
+    index tt {
+      in t
+    }
     expression {
-      pc[i,tt] = wind_cf[tt] * wcap_mw[i] / sbase - pw[i,tt]
+      pc[i,tt]
+        = wind_cf[tt] * wcap_mw[i] / sbase
+        - pw[i,tt]
     }
   }
-
   // Expression-based control bounds are enforced here explicitly for parity.
+
   constraint pg_lower_bound {
-    index g { in generators }
-    index tt { in t }
+    index g {
+      in generators
+    }
+    index tt {
+      in t
+    }
     expression {
-      pg[g,tt] >= pmin[g] / sbase
+      pg[g,tt]
+        >= pmin[g] / sbase
     }
   }
-
   constraint pg_upper_bound {
-    index g { in generators }
-    index tt { in t }
+    index g {
+      in generators
+    }
+    index tt {
+      in t
+    }
     expression {
-      pg[g,tt] <= pmax[g] / sbase
+      pg[g,tt]
+        <= pmax[g] / sbase
     }
   }
-
   constraint qg_lower_bound {
-    index g { in generators }
-    index tt { in t }
+    index g {
+      in generators
+    }
+    index tt {
+      in t
+    }
     expression {
-      qg[g,tt] >= qmin[g] / sbase
+      qg[g,tt]
+        >= qmin[g] / sbase
     }
   }
-
   constraint qg_upper_bound {
-    index g { in generators }
-    index tt { in t }
+    index g {
+      in generators
+    }
+    index tt {
+      in t
+    }
     expression {
-      qg[g,tt] <= qmax[g] / sbase
+      qg[g,tt]
+        <= qmax[g] / sbase
     }
   }
-
   constraint va_lower_bound {
-    index i { in bus }
-    index tt { in t }
+    index i {
+      in bus
+    }
+    index tt {
+      in t
+    }
     expression {
-      va[i,tt] >= -1.5707963268 * (1 - is_slack[i])
+      va[i,tt]
+        >= -1.5707963268 * (1 - is_slack[i])
     }
   }
-
   constraint va_upper_bound {
-    index i { in bus }
-    index tt { in t }
+    index i {
+      in bus
+    }
+    index tt {
+      in t
+    }
     expression {
-      va[i,tt] <= 1.5707963268 * (1 - is_slack[i])
+      va[i,tt]
+        <= 1.5707963268 * (1 - is_slack[i])
     }
   }
-
   constraint pij_lower_bound {
-    index i { in bus }
-    index j { in bus }
-    index tt { in t }
+    index i {
+      in bus
+    }
+    index j {
+      in bus
+    }
+    index tt {
+      in t
+    }
     if {
-      sum(from_w[l,i] * to_w[l,j] + from_w[l,j] * to_w[l,i] for l in lines) == 1
+      sum(from_w[l,i] * to_w[l,j] + from_w[l,j] * to_w[l,i] for l in lines)
+        == 1
     }
     expression {
       pij[i,j,tt]
-      >= -sum(
-           (from_w[l,i] * to_w[l,j] + from_w[l,j] * to_w[l,i]) * limit_mw[l]
-           for l in lines
-         ) / sbase
+        >= -sum( (from_w[l,i] * to_w[l,j] + from_w[l,j] * to_w[l,i]) * limit_mw[l] for l in lines ) / sbase
     }
   }
-
   constraint pij_upper_bound {
-    index i { in bus }
-    index j { in bus }
-    index tt { in t }
+    index i {
+      in bus
+    }
+    index j {
+      in bus
+    }
+    index tt {
+      in t
+    }
     if {
-      sum(from_w[l,i] * to_w[l,j] + from_w[l,j] * to_w[l,i] for l in lines) == 1
+      sum(from_w[l,i] * to_w[l,j] + from_w[l,j] * to_w[l,i] for l in lines)
+        == 1
     }
     expression {
       pij[i,j,tt]
-      <= sum(
-           (from_w[l,i] * to_w[l,j] + from_w[l,j] * to_w[l,i]) * limit_mw[l]
-           for l in lines
-         ) / sbase
+        <= sum( (from_w[l,i] * to_w[l,j] + from_w[l,j] * to_w[l,i]) * limit_mw[l] for l in lines ) / sbase
     }
   }
-
   constraint qij_lower_bound {
-    index i { in bus }
-    index j { in bus }
-    index tt { in t }
+    index i {
+      in bus
+    }
+    index j {
+      in bus
+    }
+    index tt {
+      in t
+    }
     if {
-      sum(from_w[l,i] * to_w[l,j] + from_w[l,j] * to_w[l,i] for l in lines) == 1
+      sum(from_w[l,i] * to_w[l,j] + from_w[l,j] * to_w[l,i] for l in lines)
+        == 1
     }
     expression {
       qij[i,j,tt]
-      >= -sum(
-           (from_w[l,i] * to_w[l,j] + from_w[l,j] * to_w[l,i]) * limit_mw[l]
-           for l in lines
-         ) / sbase
+        >= -sum( (from_w[l,i] * to_w[l,j] + from_w[l,j] * to_w[l,i]) * limit_mw[l] for l in lines ) / sbase
     }
   }
-
   constraint qij_upper_bound {
-    index i { in bus }
-    index j { in bus }
-    index tt { in t }
+    index i {
+      in bus
+    }
+    index j {
+      in bus
+    }
+    index tt {
+      in t
+    }
     if {
-      sum(from_w[l,i] * to_w[l,j] + from_w[l,j] * to_w[l,i] for l in lines) == 1
+      sum(from_w[l,i] * to_w[l,j] + from_w[l,j] * to_w[l,i] for l in lines)
+        == 1
     }
     expression {
       qij[i,j,tt]
-      <= sum(
-           (from_w[l,i] * to_w[l,j] + from_w[l,j] * to_w[l,i]) * limit_mw[l]
-           for l in lines
-         ) / sbase
+        <= sum( (from_w[l,i] * to_w[l,j] + from_w[l,j] * to_w[l,i]) * limit_mw[l] for l in lines ) / sbase
     }
   }
-
   constraint wind_upper {
-    index i { in bus }
-    index tt { in t }
+    index i {
+      in bus
+    }
+    index tt {
+      in t
+    }
     expression {
-      pw[i,tt] <= wind_cf[tt] * wcap_mw[i] / sbase
+      pw[i,tt]
+        <= wind_cf[tt] * wcap_mw[i] / sbase
     }
   }
-
   constraint curtailment_upper {
-    index i { in bus }
-    index tt { in t }
+    index i {
+      in bus
+    }
+    index tt {
+      in t
+    }
     expression {
-      pc[i,tt] <= wind_cf[tt] * wcap_mw[i] / sbase
+      pc[i,tt]
+        <= wind_cf[tt] * wcap_mw[i] / sbase
     }
   }
-
   constraint load_shedding_upper {
-    index i { in bus }
-    index tt { in t }
+    index i {
+      in bus
+    }
+    index tt {
+      in t
+    }
     expression {
-      lsh[i,tt] <= demand_scale[tt] * pd_mw[i] / sbase
+      lsh[i,tt]
+        <= demand_scale[tt] * pd_mw[i] / sbase
     }
   }
-
   // Objective equivalent to GAMS eq5.
+
   expression GenerationCost {
     sum(pg[g,tt] * b[g] * sbase for g in generators for tt in t)
   }
-
   expression SheddingPenalty {
     sum(voll * lsh[i,tt] * sbase for i in bus for tt in t)
   }
-
   expression CurtailmentPenalty {
     sum(volw * pc[i,tt] * sbase for i in bus for tt in t)
   }
-
   expression TotalCost {
-    GenerationCost + SheddingPenalty + CurtailmentPenalty
+    GenerationCost
+      + SheddingPenalty
+      + CurtailmentPenalty
   }
-
   minimize OF {
     TotalCost
   }
 }
-
 scenario MultiPeriod24BusACOPFCase {
   use MultiPeriod24BusACOPF
-
   report OF
   report TotalCost
   report GenerationCost
   report SheddingPenalty
   report CurtailmentPenalty
-
   report v
   report va
   report pg
@@ -497,7 +543,6 @@ scenario MultiPeriod24BusACOPFCase {
   report lsh
   report pij
   report qij
-
   report dual power_balance
   report dual reactive_power_balance
 }

--- a/examples/multi-period-optimal-power-flow/dc-opf-24bus-wind-load-shedding/input.kdl
+++ b/examples/multi-period-optimal-power-flow/dc-opf-24bus-wind-load-shedding/input.kdl
@@ -1,318 +1,432 @@
 // Multi-period DC-OPF (LP) for IEEE 24-bus with wind, curtailment, and load shedding.
 // Translated from Soroudi Gcode6.6 structure into Arco KDL.
-
 data bus_data source="data/buses.csv" {
-  map bus from="bus"
-
-  set bus alias="i"
-
-  param pd_mw index="bus"
-  param is_slack index="bus"
-  param wcap_mw index="bus"
+  map bus from=bus
+  set bus alias=i
+  param pd_mw index=bus
+  param is_slack index=bus
+  param wcap_mw index=bus
 }
-
 data generator_data source="data/generators.csv" {
-  map generators from="generator"
-
-  set generators alias="g"
-
-  param pmax index="generators"
-  param pmin index="generators"
-  param b index="generators"
-  param ru index="generators"
-  param rd index="generators"
+  map generators from=generator
+  set generators alias=g
+  param pmax index=generators
+  param pmin index=generators
+  param b index=generators
+  param ru index=generators
+  param rd index=generators
 }
-
 data gen_bus_data source="data/gen_bus.csv" {
-  map generators from="generator"
-
+  map generators from=generator
   set bus
   set generators
-
   param connected {
     index bus
     index generators
   }
 }
-
 data line_data source="data/lines.csv" {
-  map lines from="line"
-
-  set lines alias="l"
-
-  param x index="lines"
-  param bij index="lines"
-  param limit_mw index="lines"
+  map lines from=line
+  set lines alias=l
+  param x index=lines
+  param bij index=lines
+  param limit_mw index=lines
 }
-
 data line_endpoint_data source="data/line_endpoints.csv" {
-  map lines from="line"
-  map bus from="bus"
-
+  map lines from=line
+  map bus from=bus
   set lines
   set bus
-
   param from_w {
     index lines
     index bus
   }
-
   param to_w {
     index lines
     index bus
   }
 }
-
 data temporal_sets source="data/temporal_sets.csv" {
   set t
-  set taf { in t }
-  param t_next from="taf" index="t"
+  set taf {
+    in t
+  }
+  param t_next from=taf index=t
 }
-
 data profile_data source="data/profiles.csv" {
-  param wind_cf from="w" index="t"
-  param demand_scale from="d" index="t"
+  param wind_cf from=w index=t
+  param demand_scale from=d index=t
 }
-
 model MultiPeriod24BusDCOPF {
   param sbase 100
   param voll 10000
   param volw 50
-
   control pg {
     index g
     index t
     bounds {
-      lower { pmin[g] / sbase }
-      upper { pmax[g] / sbase }
+      lower {
+        pmin[g] / sbase
+      }
+      upper {
+        pmax[g] / sbase
+      }
     }
   }
-
   // Voltage angle. Slack bus enforced via explicit constraint below.
+
   control delta {
     index i
     index t
     bounds {
-      lower { -1.5707963268 }
-      upper {  1.5707963268 }
+      lower {
+        -1.5707963268
+      }
+      upper {
+        1.5707963268
+      }
     }
   }
-
   control pw {
     index i
     index t
     bounds {
-      lower { 0 }
-      upper { wind_cf[t] * wcap_mw[i] / sbase }
+      lower {
+        0
+      }
+      upper {
+        wind_cf[t] * wcap_mw[i] / sbase
+      }
     }
   }
-
   control pc {
     index i
     index t
     bounds {
-      lower { 0 }
-      upper { wind_cf[t] * wcap_mw[i] / sbase }
+      lower {
+        0
+      }
+      upper {
+        wind_cf[t] * wcap_mw[i] / sbase
+      }
     }
   }
-
   control lsh {
     index i
     index t
     bounds {
-      lower { 0 }
-      upper { demand_scale[t] * pd_mw[i] / sbase }
+      lower {
+        0
+      }
+      upper {
+        demand_scale[t] * pd_mw[i] / sbase
+      }
     }
   }
-
   // Per-line directed flow, bounded by thermal limits.
+
   control flow {
     index l
     index t
     bounds {
-      lower { -limit_mw[l] / sbase }
-      upper {  limit_mw[l] / sbase }
+      lower {
+        -limit_mw[l] / sbase
+      }
+      upper {
+        limit_mw[l] / sbase
+      }
     }
   }
-
   // const1 (DC): flow[l,t] = bij[l] * (delta[from,t] - delta[to,t]),  bij = 1/x.
   // The signed bus incidence is encoded via (from_w - to_w).
+
   constraint flow_definition {
-    index l { in lines }
-    index tt { in t }
+    index l {
+      in lines
+    }
+    index tt {
+      in t
+    }
     expression {
-      flow[l,tt] = bij[l] * sum((from_w[l,i] - to_w[l,i]) * delta[i,tt] for i in bus)
+      flow[l,tt]
+        = bij[l] * sum((from_w[l,i] - to_w[l,i]) * delta[i,tt] for i in bus)
     }
   }
-
   // const2: nodal active power balance.
   // Net injection at bus i = sum of flows leaving (from_w=1) minus arriving (to_w=1).
+
   constraint power_balance {
-    index i { in bus }
-    index tt { in t }
+    index i {
+      in bus
+    }
+    index tt {
+      in t
+    }
     expression {
       lsh[i,tt]
-      + pw[i,tt]
-      + sum(connected[i,g] * pg[g,tt] for g in generators)
-      - demand_scale[tt] * pd_mw[i] / sbase
-      = sum((from_w[l,i] - to_w[l,i]) * flow[l,tt] for l in lines)
+        + pw[i,tt]
+        + sum(connected[i,g] * pg[g,tt] for g in generators)
+        - demand_scale[tt] * pd_mw[i] / sbase
+        = sum((from_w[l,i] - to_w[l,i]) * flow[l,tt] for l in lines)
     }
   }
-
   // const4: ramp up between consecutive time steps via successor map taf.
+
   constraint ramp_up {
-    index g { in generators }
-    index tp { in t }
-    index tt { in t }
-    if { t_next[tp] == tt }
+    index g {
+      in generators
+    }
+    index tp {
+      in t
+    }
+    index tt {
+      in t
+    }
+    if {
+      t_next[tp]
+        == tt
+    }
     expression {
-      pg[g,tt] - pg[g,tp] <= ru[g] / sbase
+      pg[g,tt]
+        - pg[g,tp]
+        <= ru[g] / sbase
     }
   }
-
   // const5: ramp down.
+
   constraint ramp_down {
-    index g { in generators }
-    index tp { in t }
-    index tt { in t }
-    if { t_next[tp] == tt }
+    index g {
+      in generators
+    }
+    index tp {
+      in t
+    }
+    index tt {
+      in t
+    }
+    if {
+      t_next[tp]
+        == tt
+    }
     expression {
-      pg[g,tp] - pg[g,tt] <= rd[g] / sbase
+      pg[g,tp]
+        - pg[g,tt]
+        <= rd[g] / sbase
     }
   }
-
   // const6: curtailment definition. For buses without wind capacity the
   // bounds on pc and pw fix both to 0 and the equation is trivially satisfied.
+
   constraint curtailment_definition {
-    index i { in bus }
-    index tt { in t }
+    index i {
+      in bus
+    }
+    index tt {
+      in t
+    }
     expression {
-      pc[i,tt] = wind_cf[tt] * wcap_mw[i] / sbase - pw[i,tt]
+      pc[i,tt]
+        = wind_cf[tt] * wcap_mw[i] / sbase
+        - pw[i,tt]
     }
   }
-
   // Slack bus angle reference.
+
   constraint slack_angle {
-    index i { in bus }
-    index tt { in t }
-    if { is_slack[i] > 0 }
+    index i {
+      in bus
+    }
+    index tt {
+      in t
+    }
+    if {
+      is_slack[i] > 0
+    }
     expression {
-      delta[i,tt] = 0
+      delta[i,tt]
+        = 0
     }
   }
-
-  // Expression-based control bounds enforced explicitly (the bounds { lower {}
-  // upper {} } blocks above only act as hints when their RHS depends on data
+  // Expression-based control bounds enforced explicitly (the bounds { lower expression=""
+  // upper expression="" } blocks above only act as hints when their RHS depends on data
   // params; mirror the AC OPF example and emit them as constraints).
+
   constraint pg_lower_bound {
-    index g { in generators }
-    index tt { in t }
-    expression { pg[g,tt] >= pmin[g] / sbase }
+    index g {
+      in generators
+    }
+    index tt {
+      in t
+    }
+    expression {
+      pg[g,tt]
+        >= pmin[g] / sbase
+    }
   }
-
   constraint pg_upper_bound {
-    index g { in generators }
-    index tt { in t }
-    expression { pg[g,tt] <= pmax[g] / sbase }
+    index g {
+      in generators
+    }
+    index tt {
+      in t
+    }
+    expression {
+      pg[g,tt]
+        <= pmax[g] / sbase
+    }
   }
-
   constraint delta_lower_bound {
-    index i { in bus }
-    index tt { in t }
-    expression { delta[i,tt] >= -1.5707963268 }
+    index i {
+      in bus
+    }
+    index tt {
+      in t
+    }
+    expression {
+      delta[i,tt]
+        >= -1.5707963268
+    }
   }
-
   constraint delta_upper_bound {
-    index i { in bus }
-    index tt { in t }
-    expression { delta[i,tt] <= 1.5707963268 }
+    index i {
+      in bus
+    }
+    index tt {
+      in t
+    }
+    expression {
+      delta[i,tt]
+        <= 1.5707963268
+    }
   }
-
   constraint pw_lower_bound {
-    index i { in bus }
-    index tt { in t }
-    expression { pw[i,tt] >= 0 }
+    index i {
+      in bus
+    }
+    index tt {
+      in t
+    }
+    expression {
+      pw[i,tt]
+        >= 0
+    }
   }
-
   constraint pw_upper_bound {
-    index i { in bus }
-    index tt { in t }
-    expression { pw[i,tt] <= wind_cf[tt] * wcap_mw[i] / sbase }
+    index i {
+      in bus
+    }
+    index tt {
+      in t
+    }
+    expression {
+      pw[i,tt]
+        <= wind_cf[tt] * wcap_mw[i] / sbase
+    }
   }
-
   constraint pc_lower_bound {
-    index i { in bus }
-    index tt { in t }
-    expression { pc[i,tt] >= 0 }
+    index i {
+      in bus
+    }
+    index tt {
+      in t
+    }
+    expression {
+      pc[i,tt]
+        >= 0
+    }
   }
-
   constraint pc_upper_bound {
-    index i { in bus }
-    index tt { in t }
-    expression { pc[i,tt] <= wind_cf[tt] * wcap_mw[i] / sbase }
+    index i {
+      in bus
+    }
+    index tt {
+      in t
+    }
+    expression {
+      pc[i,tt]
+        <= wind_cf[tt] * wcap_mw[i] / sbase
+    }
   }
-
   constraint lsh_lower_bound {
-    index i { in bus }
-    index tt { in t }
-    expression { lsh[i,tt] >= 0 }
+    index i {
+      in bus
+    }
+    index tt {
+      in t
+    }
+    expression {
+      lsh[i,tt]
+        >= 0
+    }
   }
-
   constraint lsh_upper_bound {
-    index i { in bus }
-    index tt { in t }
-    expression { lsh[i,tt] <= demand_scale[tt] * pd_mw[i] / sbase }
+    index i {
+      in bus
+    }
+    index tt {
+      in t
+    }
+    expression {
+      lsh[i,tt]
+        <= demand_scale[tt] * pd_mw[i] / sbase
+    }
   }
-
   constraint flow_lower_bound {
-    index l { in lines }
-    index tt { in t }
-    expression { flow[l,tt] >= -limit_mw[l] / sbase }
+    index l {
+      in lines
+    }
+    index tt {
+      in t
+    }
+    expression {
+      flow[l,tt]
+        >= -limit_mw[l] / sbase
+    }
   }
-
   constraint flow_upper_bound {
-    index l { in lines }
-    index tt { in t }
-    expression { flow[l,tt] <= limit_mw[l] / sbase }
+    index l {
+      in lines
+    }
+    index tt {
+      in t
+    }
+    expression {
+      flow[l,tt]
+        <= limit_mw[l] / sbase
+    }
   }
-
   // const3: objective.
+
   expression GenerationCost {
     sum(pg[g,tt] * b[g] * sbase for g in generators for tt in t)
   }
-
   expression SheddingPenalty {
     sum(voll * lsh[i,tt] * sbase for i in bus for tt in t)
   }
-
   expression CurtailmentPenalty {
     sum(volw * pc[i,tt] * sbase for i in bus for tt in t)
   }
-
   expression TotalCost {
-    GenerationCost + SheddingPenalty + CurtailmentPenalty
+    GenerationCost
+      + SheddingPenalty
+      + CurtailmentPenalty
   }
-
   minimize OF {
     TotalCost
   }
 }
-
 scenario MultiPeriod24BusDCOPFCase {
   use MultiPeriod24BusDCOPF
-
   report OF
   report TotalCost
   report GenerationCost
   report SheddingPenalty
   report CurtailmentPenalty
-
   report delta
   report pg
   report pw
   report pc
   report lsh
   report flow
-
   report dual power_balance
 }

--- a/examples/nodal-allocation/input.kdl
+++ b/examples/nodal-allocation/input.kdl
@@ -1,96 +1,109 @@
 data links source="data/links.csv" {
-  map generators from="gen"
-  map buses from="bus"
-
-  set area alias="a"
-  set tech alias="i"
-  set generators alias="g"
-  set buses alias="b"
-
+  map generators from=gen
+  map buses from=bus
+  set area alias=a
+  set tech alias=i
+  set generators alias=g
+  set buses alias=b
   set feasible_links {
-    index a { in area }
-    index i { in tech }
-    index g { in generators }
-    index b { in buses }
-    filter { feasible > 0 }
+    index a {
+      in area
+    }
+    index i {
+      in tech
+    }
+    index g {
+      in generators
+    }
+    index b {
+      in buses
+    }
+    filter {
+      feasible > 0
+    }
   }
-
   param capacity_mw {
     index a
     index i
     index g
     index b
   }
-
   param priority_floor_mw {
     index a
     index i
     index g
     index b
   }
-
   param mw_target {
     index a
     index i
-    reduce "max"
+    reduce max
   }
 }
-
 set priority_links {
   in feasible_links
-  index a { in area }
-  index i { in tech }
-  index g { in generators }
-  index b { in buses }
-  filter { area == "south" }
+  index a {
+    in area
+  }
+  index i {
+    in tech
+  }
+  index g {
+    in generators
+  }
+  index b {
+    in buses
+  }
+  filter {
+    area
+      == "south"
+  }
 }
-
 set feasible_ai {
   in feasible_links
-  index a { in area }
-  index i { in tech }
+  index a {
+    in area
+  }
+  index i {
+    in tech
+  }
 }
-
-projection "ai" {
-  from "feasible_links"
-  to "a" "i"
+projection ai {
+  from feasible_links
+  to a i
 }
-
 model NodalAllocation {
   control capacity_nodal_site lower=0 {
     index feasible_links
   }
-
   expression allocated_capacity {
-    reduce "ai" {
-      sum "capacity_nodal_site"
-    }
+    reduce "ai" { sum "capacity_nodal_site" }
   }
-
   constraint investment_capacity {
     index feasible_links
     expression {
-      capacity_nodal_site[feasible_links] <= capacity_mw[feasible_links]
+      capacity_nodal_site[feasible_links]
+        <= capacity_mw[feasible_links]
     }
   }
-
   constraint priority_floor {
     index priority_links
     expression {
-      capacity_nodal_site[priority_links] >= priority_floor_mw[priority_links]
+      capacity_nodal_site[priority_links]
+        >= priority_floor_mw[priority_links]
     }
   }
-
   constraint enforce_mw_target {
     index feasible_ai
     expression {
-      allocated_capacity[feasible_ai] >= mw_target[feasible_ai]
+      allocated_capacity[feasible_ai]
+        >= mw_target[feasible_ai]
     }
   }
-
-  minimize tuple_membership_tracer { 0 }
+  minimize tuple_membership_tracer {
+    0
+  }
 }
-
 scenario NodalAllocationDay {
   use NodalAllocation
   report capacity_nodal_site

--- a/examples/price-taker-battery/input.kdl
+++ b/examples/price-taker-battery/input.kdl
@@ -1,8 +1,6 @@
 data battery source="data/battery.csv" {
-  map asset_id from="asset"
-
-  set asset_id alias="a"
-
+  map asset_id from=asset
+  set asset_id alias=a
   param power_mw {
     index asset_id
   }
@@ -22,17 +20,14 @@ data battery source="data/battery.csv" {
     index asset_id
   }
 }
-
 data price_curve source="data/prices.csv" {
   set t
   param prices {
     index t
   }
 }
-
 model price_taker_battery {
-  set time alias="t"
-
+  set time alias=t
   control charge {
     index asset_id
     index time
@@ -45,65 +40,94 @@ model price_taker_battery {
     index asset_id
     index time
   }
-
   expression arbitrage_revenue {
     sum(prices[t] * (discharge[asset,t] - charge[asset,t]) for asset in asset_id for t in time)
   }
-
   constraint soc_initial {
-    index asset { in asset_id }
+    index asset {
+      in asset_id
+    }
     expression {
-      soc[asset,1] = initial_soc_mwh[asset] + charge_efficiency[asset] * charge[asset,1] - discharge[asset,1] / discharge_efficiency[asset]
+      soc[asset,1]
+        = initial_soc_mwh[asset]
+        + charge_efficiency[asset] * charge[asset,1]
+        - discharge[asset,1] / discharge_efficiency[asset]
     }
   }
-
   constraint soc_balance {
-    index asset { in asset_id }
-    index t { in time }
-    if { t > 1 }
+    index asset {
+      in asset_id
+    }
+    index t {
+      in time
+    }
+    if {
+      t > 1
+    }
     expression {
-      soc[asset,t] = soc[asset,t-1] + charge_efficiency[asset] * charge[asset,t] - discharge[asset,t] / discharge_efficiency[asset]
+      soc[asset,t]
+        = soc[asset,t-1]
+        + charge_efficiency[asset] * charge[asset,t]
+        - discharge[asset,t] / discharge_efficiency[asset]
     }
   }
-
   constraint charge_limit {
-    index asset { in asset_id }
-    index t { in time }
+    index asset {
+      in asset_id
+    }
+    index t {
+      in time
+    }
     expression {
-      charge[asset,t] <= power_mw[asset]
+      charge[asset,t]
+        <= power_mw[asset]
     }
   }
-
   constraint discharge_limit {
-    index asset { in asset_id }
-    index t { in time }
+    index asset {
+      in asset_id
+    }
+    index t {
+      in time
+    }
     expression {
-      discharge[asset,t] <= power_mw[asset]
+      discharge[asset,t]
+        <= power_mw[asset]
     }
   }
-
   constraint soc_bounds {
-    index asset { in asset_id }
-    index t { in time }
+    index asset {
+      in asset_id
+    }
+    index t {
+      in time
+    }
     expression {
-      0 <= soc[asset,t] <= energy_mwh[asset]
+      0
+        <= soc[asset,t]
+        <= energy_mwh[asset]
     }
   }
-
   constraint terminal_soc {
-    index asset { in asset_id }
-    index t { in time }
-    if { t == 24 }
+    index asset {
+      in asset_id
+    }
+    index t {
+      in time
+    }
+    if {
+      t
+        == 24
+    }
     expression {
-      soc[asset,t] = terminal_soc_mwh[asset]
+      soc[asset,t]
+        = terminal_soc_mwh[asset]
     }
   }
-
   maximize arbitrage_profit {
     arbitrage_revenue
   }
 }
-
 scenario battery_arbitrage_day {
   use price_taker_battery
   report arbitrage_revenue

--- a/examples/reeds-benchmark/data.kdl
+++ b/examples/reeds-benchmark/data.kdl
@@ -1,52 +1,69 @@
 data regions source="data/regions.csv" {
-  set region alias="r"
+  set region alias=r
 }
-
 data techs source="data/techs.csv" {
-  set tech alias="i"
+  set tech alias=i
 }
-
 data hours source="data/hours.csv" {
-  set hour alias="h"
+  set hour alias=h
 }
-
 data years source="data/years.csv" {
-  set year alias="t"
+  set year alias=t
 }
-
 data tech_params source="data/tech_params.csv" {
-  param cost_inv { index tech }
-  param cost_gen { index tech }
+  param cost_inv {
+    index tech
+  }
+  param cost_gen {
+    index tech
+  }
 }
-
 data active_capacity source="data/active_capacity.csv" {
   set active_irt {
-    index i { in tech }
-    index r { in region }
-    index t { in year }
+    index i {
+      in tech
+    }
+    index r {
+      in region
+    }
+    index t {
+      in year
+    }
   }
 }
-
 data capacity_transitions source="data/cap_transition.csv" {
-  map prev_years from="prev_year"
-  set prev_years alias="tp"
-
+  map prev_years from=prev_year
+  set prev_years alias=tp
   set cap_transition {
-    index i { in tech }
-    index r { in region }
-    index tp { in prev_years }
-    index t { in year }
+    index i {
+      in tech
+    }
+    index r {
+      in region
+    }
+    index tp {
+      in prev_years
+    }
+    index t {
+      in year
+    }
   }
 }
-
 data dispatch source="data/dispatch.csv" {
   set active_irht {
-    index i { in tech }
-    index r { in region }
-    index h { in hour }
-    index t { in year }
+    index i {
+      in tech
+    }
+    index r {
+      in region
+    }
+    index h {
+      in hour
+    }
+    index t {
+      in year
+    }
   }
-
   param cf {
     index tech
     index region
@@ -54,14 +71,12 @@ data dispatch source="data/dispatch.csv" {
     index year
   }
 }
-
 data cap_init source="data/cap_init.csv" {
   param cap_init {
     index tech
     index region
   }
 }
-
 data load source="data/load.csv" {
   param load {
     index region

--- a/examples/reeds-benchmark/input.kdl
+++ b/examples/reeds-benchmark/input.kdl
@@ -1,6 +1,5 @@
-include "data.kdl"
-include "model.kdl"
-
+include data.kdl
+include model.kdl
 scenario reeds_benchmark_small {
   use reeds_benchmark
   report total_cost

--- a/examples/reeds-benchmark/model.kdl
+++ b/examples/reeds-benchmark/model.kdl
@@ -2,55 +2,63 @@ model reeds_benchmark {
   control cap lower=0 {
     index active_irt
   }
-
   control inv lower=0 {
     index active_irt
   }
-
   control gen lower=0 {
     index active_irht
   }
-
   expression investment_cost {
     sum(cost_inv[i] * inv[i,r,t] for i in tech for r in region for t in year)
   }
-
   expression generation_cost {
     sum(cost_gen[i] * gen[i,r,h,t] for i in tech for r in region for h in hour for t in year)
   }
-
   constraint initial_capacity {
-    index i { in tech }
-    index r { in region }
+    index i {
+      in tech
+    }
+    index r {
+      in region
+    }
     expression {
-      cap[i,r,2030] = cap_init[i,r] + inv[i,r,2030]
+      cap[i,r,2030]
+        = cap_init[i,r]
+        + inv[i,r,2030]
     }
   }
-
   constraint capacity_rollforward {
     index cap_transition
     expression {
-      cap[i,r,t] = cap[i,r,tp] + inv[i,r,t]
+      cap[i,r,t]
+        = cap[i,r,tp]
+        + inv[i,r,t]
     }
   }
-
   constraint generation_limit {
     index active_irht
     expression {
-      gen[active_irht] <= cf[active_irht] * cap[i,r,t]
+      gen[active_irht]
+        <= cf[active_irht] * cap[i,r,t]
     }
   }
-
   constraint supply_demand_balance {
-    index r { in region }
-    index h { in hour }
-    index t { in year }
+    index r {
+      in region
+    }
+    index h {
+      in hour
+    }
+    index t {
+      in year
+    }
     expression {
-      sum(gen[i,r,h,t] for i in tech) >= load[r,h,t]
+      sum(gen[i,r,h,t] for i in tech)
+        >= load[r,h,t]
     }
   }
-
   minimize total_cost {
-    investment_cost + generation_cost
+    investment_cost
+      + generation_cost
   }
 }

--- a/examples/sdom/input.kdl
+++ b/examples/sdom/input.kdl
@@ -20,96 +20,81 @@
 //   - Storage capacity bounds (min/max duration, max power, max annual cycles)
 //   - Hydro run-of-river (generation fixed to availability)
 //   - Thermal capacity limits
-
 // ============================================================================
 // DATA BLOCKS
 // ============================================================================
-
 data demand_data source="data/demand.csv" {
   set t
   param demand {
     index t
   }
 }
-
 data nuclear_data source="data/nuclear.csv" {
   param nuclear_mw {
     index t
   }
 }
-
 data hydro_data source="data/hydro.csv" {
   param hydro_mw {
     index t
   }
 }
-
 data other_renewables_data source="data/other_renewables.csv" {
   param other_renewables_mw {
     index t
   }
 }
-
 data wind_plants_data source="data/wind_plants.csv" {
-  map wind_plant from="plant_id"
-
-  set wind_plant alias="wp"
-  param wind_max_capacity from="max_capacity" {
+  map wind_plant from=plant_id
+  set wind_plant alias=wp
+  param wind_max_capacity from=max_capacity {
     index wind_plant
   }
-  param wind_capex_m from="capex_m" {
+  param wind_capex_m from=capex_m {
     index wind_plant
   }
-  param wind_fom_m from="fom_m" {
+  param wind_fom_m from=fom_m {
     index wind_plant
   }
-  param wind_trans_cost from="trans_cap_cost" {
+  param wind_trans_cost from=trans_cap_cost {
     index wind_plant
   }
 }
-
 data solar_plants_data source="data/solar_plants.csv" {
-  map solar_plant from="plant_id"
-
-  set solar_plant alias="sp"
-  param solar_max_capacity from="max_capacity" {
+  map solar_plant from=plant_id
+  set solar_plant alias=sp
+  param solar_max_capacity from=max_capacity {
     index solar_plant
   }
-  param solar_capex_m from="capex_m" {
+  param solar_capex_m from=capex_m {
     index solar_plant
   }
-  param solar_fom_m from="fom_m" {
+  param solar_fom_m from=fom_m {
     index solar_plant
   }
-  param solar_trans_cost from="trans_cap_cost" {
+  param solar_trans_cost from=trans_cap_cost {
     index solar_plant
   }
 }
-
 data wind_cf_data source="data/wind_cf.csv" {
-  map wind_plant from="plant_id"
-
+  map wind_plant from=plant_id
   set wind_plant
   param wind_cf {
     index t
     index wind_plant
   }
 }
-
 data solar_cf_data source="data/solar_cf.csv" {
-  map solar_plant from="plant_id"
-
+  map solar_plant from=plant_id
   set solar_plant
   param solar_cf {
     index t
     index solar_plant
   }
 }
-
 data storage_data source="data/storage.csv" {
-  map storage_tech from="tech_id"
-
-  set storage_tech alias="j"
+  map storage_tech from=tech_id
+  set storage_tech alias=j
   param p_capex {
     index storage_tech
   }
@@ -134,34 +119,32 @@ data storage_data source="data/storage.csv" {
   param coupled {
     index storage_tech
   }
-  param storage_fom from="fom" {
+  param storage_fom from=fom {
     index storage_tech
   }
-  param storage_vom from="vom" {
+  param storage_vom from=vom {
     index storage_tech
   }
-  param storage_lifetime from="lifetime" {
+  param storage_lifetime from=lifetime {
     index storage_tech
   }
   param cost_ratio {
     index storage_tech
   }
-  param storage_crf from="crf" {
+  param storage_crf from=crf {
     index storage_tech
   }
 }
-
 data thermal_data source="data/thermal.csv" {
-  map thermal_unit from="plant_id"
-
-  set thermal_unit alias="bu"
+  map thermal_unit from=plant_id
+  set thermal_unit alias=bu
   param min_capacity {
     index thermal_unit
   }
   param max_capacity {
     index thermal_unit
   }
-  param thermal_capex from="capex" {
+  param thermal_capex from=capex {
     index thermal_unit
   }
   param heat_rate {
@@ -170,31 +153,27 @@ data thermal_data source="data/thermal.csv" {
   param fuel_cost {
     index thermal_unit
   }
-  param thermal_vom from="vom" {
+  param thermal_vom from=vom {
     index thermal_unit
   }
-  param thermal_fom from="fom" {
+  param thermal_fom from=fom {
     index thermal_unit
   }
-  param thermal_crf from="crf" {
+  param thermal_crf from=crf {
     index thermal_unit
   }
 }
-
 // ============================================================================
 // MODEL
 // ============================================================================
-
 model sdom {
-  set time alias="t"
-
+  set time alias=t
   // FCR_VRE = r*(1+r)^lifetime / ((1+r)^lifetime - 1) with r=0.06, lifetime=30
+
   param fcr_vre 0.072649
   param mw_to_kw 1000
   param num_steps 24
-
   // Data-level sets and params are globally visible (no model redeclaration).
-
   // ========================================================================
   // DECISION VARIABLES (controls)
   // ========================================================================
@@ -205,7 +184,6 @@ model sdom {
   control solar_cap_frac lower=0 upper=1 {
     index solar_plant
   }
-
   control wind_gen lower=0 {
     index time
   }
@@ -218,7 +196,6 @@ model sdom {
   control solar_curtail lower=0 {
     index time
   }
-
   control pc lower=0 {
     index time
     index storage_tech
@@ -231,7 +208,6 @@ model sdom {
     index time
     index storage_tech
   }
-
   control pcha lower=0 {
     index storage_tech
   }
@@ -241,12 +217,10 @@ model sdom {
   control ecap lower=0 {
     index storage_tech
   }
-
   control storage_binary kind=binary {
     index storage_tech
     index time
   }
-
   control thermal_cap lower=0 {
     index thermal_unit
   }
@@ -254,236 +228,285 @@ model sdom {
     index time
     index thermal_unit
   }
-
   control hydro_gen lower=0 {
     index time
   }
-
   expression wind_capex {
     fcr_vre * sum((wind_capex_m[wp] * mw_to_kw + wind_trans_cost[wp]) * wind_max_capacity[wp] * wind_cap_frac[wp] for wp in wind_plant)
   }
-
   expression solar_capex {
     fcr_vre * sum((solar_capex_m[sp] * mw_to_kw + solar_trans_cost[sp]) * solar_max_capacity[sp] * solar_cap_frac[sp] for sp in solar_plant)
   }
-
   expression wind_fom {
     sum(wind_fom_m[wp] * mw_to_kw * wind_max_capacity[wp] * wind_cap_frac[wp] for wp in wind_plant)
   }
-
   expression solar_fom {
     sum(solar_fom_m[sp] * mw_to_kw * solar_max_capacity[sp] * solar_cap_frac[sp] for sp in solar_plant)
   }
-
   expression storage_power_capex {
     sum(storage_crf[j] * (mw_to_kw * cost_ratio[j] * p_capex[j] * pcha[j] + mw_to_kw * (1 - cost_ratio[j]) * p_capex[j] * pdis[j]) for j in storage_tech)
   }
-
   expression storage_energy_capex {
     sum(storage_crf[j] * mw_to_kw * e_capex[j] * ecap[j] for j in storage_tech)
   }
-
   expression storage_fixed_om {
     sum(mw_to_kw * cost_ratio[j] * storage_fom[j] * pcha[j] + mw_to_kw * (1 - cost_ratio[j]) * storage_fom[j] * pdis[j] for j in storage_tech)
   }
-
   expression storage_var_om {
     sum(storage_vom[j] * sum(pd[t,j] for t in time) for j in storage_tech)
   }
-
   expression thermal_total_capex {
     sum(thermal_crf[bu] * thermal_capex[bu] * mw_to_kw * thermal_cap[bu] for bu in thermal_unit)
   }
-
   expression thermal_total_fom {
     sum(thermal_fom[bu] * mw_to_kw * thermal_cap[bu] for bu in thermal_unit)
   }
-
   expression thermal_fuel_cost {
     sum(fuel_cost[bu] * heat_rate[bu] * sum(thermal_gen[t,bu] for t in time) for bu in thermal_unit)
   }
-
   expression thermal_var_om {
     sum(thermal_vom[bu] * sum(thermal_gen[t,bu] for t in time) for bu in thermal_unit)
   }
-
   expression total_vre_cost {
-    wind_capex + solar_capex + wind_fom + solar_fom
+    wind_capex
+      + solar_capex
+      + wind_fom
+      + solar_fom
   }
-
   expression total_storage_cost {
-    storage_power_capex + storage_energy_capex + storage_fixed_om + storage_var_om
+    storage_power_capex
+      + storage_energy_capex
+      + storage_fixed_om
+      + storage_var_om
   }
-
   expression total_thermal_cost {
-    thermal_total_capex + thermal_total_fom + thermal_fuel_cost + thermal_var_om
+    thermal_total_capex
+      + thermal_total_fom
+      + thermal_fuel_cost
+      + thermal_var_om
   }
-
-
   constraint supply_balance {
-    index t { in time }
+    index t {
+      in time
+    }
     expression {
       demand[t]
-      + sum(pc[t,j] for j in storage_tech)
-      - sum(pd[t,j] for j in storage_tech)
-      - nuclear_mw[t]
-      - hydro_gen[t]
-      - other_renewables_mw[t]
-      - solar_gen[t]
-      - wind_gen[t]
-      - sum(thermal_gen[t,bu] for bu in thermal_unit) = 0
+        + sum(pc[t,j] for j in storage_tech)
+        - sum(pd[t,j] for j in storage_tech)
+        - nuclear_mw[t]
+        - hydro_gen[t]
+        - other_renewables_mw[t]
+        - solar_gen[t]
+        - wind_gen[t]
+        - sum(thermal_gen[t,bu] for bu in thermal_unit)
+        = 0
     }
   }
-
   // --- Generation mix target: thermal + imports <= (1 - target) * adjusted demand ---
   // With GenMix_Target=1 (100% clean), this forces thermal generation to zero
+
   constraint gen_mix_share {
     expression {
-      sum(thermal_gen[t,bu] for t in time for bu in thermal_unit) <= 0
+      sum(thermal_gen[t,bu] for t in time for bu in thermal_unit)
+        <= 0
     }
   }
-
   constraint wind_balance {
-    index t { in time }
+    index t {
+      in time
+    }
     expression {
-      wind_gen[t] + wind_curtail[t]
-      = sum(wind_cf[t,wp] * wind_max_capacity[wp] * wind_cap_frac[wp] for wp in wind_plant)
+      wind_gen[t]
+        + wind_curtail[t]
+        = sum(wind_cf[t,wp] * wind_max_capacity[wp] * wind_cap_frac[wp] for wp in wind_plant)
     }
   }
-
   constraint solar_balance {
-    index t { in time }
+    index t {
+      in time
+    }
     expression {
-      solar_gen[t] + solar_curtail[t]
-      = sum(solar_cf[t,sp] * solar_max_capacity[sp] * solar_cap_frac[sp] for sp in solar_plant)
+      solar_gen[t]
+        + solar_curtail[t]
+        = sum(solar_cf[t,sp] * solar_max_capacity[sp] * solar_cap_frac[sp] for sp in solar_plant)
     }
   }
-
   // Cyclical SOC: t=1 wraps to the last time step
+
   constraint soc_balance_initial {
-    index j { in storage_tech }
+    index j {
+      in storage_tech
+    }
     expression {
-      soc[1,j] = soc[num_steps,j]
+      soc[1,j]
+        = soc[num_steps,j]
         + sqrt(efficiency[j]) * pc[1,j]
         - pd[1,j] / sqrt(efficiency[j])
     }
   }
-
   constraint soc_balance {
-    index j { in storage_tech }
-    index t { in time }
-    if { t > 1 }
+    index j {
+      in storage_tech
+    }
+    index t {
+      in time
+    }
+    if {
+      t > 1
+    }
     expression {
-      soc[t,j] = soc[t-1,j]
+      soc[t,j]
+        = soc[t-1,j]
         + sqrt(efficiency[j]) * pc[t,j]
         - pd[t,j] / sqrt(efficiency[j])
     }
   }
-
   constraint charge_binary_limit {
-    index t { in time }
-    index j { in storage_tech }
+    index t {
+      in time
+    }
+    index j {
+      in storage_tech
+    }
     expression {
-      pc[t,j] <= max_p[j] * storage_binary[j,t]
+      pc[t,j]
+        <= max_p[j] * storage_binary[j,t]
     }
   }
-
   constraint discharge_binary_limit {
-    index t { in time }
-    index j { in storage_tech }
+    index t {
+      in time
+    }
+    index j {
+      in storage_tech
+    }
     expression {
-      pd[t,j] <= max_p[j] * (1 - storage_binary[j,t])
+      pd[t,j]
+        <= max_p[j] * (1 - storage_binary[j,t])
     }
   }
-
   constraint max_hourly_charging {
-    index t { in time }
-    index j { in storage_tech }
+    index t {
+      in time
+    }
+    index j {
+      in storage_tech
+    }
     expression {
-      pc[t,j] <= pcha[j]
+      pc[t,j]
+        <= pcha[j]
     }
   }
-
   constraint max_hourly_discharging {
-    index t { in time }
-    index j { in storage_tech }
+    index t {
+      in time
+    }
+    index j {
+      in storage_tech
+    }
     expression {
-      pd[t,j] <= pdis[j]
+      pd[t,j]
+        <= pdis[j]
     }
   }
-
   constraint max_soc {
-    index t { in time }
-    index j { in storage_tech }
+    index t {
+      in time
+    }
+    index j {
+      in storage_tech
+    }
     expression {
-      soc[t,j] <= ecap[j]
+      soc[t,j]
+        <= ecap[j]
     }
   }
-
   constraint max_charge_capacity {
-    index j { in storage_tech }
+    index j {
+      in storage_tech
+    }
     expression {
-      pcha[j] <= max_p[j]
+      pcha[j]
+        <= max_p[j]
     }
   }
-
   constraint max_discharge_capacity {
-    index j { in storage_tech }
+    index j {
+      in storage_tech
+    }
     expression {
-      pdis[j] <= max_p[j]
+      pdis[j]
+        <= max_p[j]
     }
   }
-
   // Coupled technologies (Li-Ion, PHS) must have equal charge/discharge capacity
+
   constraint charge_equals_discharge {
-    index j { in storage_tech }
-    if { coupled[j] > 0 }
+    index j {
+      in storage_tech
+    }
+    if {
+      coupled[j] > 0
+    }
     expression {
-      pcha[j] = pdis[j]
+      pcha[j]
+        = pdis[j]
     }
   }
-
   constraint min_energy_capacity {
-    index j { in storage_tech }
+    index j {
+      in storage_tech
+    }
     expression {
-      ecap[j] >= min_duration[j] * pdis[j] / sqrt(efficiency[j])
+      ecap[j]
+        >= min_duration[j] * pdis[j] / sqrt(efficiency[j])
     }
   }
-
   constraint max_energy_capacity {
-    index j { in storage_tech }
+    index j {
+      in storage_tech
+    }
     expression {
-      ecap[j] <= max_duration[j] * pdis[j] / sqrt(efficiency[j])
+      ecap[j]
+        <= max_duration[j] * pdis[j] / sqrt(efficiency[j])
     }
   }
-
   constraint max_cycle_year {
-    index j { in storage_tech }
+    index j {
+      in storage_tech
+    }
     expression {
-      sum(pd[t,j] for t in time) <= (max_cycles[j] / storage_lifetime[j]) * ecap[j]
+      sum(pd[t,j] for t in time)
+        <= (max_cycles[j] / storage_lifetime[j]) * ecap[j]
     }
   }
-
   constraint thermal_capacity_limit {
-    index t { in time }
-    index bu { in thermal_unit }
+    index t {
+      in time
+    }
+    index bu {
+      in thermal_unit
+    }
     expression {
-      thermal_cap[bu] >= thermal_gen[t,bu]
+      thermal_cap[bu]
+        >= thermal_gen[t,bu]
     }
   }
-
   constraint hydro_run_of_river {
-    index t { in time }
+    index t {
+      in time
+    }
     expression {
-      hydro_gen[t] = hydro_mw[t]
+      hydro_gen[t]
+        = hydro_mw[t]
     }
   }
-
   minimize total_cost {
-    total_vre_cost + total_storage_cost + total_thermal_cost
+    total_vre_cost
+      + total_storage_cost
+      + total_thermal_cost
   }
 }
-
 scenario sdom_no_resiliency_24h {
   use sdom
   report total_cost
@@ -493,6 +516,9 @@ scenario sdom_no_resiliency_24h {
   report wind_cap_frac
   report pcha
   report soc {
-    filter { storage_tech == "Li-Ion"}
+    filter {
+      storage_tech
+        == "Li-Ion"
+    }
   }
 }

--- a/examples/simple-electricity-market-storage/input.kdl
+++ b/examples/simple-electricity-market-storage/input.kdl
@@ -1,14 +1,11 @@
 data units source="data/units.csv" {
-  map asset_id from="asset"
-
-  set asset_id alias="a"
-  param capacity_mw index="asset_id"
-  param marginal_cost index="asset_id"
+  map asset_id from=asset
+  set asset_id alias=a
+  param capacity_mw index=asset_id
+  param marginal_cost index=asset_id
 }
-
 data availability_data source="data/availability.csv" {
-  map asset_id from="asset_name"
-
+  map asset_id from=asset_name
   set asset_id
   set t
   param availability {
@@ -16,44 +13,44 @@ data availability_data source="data/availability.csv" {
     index t
   }
 }
-
 data load_data source="data/load.csv" {
   set t
-  param load index="t"
+  param load index=t
 }
-
 model SouthAfricaSingleZoneDispatch {
-  set time alias="t"
-
+  set time alias=t
   control dispatch {
     index asset_id
     index time
   }
-
   expression dispatch_cost {
     sum(marginal_cost[asset] * dispatch[asset,t] for asset in asset_id for t in time)
   }
-
   constraint dispatch_limit {
-    index asset { in asset_id }
-    index t { in time }
+    index asset {
+      in asset_id
+    }
+    index t {
+      in time
+    }
     expression {
-      dispatch[asset,t] <= capacity_mw[asset] * availability[asset,t]
+      dispatch[asset,t]
+        <= capacity_mw[asset] * availability[asset,t]
     }
   }
-
   constraint balance {
-    index t { in time }
+    index t {
+      in time
+    }
     expression {
-      sum(dispatch[asset,t] for asset in asset_id) = load[t]
+      sum(dispatch[asset,t] for asset in asset_id)
+        = load[t]
     }
   }
-
   minimize total_system_cost {
     dispatch_cost
   }
 }
-
 scenario south_africa_single_zone_with_storage {
   use SouthAfricaSingleZoneDispatch
   report dispatch_cost

--- a/examples/unit-commitment/input.kdl
+++ b/examples/unit-commitment/input.kdl
@@ -86,55 +86,99 @@
 // $$
 data generators_data source="data/generators.csv" {
   map generators from=generator
-
   // Unit domain from generators.csv (column mapped as `generators`).
   // Alias `g` is used in set-reference positions and algebra iteration.
+
   set generators alias=g
-
-  param a { index g }
-  param b { index g }
-  param c { index g }
-  param costsd { index g }
-  param costst { index g }
-  param ru { index g }
-  param rd { index g }
-  param ut { index g }
-  param dt { index g }
-  param sd { index g }
-  param su { index g }
-  param pmin { index g }
-  param pmax { index g }
-  param u0 { index g }
-  param uini { index g }
-  param initial_commitment from=uini { index g }
-  param s0 { index g }
-  param lj { index g }
-  param fj { index g }
-  param mincost { index g }
+  param a {
+    index g
+  }
+  param b {
+    index g
+  }
+  param c {
+    index g
+  }
+  param costsd {
+    index g
+  }
+  param costst {
+    index g
+  }
+  param ru {
+    index g
+  }
+  param rd {
+    index g
+  }
+  param ut {
+    index g
+  }
+  param dt {
+    index g
+  }
+  param sd {
+    index g
+  }
+  param su {
+    index g
+  }
+  param pmin {
+    index g
+  }
+  param pmax {
+    index g
+  }
+  param u0 {
+    index g
+  }
+  param uini {
+    index g
+  }
+  param initial_commitment from=uini {
+    index g
+  }
+  param s0 {
+    index g
+  }
+  param lj {
+    index g
+  }
+  param fj {
+    index g
+  }
+  param mincost {
+    index g
+  }
 }
-
 data temporal_sets source="data/temporal_sets.csv" {
   // Temporal domains are user-provided at the data layer.
   // t: primary time/day index used by the model.
   // taf/tbl: user-provided helper subsets for t-1 / t+1 constraints.
+
   set t
-  set taf { in t }
-  set tbl { in t }
+  set taf {
+    in t
+  }
+  set tbl {
+    in t
+  }
 }
-
 data demand_data source="data/load.csv" {
-  param lambda { index t }
-  param load { index t }
+  param lambda {
+    index t
+  }
+  param load {
+    index t
+  }
 }
-
 data segment_set source="data/segments.csv" {
   // Piecewise cost segment domain from segments.csv column `k`.
+
   set k
 }
-
 data segment_data source="data/segment_data.csv" {
   map generators from=generator
-
   param dp {
     index g
     index k
@@ -144,10 +188,8 @@ data segment_data source="data/segment_data.csv" {
     index k
   }
 }
-
 data time_masks_data source="data/time_masks.csv" {
   map generators from=generator
-
   param uptime1_mask {
     index g
     index t
@@ -173,13 +215,11 @@ data time_masks_data source="data/time_masks.csv" {
     index t
   }
 }
-
 data time_windows_data source="data/time_windows.csv" {
   map generators from=generator
-
   // `t` is the anchor index (day/time bucket), `h` is the hour index.
-  set h
 
+  set h
   param uptime_window {
     index g
     index t
@@ -191,7 +231,6 @@ data time_windows_data source="data/time_windows.csv" {
     index h
   }
 }
-
 model uc_gams_parity {
   // `g`, `k`, `t`, `taf`, `tbl`, and `h` are global sets from data blocks.
 
@@ -199,218 +238,258 @@ model uc_gams_parity {
     index g
     index t
   }
-
   control p lower=0 {
     index g
     index t
   }
-
   control stc lower=0 {
     index g
     index t
   }
-
   control sdc lower=0 {
     index g
     index t
   }
-
   control pk lower=0 {
     index g
     index t
     index k
   }
-
   control u kind=binary {
     index g
     index t
   }
-
   control y kind=binary {
     index g
     index t
   }
-
   control z kind=binary {
     index g
     index t
   }
-
   constraint uptime1 {
     index g
     expression {
-      sum((1 - u[g,tt]) * uptime1_mask[g,tt] for tt in t) = 0
+      sum((1 - u[g,tt]) * uptime1_mask[g,tt] for tt in t)
+        = 0
     }
   }
-
   constraint uptime2 {
     index g
     expression {
-      sum((u[g,tt] - y[g,tt]) * uptime2_mask[g,tt] for tt in t) >= 0
+      sum((u[g,tt] - y[g,tt]) * uptime2_mask[g,tt] for tt in t)
+        >= 0
     }
   }
-
   constraint uptime3 {
     index g
-    index tt { in t }
-    if { uptime3_active[g,tt] > 0 }
+    index tt {
+      in t
+    }
+    if {
+      uptime3_active[g,tt] > 0
+    }
     expression {
-      sum(u[g,hh] * uptime_window[g,tt,hh] for hh in h) >= ut[g] * y[g,tt]
+      sum(u[g,hh] * uptime_window[g,tt,hh] for hh in h)
+        >= ut[g] * y[g,tt]
     }
   }
-
   constraint dntime1 {
     index g
     expression {
-      sum(u[g,tt] * dntime1_mask[g,tt] for tt in t) = 0
+      sum(u[g,tt] * dntime1_mask[g,tt] for tt in t)
+        = 0
     }
   }
-
   constraint dntime2 {
     index g
     expression {
-      sum((1 - u[g,tt] - z[g,tt]) * dntime2_mask[g,tt] for tt in t) >= 0
+      sum((1 - u[g,tt] - z[g,tt]) * dntime2_mask[g,tt] for tt in t)
+        >= 0
     }
   }
-
   constraint dntime3 {
     index g
-    index tt { in t }
-    if { dntime3_active[g,tt] > 0 }
+    index tt {
+      in t
+    }
+    if {
+      dntime3_active[g,tt] > 0
+    }
     expression {
-      sum((1 - u[g,hh]) * dntime_window[g,tt,hh] for hh in h) >= dt[g] * z[g,tt]
+      sum((1 - u[g,hh]) * dntime_window[g,tt,hh] for hh in h)
+        >= dt[g] * z[g,tt]
     }
   }
-
   constraint startc {
     index g
-    index tt { in t }
+    index tt {
+      in t
+    }
     expression {
-      stc[g,tt] >= costst[g] * y[g,tt]
+      stc[g,tt]
+        >= costst[g] * y[g,tt]
     }
   }
-
   constraint shtdnc {
     index g
-    index tt { in t }
+    index tt {
+      in t
+    }
     expression {
-      sdc[g,tt] >= costsd[g] * z[g,tt]
+      sdc[g,tt]
+        >= costsd[g] * z[g,tt]
     }
   }
-
   constraint genconst1 {
     index g
-    index tt { in t }
+    index tt {
+      in t
+    }
     expression {
-      p[g,tt] = u[g,tt] * pmin[g] + sum(pk[g,tt,kk] for kk in k)
+      p[g,tt]
+        = u[g,tt] * pmin[g]
+        + sum(pk[g,tt,kk] for kk in k)
     }
   }
-
   constraint genconst2_initial {
     index g
     expression {
-      u[g,1] = initial_commitment[g] + y[g,1] - z[g,1]
+      u[g,1]
+        = initial_commitment[g]
+        + y[g,1]
+        - z[g,1]
     }
   }
-
   constraint genconst2 {
     index g
-    index tt { in taf }
+    index tt {
+      in taf
+    }
     expression {
-      u[g,tt] = u[g,tt-1] + y[g,tt] - z[g,tt]
+      u[g,tt]
+        = u[g,tt-1]
+        + y[g,tt]
+        - z[g,tt]
     }
   }
-
   constraint genconst3 {
     index g
-    index tt { in t }
-    index kk { in k }
+    index tt {
+      in t
+    }
+    index kk {
+      in k
+    }
     expression {
-      pk[g,tt,kk] <= u[g,tt] * dp[g,kk]
+      pk[g,tt,kk]
+        <= u[g,tt] * dp[g,kk]
     }
   }
-
   constraint pk_physical_limit {
     index g
-    index tt { in t }
-    index kk { in k }
+    index tt {
+      in t
+    }
+    index kk {
+      in k
+    }
     expression {
-      pk[g,tt,kk] <= dp[g,kk]
+      pk[g,tt,kk]
+        <= dp[g,kk]
     }
   }
-
   constraint p_upper_bound {
     index g
-    index tt { in t }
+    index tt {
+      in t
+    }
     expression {
-      p[g,tt] <= pmax[g]
+      p[g,tt]
+        <= pmax[g]
     }
   }
-
   constraint pu_upper_bound {
     index g
-    index tt { in t }
+    index tt {
+      in t
+    }
     expression {
-      pu[g,tt] <= pmax[g]
+      pu[g,tt]
+        <= pmax[g]
     }
   }
-
   constraint ramp1_initial {
     index g
     expression {
-      -p[g,1] <= u[g,1] * rd[g] + z[g,1] * sd[g]
+      -p[g,1]
+        <= u[g,1] * rd[g]
+        + z[g,1] * sd[g]
     }
   }
-
   constraint ramp1 {
     index g
-    index tt { in taf }
+    index tt {
+      in taf
+    }
     expression {
-      p[g,tt-1] - p[g,tt] <= u[g,tt] * rd[g] + z[g,tt] * sd[g]
+      p[g,tt-1]
+        - p[g,tt]
+        <= u[g,tt] * rd[g]
+        + z[g,tt] * sd[g]
     }
   }
-
   constraint ramp2 {
     index g
-    index tt { in t }
+    index tt {
+      in t
+    }
     expression {
-      p[g,tt] <= pu[g,tt]
+      p[g,tt]
+        <= pu[g,tt]
     }
   }
-
   constraint ramp3 {
     index g
-    index tt { in tbl }
+    index tt {
+      in tbl
+    }
     expression {
-      pu[g,tt] <= (u[g,tt] - z[g,tt+1]) * pmax[g] + z[g,tt+1] * sd[g]
+      pu[g,tt]
+        <= (u[g,tt] - z[g,tt+1]) * pmax[g]
+        + z[g,tt+1] * sd[g]
     }
   }
-
   constraint ramp4 {
     index g
-    index tt { in taf }
+    index tt {
+      in taf
+    }
     expression {
-      pu[g,tt] <= p[g,tt-1] + u[g,tt-1] * ru[g] + y[g,tt] * su[g]
+      pu[g,tt]
+        <= p[g,tt-1]
+        + u[g,tt-1] * ru[g]
+        + y[g,tt] * su[g]
     }
   }
-
   constraint balance {
-    index tt { in t }
+    index tt {
+      in t
+    }
     expression {
-      sum(p[g,tt] for g in g) <= load[tt]
+      sum(p[g,tt] for g in g)
+        <= load[tt]
     }
   }
-
   expression cost_thermal {
     sum(stc[g,tt] + sdc[g,tt] for g in g for tt in t)
-    + sum(u[g,tt] * mincost[g] + sum(slope[g,kk] * pk[g,tt,kk] for kk in k) for g in g for tt in t)
+      + sum(u[g,tt] * mincost[g] + sum(slope[g,kk] * pk[g,tt,kk] for kk in k) for g in g for tt in t)
   }
-
   maximize of {
-    sum(lambda[tt] * sum(p[g,tt] for g in g) for tt in t) - cost_thermal
+    sum(lambda[tt] * sum(p[g,tt] for g in g) for tt in t)
+      - cost_thermal
   }
 }
-
 scenario uc_gams_parityCase {
   use uc_gams_parity
   report cost_thermal

--- a/justfile
+++ b/justfile
@@ -84,6 +84,10 @@ kdl-overlay-check:
     ./scripts/check-kdl-overlay.sh
 
 [group: 'hygiene']
+vscode-extension-check:
+    bash scripts/ci_vscode_extension_check.sh
+
+[group: 'hygiene']
 workflow-quality:
     uvx zizmor --pedantic .github/
 
@@ -216,6 +220,10 @@ build-cli-feature features:
 [group: 'product']
 build-cli-release:
     "{{ solver-build-env }}" cargo build --release -p arco-cli --bin arco --all-features
+
+[group: 'product']
+vscode-extension-install:
+    npm --prefix tools/vscode-arco-kdl run install:local
 
 [group: 'examples']
 kdl-examples args="":

--- a/tools/vscode-arco-kdl/README.md
+++ b/tools/vscode-arco-kdl/README.md
@@ -1,6 +1,7 @@
 # arco KDL for VS Code
 
-Minimal-setup VS Code support for arco KDL files.
+VS Code support for arco KDL files with highlighting, diagnostics, formatting,
+and format-on-save.
 
 ## Features
 
@@ -22,24 +23,19 @@ arco kdl check <file> --format json
 arco kdl fmt --stdin --stdin-filename <file>
 ```
 
-The extension does not implement a second KDL parser or formatter. The Rust
-tooling remains the source of truth.
+The extension does not implement a second KDL parser or formatter. It shells
+out to the canonical Rust `arco` CLI, so editor diagnostics and formatting stay
+aligned with command-line behavior.
 
-## Install from this repository
+## Quick install
 
 Prerequisites:
 
-- VS Code installed locally. The installer uses `code` on PATH when available
-  and also detects standard macOS app locations, including `~/User Apps`.
+- VS Code installed locally
 - Node.js/npm
-- arco CLI available by one of these methods:
-  - installed on PATH as `arco`
-  - `ARCO_CLI=/absolute/path/to/arco`
-  - built in this workspace at `target/debug/arco` or `target/release/arco`
+- an `arco` CLI that runs `arco --version`
 
 One-command local install from the repository root:
-
-This works on macOS, Linux, and Windows.
 
 ```sh
 npm --prefix tools/vscode-arco-kdl run install:local
@@ -51,7 +47,13 @@ If you use this repository's `just` workflow, the equivalent target is:
 just vscode-extension-install
 ```
 
-If VS Code is installed somewhere non-standard, set `VSCODE_CLI`:
+For standard VS Code installs, no manual `VSCODE_CLI` setting is required. The
+installer uses `code` on PATH when available, checks common macOS app locations
+such as `/Applications`, `~/Applications`, and `~/User Apps`, and falls back to
+Spotlight on macOS.
+
+Set `VSCODE_CLI` only when VS Code is installed somewhere custom or the
+installer reports that it cannot run `code`:
 
 ```sh
 VSCODE_CLI="/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code" npm --prefix tools/vscode-arco-kdl run install:local
@@ -71,10 +73,13 @@ npm --prefix tools/vscode-arco-kdl run package
 code --install-extension tools/vscode-arco-kdl/arco-kdl-vscode-0.1.0.vsix --force
 ```
 
-## arco CLI discovery
+## Configure the arco CLI
 
-No setting is required when `arco` is on PATH. The extension checks in this
-order:
+The extension uses one `arco` CLI command for both diagnostics and formatting.
+No setting is required when `arco --version` succeeds and `arco` is discoverable
+from VS Code's environment.
+
+The extension checks in this order:
 
 1. `arco.kdl.command` setting
 2. `ARCO_CLI` environment variable
@@ -88,6 +93,26 @@ shadowing a working installed CLI. If the CLI is missing, the extension shows a
 warning with actions to select the CLI path or open this setup guide.
 
 `arco.kdl.checkCommand` remains as a legacy alias for older local settings.
+
+### Recommended settings
+
+Use an absolute path when auto-detection does not find the CLI:
+
+```json
+{
+  "arco.kdl.command": "/Users/me/.local/bin/arco",
+  "arco.kdl.validateOnSave": true,
+  "arco.kdl.validateOnChange": false
+}
+```
+
+You can also run **arco KDL: Select arco CLI** from the Command Palette. This
+updates the same `arco.kdl.command` setting.
+
+For repository development, prefer an installed CLI or a release build that
+runs successfully in the VS Code environment. Avoid explicitly setting
+`arco.kdl.command` to `target/debug/arco` unless that binary runs
+`target/debug/arco --version` without dynamic library errors.
 
 ## In-editor actions
 
@@ -115,28 +140,44 @@ To format KDL files on save:
 }
 ```
 
-## VS Code settings
+## Troubleshooting
 
-Optional settings:
+### VS Code installer cannot find `code`
+
+Run the local installer again with `VSCODE_CLI` pointing at the VS Code command
+inside the application bundle:
+
+```sh
+VSCODE_CLI="$HOME/User Apps/Visual Studio Code.app/Contents/Resources/app/bin/code" npm --prefix tools/vscode-arco-kdl run install:local
+```
+
+On macOS, installing the `code` command from VS Code also works:
+
+1. Open VS Code.
+2. Run **Shell Command: Install 'code' command in PATH** from the Command
+   Palette.
+3. Run `npm --prefix tools/vscode-arco-kdl run install:local` again.
+
+### Validator reports missing dynamic libraries
+
+If VS Code shows an error like this:
+
+```text
+Validator '/path/to/target/debug/arco' did not return KDL check JSON:
+Library not loaded: @rpath/libscip.10.0.dylib
+```
+
+the selected `arco` binary cannot run in VS Code's environment. Point the
+extension at a working CLI instead:
 
 ```json
 {
-  "arco.kdl.command": "",
-  "arco.kdl.validateOnSave": true,
-  "arco.kdl.validateOnChange": false
+  "arco.kdl.command": "/Users/me/.local/bin/arco"
 }
 ```
 
-Use an absolute path if auto-detection does not find the CLI. The same command
-is used for diagnostics and formatting:
-
-```json
-{
-  "arco.kdl.command": "/Users/me/.cargo/bin/arco"
-}
-```
-
-You can also run **arco KDL: Select arco CLI** from the Command Palette.
+or run **arco KDL: Select arco CLI** from the Command Palette and choose a
+binary that passes `arco --version`.
 
 ## Verify installation
 

--- a/tools/vscode-arco-kdl/README.md
+++ b/tools/vscode-arco-kdl/README.md
@@ -5,56 +5,70 @@ Minimal-setup VS Code support for arco KDL files.
 ## Features
 
 - registers `.kdl` files as `arco-kdl`
-- provides basic syntax highlighting
+- provides syntax highlighting
 - validates open/saved KDL files with the canonical arco CLI
+- formats KDL documents with the canonical arco CLI
+- shows an `arco KDL` status bar action for validate, format, CLI selection,
+  and setup help
 - shows diagnostics from:
 
 ```sh
 arco kdl check <file> --format json
 ```
 
-The extension does not implement a second KDL parser. The Rust parser in
-`crates/arco-kdl` remains the source of truth.
+- returns format edits from:
+
+```sh
+arco kdl fmt --stdin --stdin-filename <file>
+```
+
+The extension does not implement a second KDL parser or formatter. The Rust
+tooling remains the source of truth.
 
 ## Install from this repository
 
 Prerequisites:
 
-- VS Code with the `code` command available on PATH, or set `VSCODE_CLI` to the CLI path on systems where it is not named `code`
+- VS Code installed locally. The installer uses `code` on PATH when available
+  and also detects standard macOS app locations, including `~/User Apps`.
 - Node.js/npm
 - arco CLI available by one of these methods:
   - installed on PATH as `arco`
   - `ARCO_CLI=/absolute/path/to/arco`
   - built in this workspace at `target/debug/arco` or `target/release/arco`
 
-One-command local install:
+One-command local install from the repository root:
 
 This works on macOS, Linux, and Windows.
 
 ```sh
-cd tools/vscode-arco-kdl
-npm run install:local
+npm --prefix tools/vscode-arco-kdl run install:local
 ```
 
-If VS Code's CLI is not named `code`, set `VSCODE_CLI`:
+If you use this repository's `just` workflow, the equivalent target is:
 
 ```sh
-VSCODE_CLI="/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code" npm run install:local
+just vscode-extension-install
+```
+
+If VS Code is installed somewhere non-standard, set `VSCODE_CLI`:
+
+```sh
+VSCODE_CLI="/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code" npm --prefix tools/vscode-arco-kdl run install:local
 ```
 
 On Windows PowerShell, for example:
 
 ```powershell
 $env:VSCODE_CLI = "C:\\Program Files\\Microsoft VS Code\\bin\\code.cmd"
-npm run install:local
+npm --prefix tools/vscode-arco-kdl run install:local
 ```
 
 Manual install:
 
 ```sh
-cd tools/vscode-arco-kdl
-npm run package
-code --install-extension arco-kdl-vscode-0.1.0.vsix --force
+npm --prefix tools/vscode-arco-kdl run package
+code --install-extension tools/vscode-arco-kdl/arco-kdl-vscode-0.1.0.vsix --force
 ```
 
 ## arco CLI discovery
@@ -62,14 +76,44 @@ code --install-extension arco-kdl-vscode-0.1.0.vsix --force
 No setting is required when `arco` is on PATH. The extension checks in this
 order:
 
-1. `arco.kdl.checkCommand` setting
+1. `arco.kdl.command` setting
 2. `ARCO_CLI` environment variable
-3. workspace `target/debug/arco`
-4. workspace `target/release/arco`
-5. `arco` on PATH
+3. `arco` on PATH
+4. common user install paths such as `~/.local/bin/arco` and `~/.cargo/bin/arco`
+5. runnable workspace `target/debug/arco` or `target/release/arco`
 
-If the CLI is missing, the extension shows a warning with actions to select the
-CLI path or open this setup guide.
+Auto-detected commands must run `arco --version` successfully. This prevents a
+workspace development binary with missing dynamic solver libraries from
+shadowing a working installed CLI. If the CLI is missing, the extension shows a
+warning with actions to select the CLI path or open this setup guide.
+
+`arco.kdl.checkCommand` remains as a legacy alias for older local settings.
+
+## In-editor actions
+
+Open a `.kdl` file and use the `arco KDL` status bar item for the common
+actions:
+
+- validate the current file
+- format the current file
+- select the arco CLI if auto-detection cannot find it
+- open setup help
+
+## Formatting
+
+Use **Format Document**, the `arco KDL` status bar item, or run
+**arco KDL: Format Current File** from the Command Palette.
+
+To format KDL files on save:
+
+```json
+{
+  "[arco-kdl]": {
+    "editor.defaultFormatter": "natlabrockies.arco-kdl-vscode",
+    "editor.formatOnSave": true
+  }
+}
+```
 
 ## VS Code settings
 
@@ -77,17 +121,18 @@ Optional settings:
 
 ```json
 {
-  "arco.kdl.checkCommand": "",
+  "arco.kdl.command": "",
   "arco.kdl.validateOnSave": true,
   "arco.kdl.validateOnChange": false
 }
 ```
 
-Use an absolute path if auto-detection does not find the CLI:
+Use an absolute path if auto-detection does not find the CLI. The same command
+is used for diagnostics and formatting:
 
 ```json
 {
-  "arco.kdl.checkCommand": "/Users/me/.cargo/bin/arco"
+  "arco.kdl.command": "/Users/me/.cargo/bin/arco"
 }
 ```
 
@@ -96,7 +141,7 @@ You can also run **arco KDL: Select arco CLI** from the Command Palette.
 ## Verify installation
 
 1. Open a `.kdl` file.
-2. Run **arco KDL: Validate Current File** from the Command Palette.
+2. Click the `arco KDL` status bar item and choose **Validate Current File**.
 3. For an invalid file, VS Code should show diagnostics from the canonical CLI.
 
 Direct CLI sanity check:

--- a/tools/vscode-arco-kdl/extension.js
+++ b/tools/vscode-arco-kdl/extension.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const { spawn } = require("child_process");
+const { spawn, spawnSync } = require("child_process");
 const fs = require("fs");
 const path = require("path");
 const vscode = require("vscode");
@@ -10,17 +10,23 @@ const DIAGNOSTIC_SOURCE = "arco-kdl";
 const CONFIGURATION_SECTION = "arco.kdl";
 const CHECK_ARGS = ["kdl", "check"];
 const JSON_FORMAT_ARGS = ["--format", "json"];
+const FORMAT_STDIN_ARGS = ["kdl", "fmt", "--stdin"];
+const VERSION_ARGS = ["--version"];
 const COMMANDS = {
+  formatCurrentFile: "arcoKdl.formatCurrentFile",
   validateCurrentFile: "arcoKdl.validateCurrentFile",
+  showActions: "arcoKdl.showActions",
   selectCheckCommand: "arcoKdl.selectCheckCommand",
   showSetup: "arcoKdl.showSetup",
 };
 
 let extensionContext;
+let statusBarItem;
 let missingCommandWarningShown = false;
 const activeValidations = new Map();
 const activeDiagnosticUris = new Map();
 const diagnosticReportsByUri = new Map();
+const validationStateByUri = new Map();
 
 function activate(context) {
   extensionContext = context;
@@ -28,18 +34,44 @@ function activate(context) {
     vscode.languages.createDiagnosticCollection(DIAGNOSTIC_SOURCE);
   const validateOpenDocument = (document) =>
     validateIfKdl(document, diagnostics);
+  statusBarItem = vscode.window.createStatusBarItem(
+    vscode.StatusBarAlignment.Left,
+    100,
+  );
+  statusBarItem.command = COMMANDS.showActions;
+  statusBarItem.tooltip = "arco KDL actions";
 
   validateOpenDocuments(diagnostics);
+  updateStatusBarForActiveEditor();
   context.subscriptions.push(
     diagnostics,
+    statusBarItem,
     vscode.commands.registerCommand(COMMANDS.validateCurrentFile, () =>
       validateActiveDocument(diagnostics),
+    ),
+    vscode.commands.registerCommand(
+      COMMANDS.formatCurrentFile,
+      formatActiveDocument,
+    ),
+    vscode.commands.registerCommand(COMMANDS.showActions, () =>
+      showActions(diagnostics),
     ),
     vscode.commands.registerCommand(
       COMMANDS.selectCheckCommand,
       selectCheckCommand,
     ),
     vscode.commands.registerCommand(COMMANDS.showSetup, showSetupDocument),
+    vscode.window.onDidChangeActiveTextEditor(() =>
+      updateStatusBarForActiveEditor(),
+    ),
+    vscode.languages.registerDocumentFormattingEditProvider(
+      { language: LANGUAGE_ID },
+      {
+        provideDocumentFormattingEdits(document, _options, token) {
+          return formatDocument(document, token);
+        },
+      },
+    ),
     vscode.workspace.onDidOpenTextDocument(validateOpenDocument),
     vscode.workspace.onDidCloseTextDocument((document) => {
       if (isArcoKdlDocument(document))
@@ -81,6 +113,60 @@ function validateActiveDocument(diagnostics) {
   vscode.window.showInformationMessage("Open an arco KDL file to validate it.");
 }
 
+async function formatActiveDocument() {
+  const document = vscode.window.activeTextEditor?.document;
+  if (document && isArcoKdlDocument(document)) {
+    await vscode.commands.executeCommand("editor.action.formatDocument");
+    return;
+  }
+  vscode.window.showInformationMessage("Open an arco KDL file to format it.");
+}
+
+async function showActions(diagnostics) {
+  const document = vscode.window.activeTextEditor?.document;
+  const hasKdlDocument = document && isArcoKdlDocument(document);
+  const activeCommand = hasKdlDocument ? resolveArcoCommand(document) : "auto";
+  const items = [
+    ...(hasKdlDocument
+      ? [
+          {
+            label: "$(play) Validate Current File",
+            description: "Run arco kdl check",
+            action: "validate",
+          },
+          {
+            label: "$(wand) Format Current File",
+            description: "Run arco kdl fmt",
+            action: "format",
+          },
+        ]
+      : []),
+    {
+      label: "$(terminal) Select arco CLI",
+      description: activeCommand,
+      action: "select",
+    },
+    {
+      label: "$(book) Open Setup Help",
+      description: "Install and troubleshooting notes",
+      action: "setup",
+    },
+  ];
+
+  const selection = await vscode.window.showQuickPick(items, {
+    placeHolder: hasKdlDocument
+      ? "arco KDL actions"
+      : "Open a .kdl file to validate or format",
+  });
+  if (!selection) return;
+
+  if (selection.action === "validate") validateDocument(document, diagnostics);
+  else if (selection.action === "format")
+    await vscode.commands.executeCommand("editor.action.formatDocument");
+  else if (selection.action === "select") await selectCheckCommand();
+  else if (selection.action === "setup") await showSetupDocument();
+}
+
 function validateIfKdl(document, diagnostics) {
   if (isArcoKdlDocument(document)) validateDocument(document, diagnostics);
 }
@@ -99,8 +185,9 @@ function validateDocument(document, diagnostics) {
 
   const uri = document.uri.toString();
   activeValidations.get(uri)?.child.kill();
+  setValidationState(document, { status: "checking" });
 
-  const command = resolveCheckCommand(document);
+  const command = resolveArcoCommand(document);
   const version = document.version;
   const child = spawn(
     command,
@@ -133,6 +220,7 @@ function validateDocument(document, diagnostics) {
         diagnostic: commandFailureDiagnostic(document, command, error.message),
       },
     ]);
+    setValidationState(document, { status: "setup" });
     if (!missingCommandWarningShown && error.code === "ENOENT") {
       missingCommandWarningShown = true;
       showMissingCommandWarning(command);
@@ -151,9 +239,11 @@ function validateDocument(document, diagnostics) {
           diagnostic: invalidOutputDiagnostic(document, command, stderr),
         },
       ]);
+      setValidationState(document, { status: "setup" });
       return;
     }
 
+    setValidationState(document, validationStateForDiagnostics(report.diagnostics));
     setDocumentDiagnostics(
       document,
       diagnostics,
@@ -165,23 +255,152 @@ function validateDocument(document, diagnostics) {
   });
 }
 
-function resolveCheckCommand(document) {
+function formatDocument(document, token) {
+  if (!isArcoKdlDocument(document)) return [];
+
+  const input = document.getText();
+  const command = resolveArcoCommand(document);
+  const args = [...FORMAT_STDIN_ARGS];
+  if (!document.isUntitled && document.fileName) {
+    args.push("--stdin-filename", document.fileName);
+  }
+
+  return new Promise((resolve) => {
+    const child = spawn(command, args, {
+      cwd: workspaceDirectory(document),
+      shell:
+        process.platform === "win32" && isWindowsCommandShim(command),
+    });
+
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    let cancellationListener;
+
+    const finish = (edits) => {
+      if (settled) return;
+      settled = true;
+      cancellationListener?.dispose();
+      resolve(edits);
+    };
+
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.stdin.on("error", () => {});
+    child.on("error", (error) => {
+      if (token?.isCancellationRequested) {
+        finish([]);
+        return;
+      }
+
+      showFormatterError(command, error.message);
+      if (!missingCommandWarningShown && error.code === "ENOENT") {
+        missingCommandWarningShown = true;
+        setValidationState(document, { status: "setup" });
+        showMissingCommandWarning(command);
+      }
+      finish([]);
+    });
+    child.on("close", (code) => {
+      if (token?.isCancellationRequested) {
+        finish([]);
+        return;
+      }
+
+      if (code !== 0) {
+        showFormatterError(command, formatterFailureDetail(code, stderr));
+        finish([]);
+        return;
+      }
+
+      if (stdout === input) {
+        finish([]);
+        return;
+      }
+
+      finish([vscode.TextEdit.replace(fullDocumentRange(document), stdout)]);
+    });
+
+    cancellationListener = token?.onCancellationRequested(() => {
+      child.kill();
+      finish([]);
+    });
+
+    child.stdin.end(input);
+  });
+}
+
+function resolveArcoCommand(document) {
   const workspaceRoot = workspaceDirectory(document);
+  const configuredCommand = configuredArcoCommand();
+  if (configuredCommand) return configuredCommand;
+
+  const environmentCommand = process.env.ARCO_CLI?.trim();
+  if (environmentCommand) return environmentCommand;
+
   return (
-    configuration().get("checkCommand", "").trim() ||
-    process.env.ARCO_CLI?.trim() ||
-    (workspaceRoot && findWorkspaceArco(workspaceRoot)) ||
-    findOnPath("arco") ||
+    firstRunnableCommand([
+      findOnPath("arco"),
+      ...defaultUserArcoCandidates(),
+      ...workspaceArcoCandidates(workspaceRoot),
+    ]) ||
     "arco"
   );
 }
 
-function findWorkspaceArco(workspaceRoot) {
+function configuredArcoCommand() {
+  return (
+    configuration().get("command", "").trim() ||
+    configuration().get("checkCommand", "").trim()
+  );
+}
+
+function workspaceArcoCandidates(workspaceRoot) {
+  if (!workspaceRoot) return [];
+
   const binaryName = process.platform === "win32" ? "arco.exe" : "arco";
   return [
     path.join(workspaceRoot, "target", "debug", binaryName),
     path.join(workspaceRoot, "target", "release", binaryName),
-  ].find(isExecutableFile);
+  ];
+}
+
+function defaultUserArcoCandidates() {
+  const binaryName = process.platform === "win32" ? "arco.exe" : "arco";
+  return [
+    process.env.HOME && path.join(process.env.HOME, ".local", "bin", binaryName),
+    process.env.HOME && path.join(process.env.HOME, ".cargo", "bin", binaryName),
+    process.env.USERPROFILE &&
+      path.join(process.env.USERPROFILE, ".local", "bin", binaryName),
+    process.env.USERPROFILE &&
+      path.join(process.env.USERPROFILE, ".cargo", "bin", binaryName),
+  ];
+}
+
+function firstRunnableCommand(candidates) {
+  const seen = new Set();
+  for (const candidate of candidates) {
+    if (!candidate || seen.has(candidate)) continue;
+    seen.add(candidate);
+    if (isRunnableArcoCommand(candidate)) return candidate;
+  }
+  return undefined;
+}
+
+function isRunnableArcoCommand(candidate) {
+  if (!isExecutableFile(candidate)) return false;
+
+  const result = spawnSync(candidate, VERSION_ARGS, {
+    encoding: "utf8",
+    timeout: 2_000,
+    shell:
+      process.platform === "win32" && isWindowsCommandShim(candidate),
+  });
+  return result.status === 0 && /^arco\s+\d/.test(result.stdout.trim());
 }
 
 function findOnPath(command) {
@@ -228,6 +447,68 @@ function isExecutableFile(candidate) {
 
 function workspaceDirectory(document) {
   return vscode.workspace.getWorkspaceFolder(document.uri)?.uri.fsPath;
+}
+
+function setValidationState(document, state) {
+  validationStateByUri.set(document.uri.toString(), state);
+  updateStatusBarForActiveEditor();
+}
+
+function validationStateForDiagnostics(diagnostics) {
+  if (!diagnostics.length) return { status: "ready" };
+
+  const errors = diagnostics.filter(
+    (diagnostic) => diagnostic.severity !== "warning",
+  ).length;
+  const warnings = diagnostics.length - errors;
+  return { status: "issues", errors, warnings };
+}
+
+function updateStatusBarForActiveEditor() {
+  if (!statusBarItem) return;
+
+  const document = vscode.window.activeTextEditor?.document;
+  if (!document || !isArcoKdlDocument(document)) {
+    statusBarItem.hide();
+    return;
+  }
+
+  const state =
+    validationStateByUri.get(document.uri.toString()) ?? { status: "idle" };
+  statusBarItem.text = statusBarText(state);
+  statusBarItem.tooltip = statusBarTooltip(state);
+  statusBarItem.show();
+}
+
+function statusBarText(state) {
+  if (state.status === "checking") return "$(sync~spin) arco KDL";
+  if (state.status === "setup") return "$(debug-disconnect) arco KDL";
+  if (state.status === "issues") {
+    const count = (state.errors ?? 0) + (state.warnings ?? 0);
+    return `$(warning) arco KDL ${count}`;
+  }
+  if (state.status === "ready") return "$(check) arco KDL";
+  return "$(circle-outline) arco KDL";
+}
+
+function statusBarTooltip(state) {
+  if (state.status === "checking") return "arco KDL: checking";
+  if (state.status === "setup")
+    return "arco KDL: setup needed. Click for actions.";
+  if (state.status === "issues") {
+    const errors = state.errors ?? 0;
+    const warnings = state.warnings ?? 0;
+    return `arco KDL: ${errors} error(s), ${warnings} warning(s). Click for actions.`;
+  }
+  if (state.status === "ready")
+    return "arco KDL: no issues found. Click for actions.";
+  return "arco KDL actions";
+}
+
+function fullDocumentRange(document) {
+  const start = new vscode.Position(0, 0);
+  const lastLine = document.lineAt(document.lineCount - 1);
+  return new vscode.Range(start, lastLine.rangeIncludingLineBreak.end);
 }
 
 function parseReport(stdout) {
@@ -350,6 +631,8 @@ function clearDocumentDiagnostics(document, diagnostics) {
     publishDiagnostics(diagnostics, uri);
   }
   activeDiagnosticUris.delete(sourceUri);
+  validationStateByUri.delete(sourceUri);
+  updateStatusBarForActiveEditor();
 }
 
 function publishDiagnostics(diagnostics, uri) {
@@ -399,6 +682,18 @@ function invalidOutputDiagnostic(document, command, stderr) {
   );
 }
 
+function formatterFailureDetail(code, stderr) {
+  const detail = stderr.trim().split(/\r?\n/).find(Boolean);
+  if (detail) return detail;
+  return `exited with status ${code}`;
+}
+
+function showFormatterError(command, message) {
+  vscode.window.showErrorMessage(
+    `arco KDL formatter '${command}' failed: ${message}`,
+  );
+}
+
 function fileDiagnostic(document, message) {
   const diagnostic = new vscode.Diagnostic(
     document.lineAt(0).range,
@@ -412,7 +707,7 @@ function fileDiagnostic(document, message) {
 function showMissingCommandWarning(command) {
   vscode.window
     .showWarningMessage(
-      `arco KDL validator '${command}' was not found. Install the arco CLI or select its path.`,
+      `arco CLI '${command}' was not found. Install the arco CLI or select its path.`,
       "Select CLI",
       "Setup Help",
     )
@@ -433,11 +728,11 @@ async function selectCheckCommand() {
   if (!selected) return;
 
   await configuration().update(
-    "checkCommand",
+    "command",
     selected,
     vscode.ConfigurationTarget.Global,
   );
-  vscode.window.showInformationMessage(`arco KDL validator set to ${selected}`);
+  vscode.window.showInformationMessage(`arco CLI set to ${selected}`);
 }
 
 async function showSetupDocument() {
@@ -451,4 +746,17 @@ async function showSetupDocument() {
   await vscode.window.showTextDocument(document);
 }
 
-module.exports = { activate, deactivate };
+module.exports = {
+  activate,
+  deactivate,
+  _test: {
+    FORMAT_STDIN_ARGS,
+    configuredArcoCommand,
+    formatDocument,
+    fullDocumentRange,
+    resolveArcoCommand,
+    statusBarText,
+    statusBarTooltip,
+    validationStateForDiagnostics,
+  },
+};

--- a/tools/vscode-arco-kdl/extension.js
+++ b/tools/vscode-arco-kdl/extension.js
@@ -12,6 +12,7 @@ const CHECK_ARGS = ["kdl", "check"];
 const JSON_FORMAT_ARGS = ["--format", "json"];
 const FORMAT_STDIN_ARGS = ["kdl", "fmt", "--stdin"];
 const VERSION_ARGS = ["--version"];
+const CMD_METACHARACTER_PATTERN = /[&|<>^%]/;
 const COMMANDS = {
   formatCurrentFile: "arcoKdl.formatCurrentFile",
   validateCurrentFile: "arcoKdl.validateCurrentFile",
@@ -27,6 +28,7 @@ const activeValidations = new Map();
 const activeDiagnosticUris = new Map();
 const diagnosticReportsByUri = new Map();
 const validationStateByUri = new Map();
+let resolvedCommandCache;
 
 function activate(context) {
   extensionContext = context;
@@ -86,8 +88,10 @@ function activate(context) {
         validateOpenDocument(event.document);
     }),
     vscode.workspace.onDidChangeConfiguration((event) => {
-      if (event.affectsConfiguration(CONFIGURATION_SECTION))
+      if (event.affectsConfiguration(CONFIGURATION_SECTION)) {
+        invalidateResolvedArcoCommandCache();
         validateOpenDocuments(diagnostics);
+      }
     }),
   );
 }
@@ -125,7 +129,7 @@ async function formatActiveDocument() {
 async function showActions(diagnostics) {
   const document = vscode.window.activeTextEditor?.document;
   const hasKdlDocument = document && isArcoKdlDocument(document);
-  const activeCommand = hasKdlDocument ? resolveArcoCommand(document) : "auto";
+  const activeCommand = hasKdlDocument ? displayArcoCommand(document) : "auto";
   const items = [
     ...(hasKdlDocument
       ? [
@@ -188,16 +192,24 @@ function validateDocument(document, diagnostics) {
   setValidationState(document, { status: "checking" });
 
   const command = resolveArcoCommand(document);
+  const args = [...CHECK_ARGS, document.fileName, ...JSON_FORMAT_ARGS];
+  const unsafeArgument = windowsShellUnsafeArgument(command, args);
+  if (unsafeArgument) {
+    setDocumentDiagnostics(document, diagnostics, [
+      {
+        uri: document.uri,
+        diagnostic: commandFailureDiagnostic(
+          document,
+          command,
+          unsafeWindowsShellArgumentMessage(unsafeArgument),
+        ),
+      },
+    ]);
+    setValidationState(document, { status: "setup" });
+    return;
+  }
   const version = document.version;
-  const child = spawn(
-    command,
-    [...CHECK_ARGS, document.fileName, ...JSON_FORMAT_ARGS],
-    {
-      cwd: workspaceDirectory(document),
-      shell:
-        process.platform === "win32" && isWindowsCommandShim(command),
-    },
-  );
+  const child = spawn(command, args, commandSpawnOptions(command, workspaceDirectory(document)));
   activeValidations.set(uri, { child, version });
 
   let stdout = "";
@@ -264,13 +276,19 @@ function formatDocument(document, token) {
   if (!document.isUntitled && document.fileName) {
     args.push("--stdin-filename", document.fileName);
   }
+  const unsafeArgument = windowsShellUnsafeArgument(command, args);
+  if (unsafeArgument) {
+    showFormatterError(command, unsafeWindowsShellArgumentMessage(unsafeArgument));
+    setValidationState(document, { status: "setup" });
+    return [];
+  }
 
   return new Promise((resolve) => {
-    const child = spawn(command, args, {
-      cwd: workspaceDirectory(document),
-      shell:
-        process.platform === "win32" && isWindowsCommandShim(command),
-    });
+    const child = spawn(
+      command,
+      args,
+      commandSpawnOptions(command, workspaceDirectory(document)),
+    );
 
     let stdout = "";
     let stderr = "";
@@ -342,14 +360,45 @@ function resolveArcoCommand(document) {
   const environmentCommand = process.env.ARCO_CLI?.trim();
   if (environmentCommand) return environmentCommand;
 
-  return (
+  const cacheKey = commandResolutionCacheKey(workspaceRoot);
+  if (resolvedCommandCache?.key === cacheKey) return resolvedCommandCache.command;
+
+  const command =
     firstRunnableCommand([
       findOnPath("arco"),
       ...defaultUserArcoCandidates(),
       ...workspaceArcoCandidates(workspaceRoot),
     ]) ||
-    "arco"
-  );
+    "arco";
+  resolvedCommandCache = { key: cacheKey, command };
+  return command;
+}
+
+function displayArcoCommand(document) {
+  const configuredCommand = configuredArcoCommand();
+  if (configuredCommand) return configuredCommand;
+
+  const environmentCommand = process.env.ARCO_CLI?.trim();
+  if (environmentCommand) return environmentCommand;
+
+  const cacheKey = commandResolutionCacheKey(workspaceDirectory(document));
+  if (resolvedCommandCache?.key === cacheKey) return resolvedCommandCache.command;
+  return "auto-detect";
+}
+
+function commandResolutionCacheKey(workspaceRoot) {
+  return [
+    process.platform,
+    process.env.PATH ?? "",
+    process.env.PATHEXT ?? "",
+    process.env.HOME ?? "",
+    process.env.USERPROFILE ?? "",
+    workspaceRoot ?? "",
+  ].join("\u0000");
+}
+
+function invalidateResolvedArcoCommandCache() {
+  resolvedCommandCache = undefined;
 }
 
 function configuredArcoCommand() {
@@ -393,12 +442,12 @@ function firstRunnableCommand(candidates) {
 
 function isRunnableArcoCommand(candidate) {
   if (!isExecutableFile(candidate)) return false;
+  if (windowsShellUnsafeArgument(candidate, VERSION_ARGS)) return false;
 
   const result = spawnSync(candidate, VERSION_ARGS, {
     encoding: "utf8",
     timeout: 2_000,
-    shell:
-      process.platform === "win32" && isWindowsCommandShim(candidate),
+    ...commandSpawnOptions(candidate),
   });
   return result.status === 0 && /^arco\s+\d/.test(result.stdout.trim());
 }
@@ -430,8 +479,28 @@ function candidateExecutableNames(command, extensions) {
   ];
 }
 
-function isWindowsCommandShim(command) {
-  if (process.platform !== "win32") return false;
+function commandSpawnOptions(command, cwd) {
+  return {
+    cwd,
+    shell: process.platform === "win32" && isWindowsCommandShim(command),
+  };
+}
+
+function windowsShellUnsafeArgument(command, args, platform = process.platform) {
+  if (platform !== "win32" || !isWindowsCommandShim(command, platform)) return "";
+  return [command, ...args].find(hasCmdMetacharacter) ?? "";
+}
+
+function hasCmdMetacharacter(value) {
+  return CMD_METACHARACTER_PATTERN.test(value);
+}
+
+function unsafeWindowsShellArgumentMessage(argument) {
+  return `refusing to run Windows command shim with cmd.exe metacharacters in argument: ${argument}`;
+}
+
+function isWindowsCommandShim(command, platform = process.platform) {
+  if (platform !== "win32") return false;
   const extension = path.extname(command).toLowerCase();
   return extension === ".cmd" || extension === ".bat";
 }
@@ -732,6 +801,7 @@ async function selectCheckCommand() {
     selected,
     vscode.ConfigurationTarget.Global,
   );
+  invalidateResolvedArcoCommandCache();
   vscode.window.showInformationMessage(`arco CLI set to ${selected}`);
 }
 
@@ -752,11 +822,14 @@ module.exports = {
   _test: {
     FORMAT_STDIN_ARGS,
     configuredArcoCommand,
+    displayArcoCommand,
     formatDocument,
     fullDocumentRange,
+    invalidateResolvedArcoCommandCache,
     resolveArcoCommand,
     statusBarText,
     statusBarTooltip,
     validationStateForDiagnostics,
+    windowsShellUnsafeArgument,
   },
 };

--- a/tools/vscode-arco-kdl/package.json
+++ b/tools/vscode-arco-kdl/package.json
@@ -1,7 +1,7 @@
 {
   "name": "arco-kdl-vscode",
   "displayName": "arco KDL",
-  "description": "VS Code support for arco KDL validation and basic highlighting.",
+  "description": "VS Code support for arco KDL highlighting, validation, and formatting.",
   "version": "0.1.0",
   "private": true,
   "publisher": "natlabrockies",
@@ -24,11 +24,14 @@
   },
   "categories": [
     "Programming Languages",
-    "Linters"
+    "Linters",
+    "Formatters"
   ],
   "activationEvents": [
     "onLanguage:arco-kdl",
+    "onCommand:arcoKdl.formatCurrentFile",
     "onCommand:arcoKdl.validateCurrentFile",
+    "onCommand:arcoKdl.showActions",
     "onCommand:arcoKdl.selectCheckCommand",
     "onCommand:arcoKdl.showSetup"
   ],
@@ -57,8 +60,16 @@
     ],
     "commands": [
       {
+        "command": "arcoKdl.formatCurrentFile",
+        "title": "arco KDL: Format Current File"
+      },
+      {
         "command": "arcoKdl.validateCurrentFile",
         "title": "arco KDL: Validate Current File"
+      },
+      {
+        "command": "arcoKdl.showActions",
+        "title": "arco KDL: Show Actions"
       },
       {
         "command": "arcoKdl.selectCheckCommand",
@@ -72,10 +83,16 @@
     "configuration": {
       "title": "arco KDL",
       "properties": {
+        "arco.kdl.command": {
+          "type": "string",
+          "default": "",
+          "description": "Path to the arco CLI used for validation and formatting. Leave empty to auto-detect from ARCO_CLI, PATH, user install paths, or runnable workspace target binaries."
+        },
         "arco.kdl.checkCommand": {
           "type": "string",
           "default": "",
-          "description": "Path to the arco CLI. Leave empty to auto-detect from ARCO_CLI, workspace target binaries, or PATH."
+          "description": "Legacy alias for arco.kdl.command.",
+          "markdownDeprecationMessage": "Use `arco.kdl.command` instead."
         },
         "arco.kdl.validateOnSave": {
           "type": "boolean",
@@ -91,7 +108,8 @@
     }
   },
   "scripts": {
-    "check": "node --check extension.js && node --check scripts/install-local.js",
+    "check": "node --check extension.js && node --check scripts/install-local.js && npm test",
+    "test": "node --test test/*.test.js",
     "package": "npx --yes @vscode/vsce@3.9.1 package --no-dependencies",
     "install:local": "npm run package && node scripts/install-local.js"
   }

--- a/tools/vscode-arco-kdl/scripts/install-local.js
+++ b/tools/vscode-arco-kdl/scripts/install-local.js
@@ -8,34 +8,54 @@ const root = path.resolve(__dirname, '..');
 const manifest = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8'));
 const vsix = path.join(root, `${manifest.name}-${manifest.version}.vsix`);
 
-if (!fs.existsSync(vsix)) {
-  console.error(`Missing VSIX package: ${vsix}`);
-  console.error('Run `npm run package` first.');
-  process.exit(1);
+function main() {
+  if (!fs.existsSync(vsix)) {
+    console.error(`Missing VSIX package: ${vsix}`);
+    console.error('Run `npm run package` first.');
+    process.exit(1);
+  }
+
+  const codeCommand = resolveCodeCommand(process.env) ?? 'code';
+  const result = spawnSync(codeCommand, ['--install-extension', vsix, '--force'], {
+    stdio: 'inherit',
+    shell: process.platform === 'win32' && isWindowsCommandShim(codeCommand),
+  });
+
+  if (result.error) {
+    console.error(`Failed to run '${codeCommand}': ${result.error.message}`);
+    console.error('Set VSCODE_CLI to your VS Code CLI path if VS Code is installed in a non-standard location.');
+    process.exit(1);
+  }
+
+  process.exit(result.status ?? 1);
 }
 
-const rawCodeCommand = process.env.VSCODE_CLI || 'code';
-const codeCommand =
-  process.platform === 'win32'
-    ? resolveWindowsCommand(rawCodeCommand) ?? rawCodeCommand
-    : rawCodeCommand;
-const result = spawnSync(codeCommand, ['--install-extension', vsix, '--force'], {
-  stdio: 'inherit',
-  shell: process.platform === 'win32' && isWindowsCommandShim(codeCommand),
-});
+function resolveCodeCommand(env) {
+  const configuredCommand = env.VSCODE_CLI?.trim();
+  if (configuredCommand) {
+    return resolveConfiguredCommand(configuredCommand, env) ?? configuredCommand;
+  }
 
-if (result.error) {
-  console.error(`Failed to run '${codeCommand}': ${result.error.message}`);
-  console.error('Set VSCODE_CLI to your VS Code CLI path if `code` is not on PATH.');
-  process.exit(1);
+  if (process.platform === 'win32') {
+    return resolveWindowsCommand('code', env) ?? 'code';
+  }
+
+  return findOnPath('code', env) ?? findMacCodeCommand(env) ?? 'code';
 }
 
-process.exit(result.status ?? 1);
+function resolveConfiguredCommand(command, env) {
+  if (isExecutableFile(command)) return command;
+  if (path.basename(command) === command) {
+    if (process.platform === 'win32') return resolveWindowsCommand(command, env);
+    return findOnPath(command, env);
+  }
+  return undefined;
+}
 
-function resolveWindowsCommand(command) {
+function resolveWindowsCommand(command, env) {
   if (isExecutableFile(command)) return command;
 
-  const extensions = (process.env.PATHEXT || '.EXE;.CMD;.BAT').split(';');
+  const extensions = (env.PATHEXT || '.EXE;.CMD;.BAT').split(';');
 
   for (const extension of extensions) {
     const lowerCandidate = `${command}${extension.toLowerCase()}`;
@@ -45,7 +65,7 @@ function resolveWindowsCommand(command) {
     if (isExecutableFile(upperCandidate)) return upperCandidate;
   }
 
-  const paths = (process.env.PATH || '').split(path.delimiter).filter(Boolean);
+  const paths = (env.PATH || '').split(path.delimiter).filter(Boolean);
   for (const directory of paths) {
     for (const candidateName of candidateExecutableNames(command, extensions)) {
       const candidate = path.join(directory, candidateName);
@@ -53,6 +73,67 @@ function resolveWindowsCommand(command) {
     }
   }
 
+  return undefined;
+}
+
+function findOnPath(command, env) {
+  const paths = (env.PATH || '').split(path.delimiter).filter(Boolean);
+  for (const directory of paths) {
+    const candidate = path.join(directory, command);
+    if (isExecutableFile(candidate)) return candidate;
+  }
+  return undefined;
+}
+
+function findMacCodeCommand(env) {
+  if (process.platform !== 'darwin') return undefined;
+
+  for (const candidate of macCodeCandidates(env)) {
+    if (isExecutableFile(candidate)) return candidate;
+  }
+
+  return findMacCodeCommandWithSpotlight();
+}
+
+function macCodeCandidates(env) {
+  const homes = [env.HOME, env.USERPROFILE].filter(Boolean);
+  const appRoots = [
+    '/Applications',
+    ...homes.flatMap((home) => [
+      path.join(home, 'Applications'),
+      path.join(home, 'User Apps'),
+    ]),
+  ];
+
+  return [
+    ...appRoots.map((rootPath) =>
+      path.join(rootPath, 'Visual Studio Code.app', 'Contents', 'Resources', 'app', 'bin', 'code'),
+    ),
+    ...appRoots.map((rootPath) =>
+      path.join(
+        rootPath,
+        'Visual Studio Code - Insiders.app',
+        'Contents',
+        'Resources',
+        'app',
+        'bin',
+        'code-insiders',
+      ),
+    ),
+  ];
+}
+
+function findMacCodeCommandWithSpotlight() {
+  const result = spawnSync('mdfind', ['kMDItemCFBundleIdentifier == "com.microsoft.VSCode"'], {
+    encoding: 'utf8',
+  });
+  if (result.status !== 0) return undefined;
+
+  for (const appPath of result.stdout.split(/\r?\n/)) {
+    if (!appPath) continue;
+    const candidate = path.join(appPath, 'Contents', 'Resources', 'app', 'bin', 'code');
+    if (isExecutableFile(candidate)) return candidate;
+  }
   return undefined;
 }
 
@@ -81,3 +162,13 @@ function isExecutableFile(candidate) {
     return false;
   }
 }
+
+if (require.main === module) main();
+
+module.exports = {
+  _test: {
+    findMacCodeCommand,
+    macCodeCandidates,
+    resolveCodeCommand,
+  },
+};

--- a/tools/vscode-arco-kdl/test/extension.test.js
+++ b/tools/vscode-arco-kdl/test/extension.test.js
@@ -53,6 +53,7 @@ test("resolveArcoCommand skips unrunnable workspace binary", (t) => {
   const originalHome = process.env.HOME;
   const originalPath = process.env.PATH;
   const originalUserProfile = process.env.USERPROFILE;
+  extension._test.invalidateResolvedArcoCommandCache();
   t.after(() => {
     process.env.HOME = originalHome;
     process.env.PATH = originalPath;
@@ -61,6 +62,7 @@ test("resolveArcoCommand skips unrunnable workspace binary", (t) => {
     configuredCommand = "";
     legacyConfiguredCommand = "";
     workspaceRoot = undefined;
+    extension._test.invalidateResolvedArcoCommandCache();
     fs.rmSync(root, { recursive: true, force: true });
   });
 
@@ -82,6 +84,72 @@ test("resolveArcoCommand skips unrunnable workspace binary", (t) => {
   const document = createDocument("", path.join(workspaceRoot, "input.kdl"));
 
   assert.equal(extension._test.resolveArcoCommand(document), userArco);
+});
+
+test("resolveArcoCommand caches auto-detected runnable command", (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "arco-vscode-cache-"));
+  const originalHome = process.env.HOME;
+  const originalPath = process.env.PATH;
+  const originalUserProfile = process.env.USERPROFILE;
+  extension._test.invalidateResolvedArcoCommandCache();
+  t.after(() => {
+    process.env.HOME = originalHome;
+    process.env.PATH = originalPath;
+    if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = originalUserProfile;
+    configuredCommand = "";
+    legacyConfiguredCommand = "";
+    workspaceRoot = undefined;
+    extension._test.invalidateResolvedArcoCommandCache();
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  configuredCommand = "";
+  legacyConfiguredCommand = "";
+  process.env.PATH = "";
+  delete process.env.USERPROFILE;
+
+  const home = path.join(root, "home");
+  const userBin = path.join(home, ".local", "bin");
+  fs.mkdirSync(userBin, { recursive: true });
+  process.env.HOME = home;
+  const probeLog = path.join(root, "version-probes.log");
+  const userArco = createCountingArcoCommand(userBin, probeLog);
+  const document = createDocument("", path.join(root, "workspace", "input.kdl"));
+
+  assert.equal(extension._test.displayArcoCommand(document), "auto-detect");
+  assert.equal(countVersionProbes(probeLog), 0);
+  assert.equal(extension._test.resolveArcoCommand(document), userArco);
+  assert.equal(extension._test.resolveArcoCommand(document), userArco);
+  assert.equal(countVersionProbes(probeLog), 1);
+  assert.equal(extension._test.displayArcoCommand(document), userArco);
+});
+
+test("windowsShellUnsafeArgument rejects metacharacters for command shims", () => {
+  assert.equal(
+    extension._test.windowsShellUnsafeArgument(
+      "C:\\bin\\arco.cmd",
+      ["kdl", "fmt", "--stdin-filename", "C:\\models\\a&b.kdl"],
+      "win32",
+    ),
+    "C:\\models\\a&b.kdl",
+  );
+  assert.equal(
+    extension._test.windowsShellUnsafeArgument(
+      "C:\\bin\\arco.cmd",
+      ["kdl", "fmt", "--stdin-filename", "C:\\models\\safe.kdl"],
+      "win32",
+    ),
+    "",
+  );
+  assert.equal(
+    extension._test.windowsShellUnsafeArgument(
+      "C:\\bin\\arco.exe",
+      ["kdl", "fmt", "--stdin-filename", "C:\\models\\a&b.kdl"],
+      "win32",
+    ),
+    "",
+  );
 });
 
 test("configuredArcoCommand prefers current setting over legacy setting", () => {
@@ -177,6 +245,45 @@ exec "${process.execPath}" "${fakeCli}" "$@"
     { mode: 0o755 },
   );
   return command;
+}
+
+function createCountingArcoCommand(root, probeLog) {
+  const fakeCli = path.join(root, "counting-arco.js");
+  fs.writeFileSync(
+    fakeCli,
+    `"use strict";
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+if (args[0] === "--version") {
+  fs.appendFileSync(${JSON.stringify(probeLog)}, "1\\n");
+  console.log("arco 0.8.1");
+  process.exit(0);
+}
+process.exit(0);
+`,
+  );
+
+  if (process.platform === "win32") {
+    const command = path.join(root, "arco.cmd");
+    fs.writeFileSync(command, `@"${process.execPath}" "${fakeCli}" %*\r\n`);
+    return command;
+  }
+
+  const command = path.join(root, "arco");
+  fs.writeFileSync(
+    command,
+    `#!/bin/sh
+exec "${process.execPath}" "${fakeCli}" "$@"
+`,
+    { mode: 0o755 },
+  );
+  return command;
+}
+
+function countVersionProbes(probeLog) {
+  if (!fs.existsSync(probeLog)) return 0;
+  return fs.readFileSync(probeLog, "utf8").trim().split(/\r?\n/).filter(Boolean)
+    .length;
 }
 
 function createBrokenArcoCommand(root) {

--- a/tools/vscode-arco-kdl/test/extension.test.js
+++ b/tools/vscode-arco-kdl/test/extension.test.js
@@ -1,0 +1,299 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const Module = require("node:module");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+let configuredCommand = "";
+let legacyConfiguredCommand = "";
+let workspaceRoot;
+const vscodeStub = createVscodeStub();
+const originalLoad = Module._load;
+Module._load = function loadWithVscodeStub(request, parent, isMain) {
+  if (request === "vscode") return vscodeStub;
+  return originalLoad.call(this, request, parent, isMain);
+};
+const extension = require("../extension.js");
+Module._load = originalLoad;
+
+test("formatDocument streams content through arco kdl fmt stdin", async (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "arco-vscode-format-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  configuredCommand = createFakeArcoCommand(root);
+  const fileName = path.join(root, "input.kdl");
+  const document = createDocument("node\tkey=1\n", fileName);
+
+  const edits = await extension._test.formatDocument(document);
+
+  assert.equal(edits.length, 1);
+  assert.equal(edits[0].newText, "node key=1\n");
+  assert.deepEqual(edits[0].range.start, new vscodeStub.Position(0, 0));
+  assert.deepEqual(edits[0].range.end, new vscodeStub.Position(1, 0));
+});
+
+test("formatDocument returns no edits when formatter output is unchanged", async (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "arco-vscode-format-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  configuredCommand = createFakeArcoCommand(root);
+  const fileName = path.join(root, "input.kdl");
+  const document = createDocument("node key=1\n", fileName);
+
+  const edits = await extension._test.formatDocument(document);
+
+  assert.deepEqual(edits, []);
+});
+
+test("resolveArcoCommand skips unrunnable workspace binary", (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "arco-vscode-resolve-"));
+  const originalHome = process.env.HOME;
+  const originalPath = process.env.PATH;
+  const originalUserProfile = process.env.USERPROFILE;
+  t.after(() => {
+    process.env.HOME = originalHome;
+    process.env.PATH = originalPath;
+    if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = originalUserProfile;
+    configuredCommand = "";
+    legacyConfiguredCommand = "";
+    workspaceRoot = undefined;
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  configuredCommand = "";
+  process.env.PATH = "";
+  delete process.env.USERPROFILE;
+
+  workspaceRoot = path.join(root, "workspace");
+  const workspaceDebugBin = path.join(workspaceRoot, "target", "debug");
+  fs.mkdirSync(workspaceDebugBin, { recursive: true });
+  createBrokenArcoCommand(workspaceDebugBin);
+
+  const home = path.join(root, "home");
+  const userBin = path.join(home, ".local", "bin");
+  fs.mkdirSync(userBin, { recursive: true });
+  process.env.HOME = home;
+  const userArco = createFakeArcoCommand(userBin);
+
+  const document = createDocument("", path.join(workspaceRoot, "input.kdl"));
+
+  assert.equal(extension._test.resolveArcoCommand(document), userArco);
+});
+
+test("configuredArcoCommand prefers current setting over legacy setting", () => {
+  configuredCommand = "/opt/arco/bin/arco";
+  legacyConfiguredCommand = "/legacy/arco";
+
+  assert.equal(extension._test.configuredArcoCommand(), "/opt/arco/bin/arco");
+
+  configuredCommand = "";
+  assert.equal(extension._test.configuredArcoCommand(), "/legacy/arco");
+
+  legacyConfiguredCommand = "";
+});
+
+test("status bar summarizes validation state", () => {
+  assert.equal(
+    extension._test.statusBarText({ status: "checking" }),
+    "$(sync~spin) arco KDL",
+  );
+  assert.equal(
+    extension._test.statusBarText({ status: "ready" }),
+    "$(check) arco KDL",
+  );
+  assert.equal(
+    extension._test.statusBarText({ status: "issues", errors: 1, warnings: 2 }),
+    "$(warning) arco KDL 3",
+  );
+  assert.match(
+    extension._test.statusBarTooltip({
+      status: "issues",
+      errors: 1,
+      warnings: 2,
+    }),
+    /1 error\(s\), 2 warning\(s\)/,
+  );
+});
+
+test("validationStateForDiagnostics counts errors and warnings", () => {
+  assert.deepEqual(extension._test.validationStateForDiagnostics([]), {
+    status: "ready",
+  });
+  assert.deepEqual(
+    extension._test.validationStateForDiagnostics([
+      { severity: "error" },
+      { severity: "warning" },
+      { severity: "error" },
+    ]),
+    { status: "issues", errors: 2, warnings: 1 },
+  );
+});
+
+function createFakeArcoCommand(root) {
+  const fakeCli = path.join(root, "fake-arco.js");
+  fs.writeFileSync(
+    fakeCli,
+    `"use strict";
+const args = process.argv.slice(2);
+if (args[0] === "--version") {
+  console.log("arco 0.8.1");
+  process.exit(0);
+}
+if (args[0] !== "kdl" || args[1] !== "fmt" || args[2] !== "--stdin") {
+  console.error(\`unexpected args: \${args.join(" ")}\`);
+  process.exit(9);
+}
+if (args[3] !== "--stdin-filename" || !args[4]) {
+  console.error(\`missing stdin filename: \${args.join(" ")}\`);
+  process.exit(10);
+}
+let input = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => {
+  input += chunk;
+});
+process.stdin.on("end", () => {
+  process.stdout.write(input.replace(/\\t/g, " "));
+});
+`,
+  );
+
+  if (process.platform === "win32") {
+    const command = path.join(root, "arco.cmd");
+    fs.writeFileSync(command, `@"${process.execPath}" "${fakeCli}" %*\r\n`);
+    return command;
+  }
+
+  const command = path.join(root, "arco");
+  fs.writeFileSync(
+    command,
+    `#!/bin/sh
+exec "${process.execPath}" "${fakeCli}" "$@"
+`,
+    { mode: 0o755 },
+  );
+  return command;
+}
+
+function createBrokenArcoCommand(root) {
+  const command = path.join(
+    root,
+    process.platform === "win32" ? "arco.exe" : "arco",
+  );
+  if (process.platform === "win32") {
+    fs.writeFileSync(command, "@echo dyld failure\r\n@exit /b 134\r\n");
+    return command;
+  }
+
+  fs.writeFileSync(
+    command,
+    `#!/bin/sh
+echo "dyld failure" >&2
+exit 134
+`,
+    { mode: 0o755 },
+  );
+  return command;
+}
+
+function createDocument(text, fileName) {
+  const lines = text.split("\n");
+  return {
+    fileName,
+    isUntitled: false,
+    languageId: "arco-kdl",
+    lineCount: lines.length,
+    uri: {
+      fsPath: fileName,
+      toString() {
+        return `file://${fileName}`;
+      },
+    },
+    getText() {
+      return text;
+    },
+    lineAt(index) {
+      const line = lines[index] ?? "";
+      const includesLineBreak = index < lines.length - 1;
+      const endCharacter = line.length + (includesLineBreak ? 1 : 0);
+      return {
+        range: new vscodeStub.Range(
+          new vscodeStub.Position(index, 0),
+          new vscodeStub.Position(index, line.length),
+        ),
+        rangeIncludingLineBreak: new vscodeStub.Range(
+          new vscodeStub.Position(index, 0),
+          new vscodeStub.Position(index, endCharacter),
+        ),
+      };
+    },
+  };
+}
+
+function createVscodeStub() {
+  class Position {
+    constructor(line, character) {
+      this.line = line;
+      this.character = character;
+    }
+
+    translate(lineDelta, characterDelta) {
+      return new Position(
+        this.line + lineDelta,
+        this.character + characterDelta,
+      );
+    }
+  }
+
+  class Range {
+    constructor(start, end) {
+      this.start = start;
+      this.end = end;
+    }
+  }
+
+  return {
+    Position,
+    Range,
+    TextEdit: {
+      replace(range, newText) {
+        return { range, newText };
+      },
+    },
+    workspace: {
+      getConfiguration() {
+        return {
+          get(name, fallback) {
+            if (name === "command") return configuredCommand;
+            if (name === "checkCommand") return legacyConfiguredCommand;
+            return fallback;
+          },
+          update() {
+            return Promise.resolve();
+          },
+        };
+      },
+      getWorkspaceFolder() {
+        if (!workspaceRoot) return undefined;
+        return { uri: { fsPath: workspaceRoot } };
+      },
+      textDocuments: [],
+    },
+    window: {
+      activeTextEditor: undefined,
+      showErrorMessage() {
+        return Promise.resolve();
+      },
+      showInformationMessage() {
+        return Promise.resolve();
+      },
+      showWarningMessage() {
+        return Promise.resolve(undefined);
+      },
+    },
+  };
+}

--- a/tools/vscode-arco-kdl/test/install-local.test.js
+++ b/tools/vscode-arco-kdl/test/install-local.test.js
@@ -1,0 +1,41 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const installer = require("../scripts/install-local.js");
+
+test("resolveCodeCommand finds VS Code under user apps on macOS", (t) => {
+  if (process.platform !== "darwin") {
+    t.skip("macOS app bundle discovery is only relevant on darwin");
+    return;
+  }
+
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "arco-vscode-code-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  const home = path.join(root, "home");
+  const codeCommand = path.join(
+    home,
+    "User Apps",
+    "Visual Studio Code.app",
+    "Contents",
+    "Resources",
+    "app",
+    "bin",
+    "code",
+  );
+  fs.mkdirSync(path.dirname(codeCommand), { recursive: true });
+  fs.writeFileSync(codeCommand, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+
+  assert.equal(
+    installer._test.resolveCodeCommand({
+      HOME: home,
+      PATH: "",
+    }),
+    codeCommand,
+  );
+});


### PR DESCRIPTION
## Summary

- Make `arco kdl fmt` emit Arco surface syntax by default, including readable algebra blocks instead of quoted `formula` children.
- Add `arco kdl fmt --kdl-compatible` for normalized strict KDL output.
- Add VS Code KDL formatting, status-bar actions, CLI autodetection hardening, local installer discovery, and extension tests.
- Update KDL tooling docs, README guidance, migration notes, and the DCOPF example formatting.

## Behavior Changes

- `arco kdl fmt --check` now checks Arco surface syntax by default. Existing strict-KDL files may need one committed `arco kdl fmt <paths>` pass, or downstream checks can use `arco kdl fmt --check --kdl-compatible <paths>` when strict normalized KDL is required.
- The VS Code extension uses `arco.kdl.command` for the CLI path. Existing `arco.kdl.checkCommand` settings still work as a legacy fallback.

## Review Fixes

- Preserve prose inside multiline block comments during default surface formatting.
- Cache VS Code CLI auto-detection so validation, formatting, and status-bar actions do not synchronously probe every event.
- Reject unsafe cmd.exe metacharacters when Windows `.cmd`/`.bat` shims must be launched through shell mode.

## Validation

- `cargo fmt`
- `cargo fmt --all -- --check`
- `ARCO_HIGHS_ENABLE_APPLE_STATIC=1 scripts/with_solver_build_env.sh cargo test -p arco-cli kdl_fmt --test example_cli_commands --all-features`
- `ARCO_HIGHS_ENABLE_APPLE_STATIC=1 scripts/with_solver_build_env.sh cargo test -p arco-kdl --all-features`
- `ARCO_HIGHS_ENABLE_APPLE_STATIC=1 scripts/with_solver_build_env.sh cargo clippy -p arco-kdl -p arco-cli --tests --all-features -- -D warnings`
- `just clippy-pkg arco-kdl`
- `just clippy-pkg arco-ops`
- `ARCO_HIGHS_ENABLE_APPLE_STATIC=1 scripts/with_solver_build_env.sh cargo clippy -p arco-cli --benches --tests --examples --all-features -- -D warnings`
- `npm --prefix tools/vscode-arco-kdl run check`
- `npm --prefix tools/vscode-arco-kdl run package`
- `git diff --check`
- `prek run prettier --files README.md docs/dev/kdl-tooling.md docs/migration/README.md docs/migration/kdl-formatting.md`
- pre-commit hooks during commit
- pre-push hooks during push
