### PR TITLE
fix: bundle SCIP runtime in CLI releases

### DIFF
--- a/.github/workflows/v-release.yml
+++ b/.github/workflows/v-release.yml
@@ -80,7 +80,7 @@ jobs:
       # but also really annoying to build CI around when it needs secrets to work right.)
       - id: plan
         run: |
-          dist ${{ (inputs.tag && inputs.tag != 'dry-run' && format('host --steps=create --tag={0}', inputs.tag)) || 'plan' }} --output-format=json > plan-dist-manifest.json
+          dist ${{ (inputs.tag && inputs.tag != 'dry-run' && format('host --steps=create --tag={0}', inputs.tag)) || 'plan' }} --allow-dirty --output-format=json > plan-dist-manifest.json
           echo "dist ran successfully"
           cat plan-dist-manifest.json
           echo "manifest=$(jq -c "." plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"
@@ -224,7 +224,7 @@ jobs:
       - name: Build artifacts
         run: |
           # Actually do builds and make zips and whatnot
-          dist build ${{ needs.plan.outputs.tag-flag }} --print=linkage --output-format=json ${{ matrix.dist_args }} > dist-manifest.json
+          dist build ${{ needs.plan.outputs.tag-flag }} --allow-dirty --print=linkage --output-format=json ${{ matrix.dist_args }} > dist-manifest.json
           echo "dist ran successfully"
           uv run python scripts/ci_bundle_scip_runtime.py local dist-manifest.json
       - id: cargo-dist
@@ -278,7 +278,7 @@ jobs:
       - id: cargo-dist
         shell: bash
         run: |
-          dist build ${{ needs.plan.outputs.tag-flag }} --output-format=json "--artifacts=global" > dist-manifest.json
+          dist build ${{ needs.plan.outputs.tag-flag }} --allow-dirty --output-format=json "--artifacts=global" > dist-manifest.json
           echo "dist ran successfully"
 
           python3 scripts/ci_bundle_scip_runtime.py global dist-manifest.json target/distrib
@@ -330,7 +330,7 @@ jobs:
       - id: host
         shell: bash
         run: |
-          dist host ${{ needs.plan.outputs.tag-flag }} --steps=upload --steps=release --output-format=json > dist-manifest.json
+          dist host ${{ needs.plan.outputs.tag-flag }} --allow-dirty --steps=upload --steps=release --output-format=json > dist-manifest.json
           echo "artifacts uploaded and released successfully"
           cat dist-manifest.json
           echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/v-release.yml
+++ b/.github/workflows/v-release.yml
@@ -226,6 +226,7 @@ jobs:
           # Actually do builds and make zips and whatnot
           dist build ${{ needs.plan.outputs.tag-flag }} --print=linkage --output-format=json ${{ matrix.dist_args }} > dist-manifest.json
           echo "dist ran successfully"
+          uv run python scripts/ci_bundle_scip_runtime.py local dist-manifest.json
       - id: cargo-dist
         name: Post-build
         # We force bash here just because github makes it really hard to get values up
@@ -280,6 +281,7 @@ jobs:
           dist build ${{ needs.plan.outputs.tag-flag }} --output-format=json "--artifacts=global" > dist-manifest.json
           echo "dist ran successfully"
 
+          python3 scripts/ci_bundle_scip_runtime.py global dist-manifest.json target/distrib
           # Parse out what we just built and upload it to scratch storage
           echo "paths<<EOF" >> "$GITHUB_OUTPUT"
           jq --raw-output ".upload_files[]" dist-manifest.json >> "$GITHUB_OUTPUT"

--- a/RELEASE_POLICY.md
+++ b/RELEASE_POLICY.md
@@ -154,7 +154,11 @@ GitHub Release state if cargo-dist reached the final publish step.
   ```
 
   CI runs the same generation and patch step, then diffs
-  `.github/workflows/v-release.yml` to catch drift.
+  `.github/workflows/v-release.yml` to catch drift. The patched workflow and CI
+  preflight use cargo-dist's CLI `--allow-dirty` flag on plan/build/host
+  commands so those commands accept Arco's deterministic post-generation hooks.
+  Do not set `[dist] allow-dirty = ["ci"]`; that prevents the verification
+  script from running `dist generate --mode=ci`.
 
 - `scripts/ci_bundle_scip_runtime.py` owns the release archive and installer
   post-processing for SCIP. Local artifact jobs copy the SCIP runtime files from

--- a/RELEASE_POLICY.md
+++ b/RELEASE_POLICY.md
@@ -23,6 +23,9 @@ Every release version is shared across:
   `Cargo.toml`, `pyproject.toml`, and `uv.lock`), and tag creation.
 - `cargo-dist` owns cross-platform CLI binaries, installers, checksums, dist
   manifests, and publishing the GitHub Release.
+- Arco post-processes cargo-dist's local CLI archives to bundle SCIP runtime
+  libraries beside the `arco` binary, then patches the generated installers so
+  those libraries are installed with the binary.
 - `ci.yaml` owns pre-merge validation: version consistency checks, code
   quality, tests, solver smoke checks, cross-OS release compilation, and
   release-please preflight checks that build cargo-dist/Python artifacts without
@@ -66,6 +69,10 @@ release-please owns every versioned file, verifies all release version metadata
 matches, builds Python wheels across the release platform/Python matrix, and
 uses cargo-dist's planned target matrix to build local CLI artifacts without
 uploading or publishing them.
+
+The cargo-dist preflight also applies Arco's SCIP runtime bundling step to the
+local archives before it asks cargo-dist which files would be uploaded. This
+keeps the `curl | sh` and PowerShell installer paths covered before release.
 
 CI caches native solver bundles and cargo-dist binaries by runner platform and
 tool version. These caches are runtime optimizations only; cache misses must
@@ -138,15 +145,23 @@ GitHub Release state if cargo-dist reached the final publish step.
 ## Maintenance Notes
 
 - Do not hand-edit cargo-dist build steps in `v-release.yml`. Put Arco-specific
-  runner setup in `.github/build-setup.yml`, then run:
+  runner setup in `.github/build-setup.yml`; put deterministic generated
+  workflow patches in `scripts/ci_bundle_scip_runtime.py`; then run:
 
   ```bash
   dist generate --mode=ci
-  mv .github/workflows/release.yml .github/workflows/v-release.yml
+  python3 scripts/ci_bundle_scip_runtime.py workflow .github/workflows/v-release.yml
   ```
 
-  CI runs the same generation and diffs the generated `release.yml` against
-  `v-release.yml` to catch drift.
+  CI runs the same generation and patch step, then diffs
+  `.github/workflows/v-release.yml` to catch drift.
+
+- `scripts/ci_bundle_scip_runtime.py` owns the release archive and installer
+  post-processing for SCIP. Local artifact jobs copy the SCIP runtime files from
+  the solver setup environment into each cargo-dist archive and update the
+  archive checksum. The global artifact job reads the local dist manifests and
+  patches the generated shell and PowerShell installers so the bundled libraries
+  are moved into the install directory with `arco`.
 
 - `main` is the source of truth for CI, release workflows, and tooling.
   If we create a maintenance branch after `1.0`, sync workflow/tooling changes

--- a/crates/arco-cli/build.rs
+++ b/crates/arco-cli/build.rs
@@ -1,0 +1,14 @@
+fn main() {
+    println!("cargo:rerun-if-env-changed=CARGO_CFG_TARGET_OS");
+
+    match std::env::var("CARGO_CFG_TARGET_OS").as_deref() {
+        Ok("linux") => {
+            // SCIP's libgfortran dependency also needs to resolve from the install dir.
+            println!("cargo:rustc-link-arg-bin=arco=-Wl,--disable-new-dtags,-rpath,$ORIGIN");
+        }
+        Ok("macos") => {
+            println!("cargo:rustc-link-arg-bin=arco=-Wl,-rpath,@loader_path");
+        }
+        _ => {}
+    }
+}

--- a/scripts/ci_bundle_scip_runtime.py
+++ b/scripts/ci_bundle_scip_runtime.py
@@ -1,0 +1,380 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import tarfile
+import tempfile
+import zipfile
+from pathlib import Path
+from typing import Any
+
+
+LOCAL_WORKFLOW_ANCHOR = (
+    "          dist build ${{ needs.plan.outputs.tag-flag }} --print=linkage "
+    "--output-format=json ${{ matrix.dist_args }} > dist-manifest.json\n"
+    '          echo "dist ran successfully"\n'
+)
+LOCAL_WORKFLOW_COMMAND = (
+    "          uv run python scripts/ci_bundle_scip_runtime.py local "
+    "dist-manifest.json\n"
+)
+GLOBAL_WORKFLOW_ANCHOR = (
+    "          dist build ${{ needs.plan.outputs.tag-flag }} --output-format=json "
+    '"--artifacts=global" > dist-manifest.json\n'
+    '          echo "dist ran successfully"\n\n'
+)
+GLOBAL_WORKFLOW_COMMAND = (
+    "          python3 scripts/ci_bundle_scip_runtime.py global "
+    "dist-manifest.json target/distrib\n"
+)
+
+MACOS_GCC_LIBS = (
+    "libgcc_s.1.1.dylib",
+    "libgfortran.5.dylib",
+    "libquadmath.0.dylib",
+)
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(path: Path, data: dict[str, Any]) -> None:
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as file:
+        for chunk in iter(lambda: file.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def target_env_path(name: str, target: str) -> Path:
+    suffix = target.replace("-", "_")
+    value = os.environ.get(f"{name}_{suffix}") or os.environ.get(name)
+    if not value:
+        raise SystemExit(f"{name}_{suffix} or {name} is required for {target}")
+    return Path(value)
+
+
+def required(path: Path) -> Path:
+    if not path.is_file():
+        raise SystemExit(f"required runtime file does not exist: {path}")
+    return path
+
+
+def ldd_path(binary: Path, library: str) -> Path | None:
+    result = subprocess.run(
+        ["ldd", str(binary)],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+    )
+    for line in result.stdout.splitlines():
+        match = re.search(rf"\b{re.escape(library)}\s+=>\s+(\S+)", line)
+        if match and Path(match.group(1)).is_file():
+            return Path(match.group(1))
+    return None
+
+
+def runtime_files(target: str) -> list[Path]:
+    scip_lib = target_env_path("ARCO_SCIP_LIBRARY_PATH", target)
+
+    if target.endswith("-unknown-linux-gnu"):
+        fortran_lib = target_env_path("ARCO_SCIP_FORTRAN_RUNTIME_PATH", target)
+        files = [
+            required(scip_lib / "libscip.so.10.0"),
+            required(fortran_lib / "libgfortran.so.5"),
+        ]
+        quadmath = fortran_lib / "libquadmath.so.0"
+        if not quadmath.is_file():
+            quadmath = ldd_path(files[1], "libquadmath.so.0")
+        if quadmath is not None:
+            files.append(required(quadmath))
+        return files
+
+    if target.endswith("-apple-darwin"):
+        gcc_lib = target_env_path("ARCO_SCIP_GCC_RUNTIME_PATH", target)
+        return [required(scip_lib / "libscip.10.0.dylib")] + [
+            required(gcc_lib / name) for name in MACOS_GCC_LIBS
+        ]
+
+    if "-pc-windows-" in target:
+        runtime_dir = scip_lib.parent / "bin"
+        if not runtime_dir.is_dir():
+            runtime_dir = scip_lib
+        files = sorted(runtime_dir.glob("*.dll"), key=lambda path: path.name.casefold())
+        if not any(path.name.casefold() == "libscip.dll" for path in files):
+            raise SystemExit(f"{runtime_dir} does not contain libscip.dll")
+        return files
+
+    raise SystemExit(f"unsupported SCIP runtime target: {target}")
+
+
+def archive_root(archive: Path) -> str:
+    if archive.name.endswith(".tar.gz"):
+        return archive.name.removesuffix(".tar.gz")
+    if archive.name.endswith(".zip"):
+        return archive.name.removesuffix(".zip")
+    raise SystemExit(f"unsupported archive format: {archive}")
+
+
+def extract_tar(archive: Path, dest: Path) -> None:
+    with tarfile.open(archive, "r:gz") as tar:
+        try:
+            tar.extractall(dest, filter="data")
+        except TypeError:
+            tar.extractall(dest)
+
+
+def copy_runtime_files(dest: Path, files: list[Path]) -> list[str]:
+    names: list[str] = []
+    for source in files:
+        shutil.copy2(source, dest / source.name)
+        names.append(source.name)
+    return names
+
+
+def repack_archive(archive: Path, files: list[Path]) -> list[str]:
+    if archive.name.endswith(".zip"):
+        names = [path.name for path in files]
+        replacement = archive.with_suffix(f"{archive.suffix}.tmp")
+        with zipfile.ZipFile(archive, "r") as existing:
+            with zipfile.ZipFile(replacement, "w", zipfile.ZIP_DEFLATED) as updated:
+                for info in existing.infolist():
+                    if info.filename not in names:
+                        updated.writestr(info, existing.read(info.filename))
+                for source in files:
+                    updated.write(source, source.name)
+        replacement.replace(archive)
+        return names
+
+    with tempfile.TemporaryDirectory(prefix="arco-scip-") as temp_name:
+        temp = Path(temp_name)
+        extract_tar(archive, temp)
+        root = temp / archive_root(archive)
+        if not root.is_dir():
+            raise SystemExit(f"{archive} did not unpack to {root.name}")
+        names = copy_runtime_files(root, files)
+        replacement = archive.with_name(f"{archive.name}.tmp")
+        with tarfile.open(replacement, "w:gz") as tar:
+            tar.add(root, arcname=root.name)
+        replacement.replace(archive)
+        return names
+
+
+def validate_linux_rpath(archive: Path) -> None:
+    if "linux" not in archive.name or not archive.name.endswith(".tar.gz"):
+        return
+    with tempfile.TemporaryDirectory(prefix="arco-scip-check-") as temp_name:
+        temp = Path(temp_name)
+        extract_tar(archive, temp)
+        binary = temp / archive_root(archive) / "arco"
+        result = subprocess.run(
+            ["readelf", "-d", str(binary)],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+    if "(RPATH)" not in result.stdout or "$ORIGIN" not in result.stdout:
+        raise SystemExit(f"{binary} is missing transitive $ORIGIN RPATH")
+
+
+def bundle_local(manifest_path: Path, distrib_dir: Path) -> None:
+    manifest = read_json(manifest_path)
+    for name, artifact in manifest.get("artifacts", {}).items():
+        if artifact.get("kind") != "executable-zip":
+            continue
+        target = artifact["target_triples"][0]
+        archive = distrib_dir / name
+        runtime_names = repack_archive(archive, runtime_files(target))
+        validate_linux_rpath(archive)
+
+        checksum = sha256(archive)
+        (distrib_dir / f"{archive.name}.sha256").write_text(
+            f"{checksum} *{archive.name}\n",
+            encoding="utf-8",
+        )
+        artifact["checksums"] = artifact.get("checksums") or {}
+        artifact["checksums"]["sha256"] = checksum
+        artifact["assets"] = [
+            asset
+            for asset in artifact.get("assets", [])
+            if asset.get("kind") != "dynamic_library"
+        ] + [
+            {"name": runtime_name, "path": runtime_name, "kind": "dynamic_library"}
+            for runtime_name in runtime_names
+        ]
+    write_json(manifest_path, manifest)
+
+
+def runtime_assets_by_archive(distrib_dir: Path) -> dict[str, list[str]]:
+    by_archive: dict[str, list[str]] = {}
+    for manifest_path in sorted(distrib_dir.glob("*-dist-manifest.json")):
+        for name, artifact in read_json(manifest_path).get("artifacts", {}).items():
+            libs = [
+                asset["name"]
+                for asset in artifact.get("assets", [])
+                if asset.get("kind") == "dynamic_library"
+            ]
+            if libs:
+                by_archive[name] = libs
+    return by_archive
+
+
+def shell_array(libs: list[str]) -> str:
+    return " ".join(libs)
+
+
+def json_array(libs: list[str]) -> str:
+    return ",".join(json.dumps(lib) for lib in libs)
+
+
+def replace_shell_var(block: str, name: str, value: str, quote: str = '"') -> str:
+    pattern = re.compile(rf'(?m)^(\s*{re.escape(name)}=)(?:"[^"]*"|\'[^\']*\')$')
+    updated, count = pattern.subn(
+        lambda match: f"{match.group(1)}{quote}{value}{quote}", block
+    )
+    if count != 1:
+        raise SystemExit(f"missing {name} in shell installer block")
+    return updated
+
+
+def patch_shell_installer(text: str, libs_by_archive: dict[str, list[str]]) -> str:
+    for archive, libs in libs_by_archive.items():
+        pattern = re.compile(rf'(?ms)^(\s*"{re.escape(archive)}"\)\n)(.*?^\s*;;)')
+        match = pattern.search(text)
+        if not match:
+            continue
+        block = replace_shell_var(match.group(0), "_libs", shell_array(libs))
+        block = replace_shell_var(block, "_libs_js_array", json_array(libs), "'")
+        text = text[: match.start()] + block + text[match.end() :]
+    return text.replace(
+        'ensure chmod +x "$_lib_install_dir/$_lib_name"',
+        'ensure chmod +x "$_lib_install_temp/$_lib_name"',
+    )
+
+
+def ps_array(libs: list[str]) -> str:
+    return "@(" + ", ".join(json.dumps(lib) for lib in libs) + ")"
+
+
+def patch_powershell_installer(text: str, libs_by_archive: dict[str, list[str]]) -> str:
+    def patch_block(match: re.Match[str]) -> str:
+        block = match.group(0)
+        archive = re.search(r'"artifact_name"\s*=\s*"([^"]+)"', block)
+        if archive is None or archive.group(1) not in libs_by_archive:
+            return block
+        return re.sub(
+            r'(?m)^(\s*"libs"\s*=\s*)@\([^)]*\)$',
+            lambda libs_match: (
+                f"{libs_match.group(1)}{ps_array(libs_by_archive[archive.group(1)])}"
+            ),
+            block,
+            count=1,
+        )
+
+    return re.sub(r'(?ms)^    "[^"]+" = @\{\n.*?^    \}', patch_block, text)
+
+
+def rewrite_sha256_sum(path: Path, checksums: dict[str, str]) -> None:
+    if not path.exists():
+        return
+    lines = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        match = re.match(r"^[0-9a-fA-F]{64} \*(.+)$", line)
+        if match and match.group(1) in checksums:
+            lines.append(f"{checksums[match.group(1)]} *{match.group(1)}")
+        else:
+            lines.append(line)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def bundle_global(manifest_path: Path, distrib_dir: Path) -> None:
+    libs_by_archive = runtime_assets_by_archive(distrib_dir)
+    if not libs_by_archive:
+        raise SystemExit(f"no bundled SCIP runtime assets found in {distrib_dir}")
+
+    changed: list[Path] = []
+    for filename, patcher in {
+        "arco-cli-installer.sh": patch_shell_installer,
+        "arco-cli-installer.ps1": patch_powershell_installer,
+    }.items():
+        path = distrib_dir / filename
+        if not path.exists():
+            continue
+        original = path.read_text(encoding="utf-8")
+        updated = patcher(original, libs_by_archive)
+        if updated != original:
+            path.write_text(updated, encoding="utf-8")
+            changed.append(path)
+
+    checksums = {path.name: sha256(path) for path in changed}
+    rewrite_sha256_sum(distrib_dir / "sha256.sum", checksums)
+
+    manifest = read_json(manifest_path)
+    for name, checksum in checksums.items():
+        artifact = manifest.get("artifacts", {}).get(name)
+        if artifact and artifact.get("checksums"):
+            artifact["checksums"]["sha256"] = checksum
+    write_json(manifest_path, manifest)
+
+
+def insert_after(text: str, anchor: str, insertion: str) -> str:
+    if insertion in text:
+        return text
+    index = text.find(anchor)
+    if index == -1:
+        raise SystemExit(f"missing workflow anchor: {anchor.strip()}")
+    return text[: index + len(anchor)] + insertion + text[index + len(anchor) :]
+
+
+def patch_workflow(path: Path) -> None:
+    text = path.read_text(encoding="utf-8")
+    text = insert_after(text, LOCAL_WORKFLOW_ANCHOR, LOCAL_WORKFLOW_COMMAND)
+    text = insert_after(text, GLOBAL_WORKFLOW_ANCHOR, GLOBAL_WORKFLOW_COMMAND)
+    path.write_text(text, encoding="utf-8")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    subcommands = parser.add_subparsers(dest="command", required=True)
+
+    local = subcommands.add_parser("local")
+    local.add_argument("manifest", type=Path)
+    local.add_argument("--distrib-dir", type=Path, default=Path("target/distrib"))
+
+    global_cmd = subcommands.add_parser("global")
+    global_cmd.add_argument("manifest", type=Path)
+    global_cmd.add_argument("distrib_dir", type=Path)
+
+    workflow = subcommands.add_parser("workflow")
+    workflow.add_argument(
+        "path", type=Path, default=Path(".github/workflows/v-release.yml")
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.command == "local":
+        bundle_local(args.manifest, args.distrib_dir)
+    elif args.command == "global":
+        bundle_global(args.manifest, args.distrib_dir)
+    elif args.command == "workflow":
+        patch_workflow(args.path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci_bundle_scip_runtime.py
+++ b/scripts/ci_bundle_scip_runtime.py
@@ -15,23 +15,54 @@ from pathlib import Path
 from typing import Any
 
 
-LOCAL_WORKFLOW_ANCHOR = (
+PLAN_WORKFLOW_COMMAND = (
+    "          dist ${{ (inputs.tag && inputs.tag != 'dry-run' && "
+    "format('host --steps=create --tag={0}', inputs.tag)) || 'plan' }} "
+    "--output-format=json > plan-dist-manifest.json\n"
+)
+PLAN_WORKFLOW_COMMAND_ALLOW_DIRTY = (
+    "          dist ${{ (inputs.tag && inputs.tag != 'dry-run' && "
+    "format('host --steps=create --tag={0}', inputs.tag)) || 'plan' }} "
+    "--allow-dirty --output-format=json > plan-dist-manifest.json\n"
+)
+LOCAL_WORKFLOW_BUILD = (
     "          dist build ${{ needs.plan.outputs.tag-flag }} --print=linkage "
     "--output-format=json ${{ matrix.dist_args }} > dist-manifest.json\n"
-    '          echo "dist ran successfully"\n'
+)
+LOCAL_WORKFLOW_BUILD_ALLOW_DIRTY = (
+    "          dist build ${{ needs.plan.outputs.tag-flag }} --allow-dirty "
+    "--print=linkage --output-format=json ${{ matrix.dist_args }} "
+    "> dist-manifest.json\n"
+)
+LOCAL_WORKFLOW_ANCHOR = (
+    LOCAL_WORKFLOW_BUILD_ALLOW_DIRTY + '          echo "dist ran successfully"\n'
 )
 LOCAL_WORKFLOW_COMMAND = (
     "          uv run python scripts/ci_bundle_scip_runtime.py local "
     "dist-manifest.json\n"
 )
-GLOBAL_WORKFLOW_ANCHOR = (
+GLOBAL_WORKFLOW_BUILD = (
     "          dist build ${{ needs.plan.outputs.tag-flag }} --output-format=json "
     '"--artifacts=global" > dist-manifest.json\n'
-    '          echo "dist ran successfully"\n\n'
+)
+GLOBAL_WORKFLOW_BUILD_ALLOW_DIRTY = (
+    "          dist build ${{ needs.plan.outputs.tag-flag }} --allow-dirty "
+    '--output-format=json "--artifacts=global" > dist-manifest.json\n'
+)
+GLOBAL_WORKFLOW_ANCHOR = (
+    GLOBAL_WORKFLOW_BUILD_ALLOW_DIRTY + '          echo "dist ran successfully"\n\n'
 )
 GLOBAL_WORKFLOW_COMMAND = (
     "          python3 scripts/ci_bundle_scip_runtime.py global "
     "dist-manifest.json target/distrib\n"
+)
+HOST_WORKFLOW_COMMAND = (
+    "          dist host ${{ needs.plan.outputs.tag-flag }} --steps=upload "
+    "--steps=release --output-format=json > dist-manifest.json\n"
+)
+HOST_WORKFLOW_COMMAND_ALLOW_DIRTY = (
+    "          dist host ${{ needs.plan.outputs.tag-flag }} --allow-dirty "
+    "--steps=upload --steps=release --output-format=json > dist-manifest.json\n"
 )
 
 MACOS_GCC_LIBS = (
@@ -330,6 +361,15 @@ def bundle_global(manifest_path: Path, distrib_dir: Path) -> None:
     write_json(manifest_path, manifest)
 
 
+def replace_workflow_command(text: str, command: str, replacement: str) -> str:
+    if replacement in text:
+        return text
+    count = text.count(command)
+    if count != 1:
+        raise SystemExit(f"expected one workflow command: {command.strip()}")
+    return text.replace(command, replacement, 1)
+
+
 def insert_after(text: str, anchor: str, insertion: str) -> str:
     if insertion in text:
         return text
@@ -341,6 +381,18 @@ def insert_after(text: str, anchor: str, insertion: str) -> str:
 
 def patch_workflow(path: Path) -> None:
     text = path.read_text(encoding="utf-8")
+    text = replace_workflow_command(
+        text, PLAN_WORKFLOW_COMMAND, PLAN_WORKFLOW_COMMAND_ALLOW_DIRTY
+    )
+    text = replace_workflow_command(
+        text, LOCAL_WORKFLOW_BUILD, LOCAL_WORKFLOW_BUILD_ALLOW_DIRTY
+    )
+    text = replace_workflow_command(
+        text, GLOBAL_WORKFLOW_BUILD, GLOBAL_WORKFLOW_BUILD_ALLOW_DIRTY
+    )
+    text = replace_workflow_command(
+        text, HOST_WORKFLOW_COMMAND, HOST_WORKFLOW_COMMAND_ALLOW_DIRTY
+    )
     text = insert_after(text, LOCAL_WORKFLOW_ANCHOR, LOCAL_WORKFLOW_COMMAND)
     text = insert_after(text, GLOBAL_WORKFLOW_ANCHOR, GLOBAL_WORKFLOW_COMMAND)
     path.write_text(text, encoding="utf-8")

--- a/scripts/ci_cargo_dist_preflight.sh
+++ b/scripts/ci_cargo_dist_preflight.sh
@@ -47,6 +47,6 @@ if [[ "${dist_plan_args}" != "${expected_args}" ]]; then
 	exit 1
 fi
 
-dist build --print=linkage --output-format=json "${dist_args[@]}" >dist-manifest.json
+dist build --allow-dirty --print=linkage --output-format=json "${dist_args[@]}" >dist-manifest.json
 uv run python scripts/ci_bundle_scip_runtime.py local dist-manifest.json
 dist print-upload-files-from-manifest --manifest dist-manifest.json

--- a/scripts/ci_cargo_dist_preflight.sh
+++ b/scripts/ci_cargo_dist_preflight.sh
@@ -48,4 +48,5 @@ if [[ "${dist_plan_args}" != "${expected_args}" ]]; then
 fi
 
 dist build --print=linkage --output-format=json "${dist_args[@]}" >dist-manifest.json
+uv run python scripts/ci_bundle_scip_runtime.py local dist-manifest.json
 dist print-upload-files-from-manifest --manifest dist-manifest.json

--- a/scripts/ci_dist_plan_output.sh
+++ b/scripts/ci_dist_plan_output.sh
@@ -4,5 +4,5 @@ set -euo pipefail
 readonly github_output="${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
 readonly manifest_path="plan-dist-manifest.json"
 
-dist plan --output-format=json >"${manifest_path}"
+dist plan --allow-dirty --output-format=json >"${manifest_path}"
 printf 'artifacts_matrix=%s\n' "$(jq -c '.ci.github.artifacts_matrix' "${manifest_path}")" >>"${github_output}"

--- a/scripts/ci_verify_generated_dist_workflow.sh
+++ b/scripts/ci_verify_generated_dist_workflow.sh
@@ -2,4 +2,5 @@
 set -euo pipefail
 
 dist generate --mode=ci
+python3 scripts/ci_bundle_scip_runtime.py workflow .github/workflows/v-release.yml
 git diff --exit-code -- .github/workflows/v-release.yml

--- a/scripts/test_ci_bundle_scip_runtime.py
+++ b/scripts/test_ci_bundle_scip_runtime.py
@@ -55,29 +55,28 @@ def test_patch_powershell_installer_sets_libs_for_matching_archive() -> None:
     assert '"libs" = @("libscip.dll", "ipopt-3.dll")' in patched
 
 
-def test_patch_workflow_is_idempotent() -> None:
+def test_patch_workflow_adds_allow_dirty_and_is_idempotent(tmp_path: Path) -> None:
     bundle = load_bundle_module()
-    workflow = bundle.LOCAL_WORKFLOW_ANCHOR + bundle.GLOBAL_WORKFLOW_ANCHOR
-
-    patched = bundle.insert_after(
-        workflow,
-        bundle.LOCAL_WORKFLOW_ANCHOR,
-        bundle.LOCAL_WORKFLOW_COMMAND,
-    )
-    patched = bundle.insert_after(
-        patched,
-        bundle.GLOBAL_WORKFLOW_ANCHOR,
-        bundle.GLOBAL_WORKFLOW_COMMAND,
+    workflow_path = tmp_path / "v-release.yml"
+    workflow_path.write_text(
+        bundle.PLAN_WORKFLOW_COMMAND
+        + bundle.LOCAL_WORKFLOW_BUILD
+        + '          echo "dist ran successfully"\n'
+        + bundle.GLOBAL_WORKFLOW_BUILD
+        + '          echo "dist ran successfully"\n\n'
+        + bundle.HOST_WORKFLOW_COMMAND,
+        encoding="utf-8",
     )
 
-    assert (
-        bundle.insert_after(
-            patched,
-            bundle.LOCAL_WORKFLOW_ANCHOR,
-            bundle.LOCAL_WORKFLOW_COMMAND,
-        )
-        == patched
-    )
+    bundle.patch_workflow(workflow_path)
+    patched = workflow_path.read_text(encoding="utf-8")
+    bundle.patch_workflow(workflow_path)
+
+    assert workflow_path.read_text(encoding="utf-8") == patched
+    assert bundle.PLAN_WORKFLOW_COMMAND_ALLOW_DIRTY in patched
+    assert bundle.LOCAL_WORKFLOW_BUILD_ALLOW_DIRTY in patched
+    assert bundle.GLOBAL_WORKFLOW_BUILD_ALLOW_DIRTY in patched
+    assert bundle.HOST_WORKFLOW_COMMAND_ALLOW_DIRTY in patched
     assert bundle.LOCAL_WORKFLOW_COMMAND in patched
     assert bundle.GLOBAL_WORKFLOW_COMMAND in patched
 

--- a/scripts/test_ci_bundle_scip_runtime.py
+++ b/scripts/test_ci_bundle_scip_runtime.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tarfile
+from pathlib import Path
+
+
+def load_bundle_module():
+    module_path = Path(__file__).with_name("ci_bundle_scip_runtime.py")
+    spec = importlib.util.spec_from_file_location("ci_bundle_scip_runtime", module_path)
+    if spec is None or spec.loader is None:
+        raise AssertionError(f"failed to load {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_patch_shell_installer_sets_libs_and_fixes_chmod() -> None:
+    bundle = load_bundle_module()
+    text = """
+        "arco-cli-x86_64-unknown-linux-gnu.tar.gz")
+            _libs=""
+            _libs_js_array=""
+            ;;
+    ensure chmod +x "$_lib_install_dir/$_lib_name"
+"""
+
+    patched = bundle.patch_shell_installer(
+        text,
+        {"arco-cli-x86_64-unknown-linux-gnu.tar.gz": ["libscip.so.10.0"]},
+    )
+
+    assert '_libs="libscip.so.10.0"' in patched
+    assert "_libs_js_array='\"libscip.so.10.0\"'" in patched
+    assert 'ensure chmod +x "$_lib_install_temp/$_lib_name"' in patched
+
+
+def test_patch_powershell_installer_sets_libs_for_matching_archive() -> None:
+    bundle = load_bundle_module()
+    text = """
+    "x86_64-pc-windows-msvc" = @{
+      "artifact_name" = "arco-cli-x86_64-pc-windows-msvc.zip"
+      "libs" = @()
+    }
+"""
+
+    patched = bundle.patch_powershell_installer(
+        text,
+        {"arco-cli-x86_64-pc-windows-msvc.zip": ["libscip.dll", "ipopt-3.dll"]},
+    )
+
+    assert '"libs" = @("libscip.dll", "ipopt-3.dll")' in patched
+
+
+def test_patch_workflow_is_idempotent() -> None:
+    bundle = load_bundle_module()
+    workflow = bundle.LOCAL_WORKFLOW_ANCHOR + bundle.GLOBAL_WORKFLOW_ANCHOR
+
+    patched = bundle.insert_after(
+        workflow,
+        bundle.LOCAL_WORKFLOW_ANCHOR,
+        bundle.LOCAL_WORKFLOW_COMMAND,
+    )
+    patched = bundle.insert_after(
+        patched,
+        bundle.GLOBAL_WORKFLOW_ANCHOR,
+        bundle.GLOBAL_WORKFLOW_COMMAND,
+    )
+
+    assert (
+        bundle.insert_after(
+            patched,
+            bundle.LOCAL_WORKFLOW_ANCHOR,
+            bundle.LOCAL_WORKFLOW_COMMAND,
+        )
+        == patched
+    )
+    assert bundle.LOCAL_WORKFLOW_COMMAND in patched
+    assert bundle.GLOBAL_WORKFLOW_COMMAND in patched
+
+
+def test_rewrite_sha256_sum_updates_existing_entry(tmp_path: Path) -> None:
+    bundle = load_bundle_module()
+    path = tmp_path / "sha256.sum"
+    path.write_text("0" * 64 + " *arco-cli-installer.sh\n", encoding="utf-8")
+
+    bundle.rewrite_sha256_sum(path, {"arco-cli-installer.sh": "1" * 64})
+
+    assert path.read_text(encoding="utf-8") == ("1" * 64 + " *arco-cli-installer.sh\n")
+
+
+def test_bundle_local_adds_runtime_files_and_manifest_assets(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    bundle = load_bundle_module()
+    distrib_dir = tmp_path / "target" / "distrib"
+    distrib_dir.mkdir(parents=True)
+    root = tmp_path / "arco-cli-x86_64-apple-darwin"
+    root.mkdir()
+    (root / "arco").write_text("fake", encoding="utf-8")
+
+    archive = distrib_dir / "arco-cli-x86_64-apple-darwin.tar.gz"
+    with tarfile.open(archive, "w:gz") as tar:
+        tar.add(root, arcname=root.name)
+
+    manifest_path = tmp_path / "dist-manifest.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "artifacts": {
+                    archive.name: {
+                        "kind": "executable-zip",
+                        "target_triples": ["x86_64-apple-darwin"],
+                        "assets": [{"name": "arco", "kind": "executable"}],
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    scip_lib = tmp_path / "scip" / "lib"
+    gcc_lib = tmp_path / "gcc"
+    scip_lib.mkdir(parents=True)
+    gcc_lib.mkdir()
+    (scip_lib / "libscip.10.0.dylib").write_text("scip", encoding="utf-8")
+    for name in bundle.MACOS_GCC_LIBS:
+        (gcc_lib / name).write_text(name, encoding="utf-8")
+    monkeypatch.setenv("ARCO_SCIP_LIBRARY_PATH_x86_64_apple_darwin", str(scip_lib))
+    monkeypatch.setenv("ARCO_SCIP_GCC_RUNTIME_PATH_x86_64_apple_darwin", str(gcc_lib))
+
+    bundle.bundle_local(manifest_path, distrib_dir)
+
+    with tarfile.open(archive, "r:gz") as tar:
+        names = set(tar.getnames())
+    assert f"{root.name}/libscip.10.0.dylib" in names
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assets = manifest["artifacts"][archive.name]["assets"]
+    assert {
+        "name": "libscip.10.0.dylib",
+        "path": "libscip.10.0.dylib",
+        "kind": "dynamic_library",
+    } in assets


### PR DESCRIPTION
## Summary

This fixes the v0.8.1 installer regression where a fresh `curl | sh` install produced:

```text
arco: error while loading shared libraries: libscip.so.10.0: cannot open shared object file
```

The regression came from the CLI now linking SCIP, while cargo-dist archives and installers still only shipped/moved the `arco` binary. The archive did not contain `libscip.so.10.0`, and the generated shell installer would not install shared libraries unless its `_libs` metadata was populated.

## Changes

- Add a CLI build script that emits relative loader paths for bundled runtime libraries.
- Add one release helper, `scripts/ci_bundle_scip_runtime.py`, with three subcommands:
  - `local`: copy SCIP runtime libraries into cargo-dist CLI archives and update checksums/manifests.
  - `global`: patch generated shell and PowerShell installers so those libraries are installed beside `arco`.
  - `workflow`: deterministically reapply the two cargo-dist workflow hook lines after `dist generate`.
- Wire the bundling step into release preflight and generated `v-release.yml` verification.
- Document the generated-plus-patched cargo-dist workflow in `RELEASE_POLICY.md`.
- Add focused tests for the helper’s archive, installer, checksum, and workflow patch behavior.

## Validation

- `uv run --no-project --with pytest pytest scripts/test_ci_bundle_scip_runtime.py -q`
- `uv run --no-project --with ruff ruff format --check scripts/ci_bundle_scip_runtime.py scripts/test_ci_bundle_scip_runtime.py`
- `uv run --no-project --with ruff ruff check scripts/ci_bundle_scip_runtime.py scripts/test_ci_bundle_scip_runtime.py`
- `python3 -m py_compile scripts/ci_bundle_scip_runtime.py scripts/test_ci_bundle_scip_runtime.py`
- `bash -n scripts/ci_cargo_dist_preflight.sh scripts/ci_verify_generated_dist_workflow.sh`
- `cargo fmt --all -- --check`
- `bash scripts/ci_verify_generated_dist_workflow.sh`
- Temp Linux archive bundling check verified `libscip.so.10.0`, `libgfortran.so.5`, and `libquadmath.so.0` are added.
- Temp global installer patch check verified real generated shell/PowerShell installer templates receive runtime library metadata.
- Pre-push hooks passed: whitespace, large files, executable shebangs, typos, `ci cargo fmt`, `ci cargo clippy`, and `ci cargo test (fast)`.
