### PR TITLE
fix(python): ship complete source distributions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -721,10 +721,10 @@ jobs:
         python:
           - label: cp310
             version: "3.10"
-            wheel_features: ""
+            wheel_features: "pyo3/extension-module,xpress,scip-from-source"
           - label: abi3
             version: "3.11"
-            wheel_features: "pyo3/extension-module,pyo3/abi3-py311,xpress"
+            wheel_features: "pyo3/extension-module,pyo3/abi3-py311,xpress,scip-from-source"
         platform:
           - label: linux
             os: ubuntu-latest

--- a/.github/workflows/pypi-manual-release.yaml
+++ b/.github/workflows/pypi-manual-release.yaml
@@ -51,10 +51,10 @@ jobs:
         python:
           - label: cp310
             version: "3.10"
-            wheel_features: ""
+            wheel_features: "pyo3/extension-module,xpress,scip-from-source"
           - label: abi3
             version: "3.11"
-            wheel_features: "pyo3/extension-module,pyo3/abi3-py311,xpress"
+            wheel_features: "pyo3/extension-module,pyo3/abi3-py311,xpress,scip-from-source"
         platform:
           - label: linux
             os: ubuntu-latest

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -195,10 +195,10 @@ jobs:
         python:
           - label: cp310
             version: "3.10"
-            wheel_features: ""
+            wheel_features: "pyo3/extension-module,xpress,scip-from-source"
           - label: abi3
             version: "3.11"
-            wheel_features: "pyo3/extension-module,pyo3/abi3-py311,xpress"
+            wheel_features: "pyo3/extension-module,pyo3/abi3-py311,xpress,scip-from-source"
         platform:
           - label: linux
             os: ubuntu-latest

--- a/RELEASE_POLICY.md
+++ b/RELEASE_POLICY.md
@@ -63,8 +63,9 @@ publishes artifacts for that tag.
 Release-please PRs update version metadata and `CHANGELOG.md`, which makes CI
 run the release preflight before the PR can merge. The preflight checks that
 release-please owns every versioned file, verifies all release version metadata
-matches, builds Python wheels across the release platform/Python matrix, and
-uses cargo-dist's planned target matrix to build local CLI artifacts without
+matches, builds Python wheels across the release platform/Python matrix,
+validates the Python source distribution's Cargo workspace, and uses
+cargo-dist's planned target matrix to build local CLI artifacts without
 uploading or publishing them.
 
 CI caches native solver bundles and cargo-dist binaries by runner platform and

--- a/bindings/python-core/Cargo.toml
+++ b/bindings/python-core/Cargo.toml
@@ -10,10 +10,6 @@ authors = { workspace = true }
 license-file = { workspace = true }
 publish = false
 
-[lib]
-path = "../python/src/core.rs"
-test = false
-
 [dependencies]
 pyo3 = { workspace = true }
 pyo3-macros = { workspace = true }

--- a/bindings/python-core/src/lib.rs
+++ b/bindings/python-core/src/lib.rs
@@ -1,0 +1,9 @@
+//! Python bindings for Arco optimization using PyO3.
+//!
+//! This crate exposes Arco's model builder and solver to Python with zero-copy access
+//! to solution data through memoryview.
+
+include!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../python/src/core.rs"
+));

--- a/bindings/python-types/Cargo.toml
+++ b/bindings/python-types/Cargo.toml
@@ -10,10 +10,6 @@ authors = { workspace = true }
 license-file = { workspace = true }
 publish = false
 
-[lib]
-path = "../python/src/types_lib.rs"
-test = false
-
 [dependencies]
 pyo3 = { workspace = true }
 pyo3-macros = { workspace = true }

--- a/bindings/python-types/src/lib.rs
+++ b/bindings/python-types/src/lib.rs
@@ -1,0 +1,6 @@
+//! Shared Python classes for Arco's Python extension.
+
+include!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../python/src/types_lib.rs"
+));

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -44,6 +44,7 @@ include = [
   "arco/arco.pyi",
   "arco/blocks.pyi",
   "BSD-3-Clause.txt",
+  { path = "third_party/**/*", format = "sdist" },
 ]
 python-source = "."
 

--- a/bindings/python/src/core.rs
+++ b/bindings/python/src/core.rs
@@ -1,7 +1,7 @@
-//! Python bindings for Arco optimization using PyO3
-//!
-//! This module exposes Arco's model builder and solver to Python with zero-copy access
-//! to solution data through memoryview.
+// Python bindings for Arco optimization using PyO3.
+//
+// This module exposes Arco's model builder and solver to Python with zero-copy access
+// to solution data through memoryview.
 
 mod py_modules;
 

--- a/bindings/python/src/types_lib.rs
+++ b/bindings/python/src/types_lib.rs
@@ -1,4 +1,4 @@
-//! Shared Python classes for Arco's Python extension.
+// Shared Python classes for Arco's Python extension.
 
 use pyo3::prelude::*;
 

--- a/bindings/python/tests/test_rust_boundaries.py
+++ b/bindings/python/tests/test_rust_boundaries.py
@@ -58,6 +58,23 @@ def test_python_package_builds_with_xpress_support_by_default() -> None:
     assert "xpress" in pyproject["tool"]["maturin"]["features"]
 
 
+def test_release_wheel_recipe_allows_the_abi3_matrix_features() -> None:
+    justfile = (ROOT / "justfile").read_text()
+
+    assert (
+        'PYTHON_WHEEL_FEATURES="${PYTHON_WHEEL_FEATURES:-pyo3/extension-module,xpress,scip-from-source}"'
+        in justfile
+    )
+
+    abi3_features = 'wheel_features: "pyo3/extension-module,pyo3/abi3-py311,xpress,scip-from-source"'
+    for workflow in (
+        ".github/workflows/ci.yaml",
+        ".github/workflows/pypi-manual-release.yaml",
+        ".github/workflows/release-please.yaml",
+    ):
+        assert abi3_features in (ROOT / workflow).read_text()
+
+
 def test_cli_cargo_depends_on_arco_ops_only_among_arco_modeling_crates() -> None:
     cargo_toml = (ROOT / "crates" / "arco-cli" / "Cargo.toml").read_text()
 

--- a/bindings/python/third_party
+++ b/bindings/python/third_party
@@ -1,0 +1,1 @@
+../../third_party

--- a/docs/how-to/release-python-distributions.md
+++ b/docs/how-to/release-python-distributions.md
@@ -10,7 +10,7 @@ Use this when a release is ready but a Python wheel build or PyPI upload fails.
 4. Let PyPI publish after all Python artifacts build.
 5. Verify the release files on PyPI.
 
-The wheel matrix is intentionally small: `cp310` and `abi3` across Linux, macOS arm64, and Windows. VS Code extension upload is separate and does not block PyPI publishing.
+The wheel matrix is intentionally small: `cp310` and `abi3` across Linux, macOS arm64, and Windows. The `abi3` wheels target CPython 3.11 and support Python 3.12, 3.13, and 3.14. VS Code extension upload is separate and does not block PyPI publishing.
 
 ## If a wheel job fails
 

--- a/justfile
+++ b/justfile
@@ -187,7 +187,9 @@ py-build-release-wheel: py-licenses
 
 [group: 'python']
 py-build-sdist:
-    uv run --project bindings/python --with maturin maturin sdist --manifest-path bindings/python/Cargo.toml --out dist
+    rm -f dist/*.tar.gz
+    uv run --no-project --with maturin maturin sdist --manifest-path bindings/python/Cargo.toml --out dist
+    uv run --no-project python scripts/validate_python_sdist.py --artifact dist/*.tar.gz
 
 [group: 'python']
 py-build:

--- a/justfile
+++ b/justfile
@@ -183,7 +183,7 @@ py-build-wheel: py-licenses
 
 [group: 'python']
 py-build-release-wheel: py-licenses
-    PYTHON_WHEEL_NO_DEFAULT_FEATURES=1 PYTHON_WHEEL_FEATURES="pyo3/extension-module,xpress,scip-from-source" ARCO_HIGHS_ENABLE_APPLE_STATIC=1 "{{ solver-build-env }}" bash scripts/build_python_wheel.sh
+    PYTHON_WHEEL_NO_DEFAULT_FEATURES="${PYTHON_WHEEL_NO_DEFAULT_FEATURES:-1}" PYTHON_WHEEL_FEATURES="${PYTHON_WHEEL_FEATURES:-pyo3/extension-module,xpress,scip-from-source}" ARCO_HIGHS_ENABLE_APPLE_STATIC=1 "{{ solver-build-env }}" bash scripts/build_python_wheel.sh
 
 [group: 'python']
 py-build-sdist:

--- a/scripts/validate_python_sdist.py
+++ b/scripts/validate_python_sdist.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import subprocess
+import sys
+import tarfile
+import tempfile
+from typing import Sequence
+
+
+def _parse_args(*, argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Verify that a Python source distribution has a valid Cargo workspace."
+    )
+    parser.add_argument("--artifact", required=True, type=Path)
+    return parser.parse_args(argv)
+
+
+def _extract_sdist(*, artifact: Path, destination: Path) -> Path:
+    with tarfile.open(artifact) as archive:
+        members = archive.getmembers()
+        top_levels = {member.name.split("/", maxsplit=1)[0] for member in members}
+        if len(top_levels) != 1:
+            raise ValueError(f"Expected one top-level directory in {artifact}")
+        archive.extractall(destination)
+    return destination / top_levels.pop()
+
+
+def _validate_cargo_workspace(*, source_root: Path) -> None:
+    subprocess.run(
+        ["cargo", "metadata", "--format-version", "1"],
+        check=True,
+        cwd=source_root,
+        stdout=subprocess.DEVNULL,
+    )
+
+
+def main(*, argv: Sequence[str]) -> int:
+    args = _parse_args(argv=argv)
+    artifact = args.artifact.resolve()
+    if not artifact.is_file():
+        raise FileNotFoundError(f"Source distribution does not exist: {artifact}")
+
+    with tempfile.TemporaryDirectory(prefix="arco-python-sdist-") as temporary_dir:
+        source_root = _extract_sdist(artifact=artifact, destination=Path(temporary_dir))
+        _validate_cargo_workspace(source_root=source_root)
+
+    print(f"sdist-ok artifact={artifact}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(argv=sys.argv[1:]))


### PR DESCRIPTION
## Summary
- package concrete targets for the split Python core and types crates
- include patched SCIP dependencies in the Python sdist
- validate the extracted sdist Cargo workspace during release builds

## Validation
- `just py-build-sdist`
- `cargo fmt --check`
- `cargo check -p arco-python-types --no-default-features`
- `ARCO_HIGHS_ENABLE_APPLE_STATIC=1 scripts/with_solver_build_env.sh cargo check -p arco-python-core --no-default-features`
- clippy for both Python crates
- Ruff checks for `scripts/validate_python_sdist.py`