### PR TITLE
feat(solver): add backend-independent LP algorithm selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Bug Fixes
+
+* **solver:** expose solver-independent `LpAlgorithm` selection with native HiGHS, Xpress, and SCIP mappings; restore Python Xpress feature detection after the binding-crate split
+
 ## [0.9.0](https://github.com/NatLabRockies/arco/compare/v0.8.2...v0.9.0) (2026-07-18)
 
 

--- a/bindings/python-core/Cargo.toml
+++ b/bindings/python-core/Cargo.toml
@@ -30,7 +30,7 @@ default = ["scip", "xpress"]
 ipopt = ["dep:arco-ops", "arco-ops/ipopt", "arco-python-types/ipopt"]
 scip = ["dep:arco-scip", "arco-scip/scip-bundled"]
 scip-from-source = ["dep:arco-scip", "arco-scip/scip-from-source"]
-xpress = ["dep:arco-xpress"]
+xpress = ["dep:arco-xpress", "arco-python-types/xpress"]
 
 [lints]
 workspace = true

--- a/bindings/python/arco/arco.pyi
+++ b/bindings/python/arco/arco.pyi
@@ -120,6 +120,15 @@ class SimplifyLevel(Enum):
     NONE: SimplifyLevel
     LIGHT: SimplifyLevel
 
+class LpAlgorithm(Enum):
+    AUTOMATIC: LpAlgorithm
+    PRIMAL_SIMPLEX: LpAlgorithm
+    DUAL_SIMPLEX: LpAlgorithm
+    BARRIER: LpAlgorithm
+    BARRIER_WITH_CROSSOVER: LpAlgorithm
+    PRIMAL_DUAL_FIRST_ORDER: LpAlgorithm
+    CONCURRENT: LpAlgorithm
+
 class SolutionStatus(Enum):
     OPTIMAL: SolutionStatus
     INFEASIBLE: SolutionStatus
@@ -170,6 +179,7 @@ class Solver:
         mip_gap: float | None = None,
         verbosity: int | None = None,
         log_to_console: bool | None = None,
+        lp_algorithm: LpAlgorithm | None = None,
         parameters: Mapping[str, str] | None = None,
         solver: str | None = None,
     ) -> None: ...
@@ -187,10 +197,14 @@ class Solver:
     def verbosity(self) -> int | None: ...
     @property
     def log_to_console(self) -> bool | None: ...
+    @property
+    def lp_algorithm(self) -> LpAlgorithm | None: ...
     def copy(
         self,
         *,
-        update: Mapping[str, bool | int | float | str | Mapping[str, str] | None]
+        update: Mapping[
+            str, bool | int | float | str | LpAlgorithm | Mapping[str, str] | None
+        ]
         | None = None,
     ) -> Solver: ...
 
@@ -228,6 +242,7 @@ class HiGHS(Solver):
         mip_gap: float | None = None,
         verbosity: int | None = None,
         log_to_console: bool | None = None,
+        lp_algorithm: LpAlgorithm | None = None,
         parameters: Mapping[str, str] | None = None,
         solver: str | None = None,
     ) -> None: ...
@@ -248,6 +263,7 @@ class Xpress(Solver):
         mip_gap: float | None = None,
         verbosity: int | None = None,
         log_to_console: bool | None = None,
+        lp_algorithm: LpAlgorithm | None = None,
         parameters: Mapping[str, str] | None = None,
         solver: str | None = None,
     ) -> None: ...
@@ -263,6 +279,7 @@ class Scip(Solver):
         mip_gap: float | None = None,
         verbosity: int | None = None,
         log_to_console: bool | None = None,
+        lp_algorithm: LpAlgorithm | None = None,
         parameters: Mapping[str, str] | None = None,
         solver: str | None = None,
     ) -> None: ...
@@ -849,6 +866,7 @@ class Model:
         time_limit: float | None = None,
         mip_gap: float | None = None,
         verbosity: int | None = None,
+        lp_algorithm: LpAlgorithm | None = None,
     ) -> SolveResult: ...
     def inspect(
         self,

--- a/bindings/python/src/core.rs
+++ b/bindings/python/src/core.rs
@@ -1111,7 +1111,7 @@ impl PyModel {
                     settings.verbosity = Some(v);
                 }
                 if let Some(algorithm) = lp_algorithm {
-                    settings.lp_algorithm = Some(algorithm);
+                    settings.set_lp_algorithm(algorithm);
                 }
                 pym::solver::validate_backend_settings("ipopt", &settings)?;
                 let _ = time_limit;

--- a/bindings/python/src/core.rs
+++ b/bindings/python/src/core.rs
@@ -413,7 +413,8 @@ mod py_exports;
 use py_exports::{
     BoundsSpec, PyBlockHandle, PyBlockPorts, PyBlockResults, PyBounds, PyComparisonSense,
     PyConstraint, PyConstraintArray, PyConstraintExpr, PyElasticHandle, PyExpr, PyExprArray,
-    PyIndexSet, PyModelSnapshot, PySense, PySimplifyLevel, PySlackVariable, PyVariable,
+    PyIndexSet, PyLpAlgorithm, PyModelSnapshot, PySense, PySimplifyLevel, PySlackVariable,
+    PyVariable,
     PyVariableArray, SolverSettings,
 };
 
@@ -1056,8 +1057,9 @@ impl PyModel {
     /// Optional solver controls include `time_limit`, `mip_gap`, and `verbosity`.
     /// Pass `solver=arco.Xpress()` to use FICO Xpress instead of the default HiGHS solver.
     #[pyo3(
-        signature = (*, solver=None, log_to_console=None, primal_start=None, time_limit=None, mip_gap=None, verbosity=None)
+        signature = (*, solver=None, log_to_console=None, primal_start=None, time_limit=None, mip_gap=None, verbosity=None, lp_algorithm=None)
     )]
+    #[allow(clippy::too_many_arguments)]
     fn solve(
         &mut self,
         py: Python<'_>,
@@ -1067,6 +1069,7 @@ impl PyModel {
         time_limit: Option<f64>,
         mip_gap: Option<f64>,
         verbosity: Option<u32>,
+        lp_algorithm: Option<PyLpAlgorithm>,
     ) -> PyResult<Py<PySolveResult>> {
         if primal_start
             .as_ref()
@@ -1087,6 +1090,7 @@ impl PyModel {
                 time_limit,
                 mip_gap,
                 verbosity,
+                lp_algorithm,
             );
         }
 
@@ -1106,6 +1110,10 @@ impl PyModel {
                 if let Some(v) = verbosity {
                     settings.verbosity = Some(v);
                 }
+                if let Some(algorithm) = lp_algorithm {
+                    settings.lp_algorithm = Some(algorithm);
+                }
+                pym::solver::validate_backend_settings("ipopt", &settings)?;
                 let _ = time_limit;
                 let _ = mip_gap;
                 let solver = pym::solver::PySolver { settings };
@@ -1124,6 +1132,7 @@ impl PyModel {
             time_limit,
             mip_gap,
             verbosity,
+            lp_algorithm,
         )?;
         self.last_solution = Some(py_result.clone_ref(py));
         Ok(py_result)
@@ -1610,8 +1619,17 @@ mod tests {
 
     #[test]
     fn solver_settings_rejects_zero_threads() {
-        let result =
-            SolverSettings::new(None, Some(0), None, None, None, None, None, BTreeMap::new());
+        let result = SolverSettings::new(
+            None,
+            Some(0),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            BTreeMap::new(),
+        );
         assert!(result.is_err());
     }
 
@@ -1621,6 +1639,7 @@ mod tests {
             None,
             None,
             Some(-0.5),
+            None,
             None,
             None,
             None,
@@ -1640,6 +1659,7 @@ mod tests {
             None,
             None,
             None,
+            None,
             BTreeMap::new(),
         );
         assert!(result.is_err());
@@ -1655,6 +1675,7 @@ mod tests {
             Some(-0.1),
             None,
             None,
+            None,
             BTreeMap::new(),
         );
         assert!(result.is_err());
@@ -1662,7 +1683,17 @@ mod tests {
 
     #[test]
     fn solver_settings_accepts_defaults() {
-        let result = SolverSettings::new(None, None, None, None, None, None, None, BTreeMap::new());
+        let result = SolverSettings::new(
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            BTreeMap::new(),
+        );
         assert!(result.is_ok());
     }
 }

--- a/bindings/python/src/enums.rs
+++ b/bindings/python/src/enums.rs
@@ -2,6 +2,7 @@
 
 use arco_model::expr::ComparisonSense;
 use arco_model::{Sense, SimplifyLevel};
+use arco_solver::LpAlgorithm;
 use pyo3::prelude::*;
 
 use crate::py_modules::errors::ConstraintSenseError;
@@ -136,10 +137,59 @@ impl From<SimplifyLevel> for PySimplifyLevel {
     }
 }
 
+/// Python enum for solver-independent LP algorithm selection.
+#[pyo3_macros::pyclass(from_py_object, name = "LpAlgorithm", eq, eq_int)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PyLpAlgorithm {
+    #[pyo3(name = "AUTOMATIC")]
+    Automatic,
+    #[pyo3(name = "PRIMAL_SIMPLEX")]
+    PrimalSimplex,
+    #[pyo3(name = "DUAL_SIMPLEX")]
+    DualSimplex,
+    #[pyo3(name = "BARRIER")]
+    Barrier,
+    #[pyo3(name = "BARRIER_WITH_CROSSOVER")]
+    BarrierWithCrossover,
+    #[pyo3(name = "PRIMAL_DUAL_FIRST_ORDER")]
+    PrimalDualFirstOrder,
+    #[pyo3(name = "CONCURRENT")]
+    Concurrent,
+}
+
+impl From<PyLpAlgorithm> for LpAlgorithm {
+    fn from(algorithm: PyLpAlgorithm) -> Self {
+        match algorithm {
+            PyLpAlgorithm::Automatic => LpAlgorithm::Automatic,
+            PyLpAlgorithm::PrimalSimplex => LpAlgorithm::PrimalSimplex,
+            PyLpAlgorithm::DualSimplex => LpAlgorithm::DualSimplex,
+            PyLpAlgorithm::Barrier => LpAlgorithm::Barrier,
+            PyLpAlgorithm::BarrierWithCrossover => LpAlgorithm::BarrierWithCrossover,
+            PyLpAlgorithm::PrimalDualFirstOrder => LpAlgorithm::PrimalDualFirstOrder,
+            PyLpAlgorithm::Concurrent => LpAlgorithm::Concurrent,
+        }
+    }
+}
+
+impl From<LpAlgorithm> for PyLpAlgorithm {
+    fn from(algorithm: LpAlgorithm) -> Self {
+        match algorithm {
+            LpAlgorithm::Automatic => PyLpAlgorithm::Automatic,
+            LpAlgorithm::PrimalSimplex => PyLpAlgorithm::PrimalSimplex,
+            LpAlgorithm::DualSimplex => PyLpAlgorithm::DualSimplex,
+            LpAlgorithm::Barrier => PyLpAlgorithm::Barrier,
+            LpAlgorithm::BarrierWithCrossover => PyLpAlgorithm::BarrierWithCrossover,
+            LpAlgorithm::PrimalDualFirstOrder => PyLpAlgorithm::PrimalDualFirstOrder,
+            LpAlgorithm::Concurrent => PyLpAlgorithm::Concurrent,
+        }
+    }
+}
+
 /// Register enum classes with the Python module.
 pub fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PySense>()?;
     m.add_class::<PyComparisonSense>()?;
     m.add_class::<PySimplifyLevel>()?;
+    m.add_class::<PyLpAlgorithm>()?;
     Ok(())
 }

--- a/bindings/python/src/model_blocks.rs
+++ b/bindings/python/src/model_blocks.rs
@@ -1,3 +1,4 @@
+use crate::py_modules::enums::PyLpAlgorithm;
 use crate::py_modules::errors::{BlockArtifactError, BlockContractError, BlockResultError};
 use crate::py_modules::serde_bridge;
 use crate::{BlockPort, PyModel, PyObject, PySolveResult};
@@ -715,6 +716,7 @@ pub(crate) struct LinkDef {
 
 impl PyModel {
     /// Execute composed block solve by delegating to BlockModel infrastructure.
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn solve_composed(
         &mut self,
         py: Python<'_>,
@@ -724,6 +726,7 @@ impl PyModel {
         time_limit: Option<f64>,
         mip_gap: Option<f64>,
         verbosity: Option<u32>,
+        lp_algorithm: Option<PyLpAlgorithm>,
     ) -> PyResult<Py<PySolveResult>> {
         if primal_start.is_some_and(|values| !values.is_empty()) {
             return Err(
@@ -811,6 +814,9 @@ impl PyModel {
                 }
                 if let Some(level) = verbosity {
                     solve_kwargs.set_item("verbosity", level)?;
+                }
+                if let Some(algorithm) = lp_algorithm {
+                    solve_kwargs.set_item("lp_algorithm", algorithm)?;
                 }
 
                 let solution_any = if solve_kwargs.is_empty() {

--- a/bindings/python/src/model_solve.rs
+++ b/bindings/python/src/model_solve.rs
@@ -47,7 +47,7 @@ pub(crate) fn solve_model(
     };
     let mut effective_settings = effective_settings.with_overrides(overrides)?;
     if let Some(lp_algorithm) = lp_algorithm {
-        effective_settings.lp_algorithm = Some(lp_algorithm);
+        effective_settings.set_lp_algorithm(lp_algorithm);
     }
     validate_backend_settings(&selected_backend, &effective_settings)?;
     if selected_backend == "xpress" && !crate::py_modules::solver::xpress_backend_enabled() {

--- a/bindings/python/src/model_solve.rs
+++ b/bindings/python/src/model_solve.rs
@@ -1,3 +1,4 @@
+use crate::py_modules::enums::PyLpAlgorithm;
 use crate::py_modules::errors;
 use crate::py_modules::solver::{
     SolveOverrides, detect_default_backend, extract_solver_settings, solve_failure_solution,
@@ -11,6 +12,7 @@ use arco_solver::{
 use pyo3::prelude::*;
 use pyo3::types::PyAny;
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn solve_model(
     model: &mut PyModel,
     py: Python<'_>,
@@ -20,6 +22,7 @@ pub(crate) fn solve_model(
     time_limit: Option<f64>,
     mip_gap: Option<f64>,
     verbosity: Option<u32>,
+    lp_algorithm: Option<PyLpAlgorithm>,
 ) -> PyResult<Py<PySolveResult>> {
     if model.inner.num_variables() == 0 {
         return Err(errors::generic_solver_error_to_py(SolverError::EmptyModel));
@@ -42,7 +45,10 @@ pub(crate) fn solve_model(
     } else {
         model.solver_settings.clone()
     };
-    let effective_settings = effective_settings.with_overrides(overrides)?;
+    let mut effective_settings = effective_settings.with_overrides(overrides)?;
+    if let Some(lp_algorithm) = lp_algorithm {
+        effective_settings.lp_algorithm = Some(lp_algorithm);
+    }
     validate_backend_settings(&selected_backend, &effective_settings)?;
     if selected_backend == "xpress" && !crate::py_modules::solver::xpress_backend_enabled() {
         return Err(errors::generic_solver_error_to_py(SolverError::SolverNotAvailable(

--- a/bindings/python/src/py_exports.rs
+++ b/bindings/python/src/py_exports.rs
@@ -1,7 +1,9 @@
 pub use crate::py_modules::arrays::{PyConstraintArray, PyExprArray, PyVariableArray};
 pub use crate::py_modules::bounds::{BoundsSpec, PyBounds};
 pub use crate::py_modules::constraint::PyConstraint;
-pub use crate::py_modules::enums::{PyComparisonSense, PySense, PySimplifyLevel};
+pub use crate::py_modules::enums::{
+    PyComparisonSense, PyLpAlgorithm, PySense, PySimplifyLevel,
+};
 pub use crate::py_modules::expr::{PyConstraintExpr, PyExpr};
 pub(crate) use crate::py_modules::handles::PyElasticHandle;
 pub use crate::py_modules::index_set::PyIndexSet;

--- a/bindings/python/src/solver.rs
+++ b/bindings/python/src/solver.rs
@@ -1,5 +1,6 @@
 //! Python wrappers for solver configuration and instances.
 
+use crate::py_modules::enums::PyLpAlgorithm;
 use crate::py_modules::errors::SolverInvalidSettingError;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
@@ -27,6 +28,7 @@ pub struct SolverSettings {
     pub(crate) mip_gap: Option<f64>,
     pub(crate) verbosity: Option<u32>,
     pub(crate) log_to_console: Option<bool>,
+    pub(crate) lp_algorithm: Option<PyLpAlgorithm>,
     pub(crate) parameters: SolverParameters,
 }
 
@@ -40,6 +42,7 @@ impl SolverSettings {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         presolve: Option<bool>,
         threads: Option<u32>,
@@ -48,6 +51,7 @@ impl SolverSettings {
         mip_gap: Option<f64>,
         verbosity: Option<u32>,
         log_to_console: Option<bool>,
+        lp_algorithm: Option<PyLpAlgorithm>,
         parameters: SolverParameters,
     ) -> PyResult<Self> {
         if let Some(threads) = threads {
@@ -72,6 +76,7 @@ impl SolverSettings {
             mip_gap,
             verbosity,
             log_to_console,
+            lp_algorithm,
             parameters,
         })
     }
@@ -85,6 +90,7 @@ impl SolverSettings {
             overrides.mip_gap.or(self.mip_gap),
             overrides.verbosity.or(self.verbosity),
             overrides.log_to_console.or(self.log_to_console),
+            self.lp_algorithm,
             self.parameters.clone(),
         )
     }
@@ -113,6 +119,9 @@ impl SolverSettings {
         if let Some(log_to_console) = self.log_to_console {
             config = config.with_log_to_console(log_to_console);
         }
+        if let Some(lp_algorithm) = self.lp_algorithm {
+            config = config.with_lp_algorithm(lp_algorithm.into());
+        }
         for (key, value) in &self.parameters {
             config = config.with_parameter(key.clone(), value.clone());
         }
@@ -126,16 +135,24 @@ pub fn validate_backend_settings(backend: &str, settings: &SolverSettings) -> Py
             "verbosity is not supported by the Xpress backend",
         ));
     }
+    if backend == "ipopt" && settings.lp_algorithm.is_some() {
+        return Err(SolverInvalidSettingError::new_err(
+            "lp_algorithm is not supported by the IPOPT backend",
+        ));
+    }
     Ok(())
 }
 
-fn extract_optional<T: for<'a, 'py> FromPyObject<'a, 'py, Error = PyErr>>(
+fn extract_optional<T: for<'a, 'py> FromPyObject<'a, 'py>>(
     value: &Bound<'_, PyAny>,
-) -> PyResult<Option<T>> {
+) -> PyResult<Option<T>>
+where
+    for<'a, 'py> <T as FromPyObject<'a, 'py>>::Error: Into<PyErr>,
+{
     if value.is_none() {
         return Ok(None);
     }
-    value.extract().map(Some)
+    value.extract().map(Some).map_err(Into::into)
 }
 
 fn merge_solver_parameter(
@@ -167,6 +184,7 @@ pub(crate) fn apply_solver_updates(
             "mip_gap" => settings.mip_gap = extract_optional(&value)?,
             "verbosity" => settings.verbosity = extract_optional(&value)?,
             "log_to_console" => settings.log_to_console = extract_optional(&value)?,
+            "lp_algorithm" => settings.lp_algorithm = extract_optional(&value)?,
             "parameters" => settings.parameters = value.extract()?,
             "solver" => {
                 let value: Option<String> = extract_optional(&value)?;
@@ -191,13 +209,14 @@ pub(crate) fn apply_solver_updates(
         settings.mip_gap,
         settings.verbosity,
         settings.log_to_console,
+        settings.lp_algorithm,
         settings.parameters,
     )
 }
 
 fn solver_repr(label: &str, settings: &SolverSettings) -> String {
     format!(
-        "{label}(presolve={:?}, threads={:?}, tolerance={:?}, time_limit={:?}, mip_gap={:?}, verbosity={:?}, log_to_console={:?}, parameters={:?})",
+        "{label}(presolve={:?}, threads={:?}, tolerance={:?}, time_limit={:?}, mip_gap={:?}, verbosity={:?}, log_to_console={:?}, lp_algorithm={:?}, parameters={:?})",
         settings.presolve,
         settings.threads,
         settings.tolerance,
@@ -205,6 +224,7 @@ fn solver_repr(label: &str, settings: &SolverSettings) -> String {
         settings.mip_gap,
         settings.verbosity,
         settings.log_to_console,
+        settings.lp_algorithm,
         settings.parameters,
     )
 }
@@ -308,7 +328,7 @@ impl PySolverProfile {
 impl PySolver {
     #[new]
     #[pyo3(
-        signature = (*, presolve=None, threads=None, tolerance=None, time_limit=None, mip_gap=None, verbosity=None, log_to_console=None, parameters=None, solver=None)
+        signature = (*, presolve=None, threads=None, tolerance=None, time_limit=None, mip_gap=None, verbosity=None, log_to_console=None, lp_algorithm=None, parameters=None, solver=None)
     )]
     #[allow(clippy::too_many_arguments)]
     fn new(
@@ -319,6 +339,7 @@ impl PySolver {
         mip_gap: Option<f64>,
         verbosity: Option<u32>,
         log_to_console: Option<bool>,
+        lp_algorithm: Option<PyLpAlgorithm>,
         parameters: Option<SolverParameters>,
         solver: Option<String>,
     ) -> PyResult<Self> {
@@ -330,6 +351,7 @@ impl PySolver {
             mip_gap,
             verbosity,
             log_to_console,
+            lp_algorithm,
             merge_solver_parameter(parameters, solver),
         )?;
         Ok(Self { settings })
@@ -370,6 +392,11 @@ impl PySolver {
         self.settings.log_to_console
     }
 
+    #[getter]
+    fn lp_algorithm(&self) -> Option<PyLpAlgorithm> {
+        self.settings.lp_algorithm
+    }
+
     #[pyo3(signature = (*, update=None))]
     fn copy(&self, py: Python<'_>, update: Option<&Bound<'_, PyDict>>) -> PyResult<Py<Self>> {
         let settings = apply_solver_updates(self.settings.clone(), update)?;
@@ -389,7 +416,7 @@ pub struct PyHiGHS;
 impl PyHiGHS {
     #[new]
     #[pyo3(
-        signature = (*, presolve=None, threads=None, tolerance=None, time_limit=None, mip_gap=None, verbosity=None, log_to_console=None, parameters=None, solver=None)
+        signature = (*, presolve=None, threads=None, tolerance=None, time_limit=None, mip_gap=None, verbosity=None, log_to_console=None, lp_algorithm=None, parameters=None, solver=None)
     )]
     #[allow(clippy::too_many_arguments)]
     fn new(
@@ -400,6 +427,7 @@ impl PyHiGHS {
         mip_gap: Option<f64>,
         verbosity: Option<u32>,
         log_to_console: Option<bool>,
+        lp_algorithm: Option<PyLpAlgorithm>,
         parameters: Option<SolverParameters>,
         solver: Option<String>,
     ) -> PyResult<PyClassInitializer<Self>> {
@@ -411,6 +439,7 @@ impl PyHiGHS {
             mip_gap,
             verbosity,
             log_to_console,
+            lp_algorithm,
             merge_solver_parameter(parameters, solver),
         )?;
         Ok(PyClassInitializer::from(PySolver { settings }).add_subclass(PyHiGHS))
@@ -442,7 +471,7 @@ pub struct PyXpress;
 impl PyXpress {
     #[new]
     #[pyo3(
-        signature = (*, presolve=None, threads=None, tolerance=None, time_limit=None, mip_gap=None, verbosity=None, log_to_console=None, parameters=None, solver=None)
+        signature = (*, presolve=None, threads=None, tolerance=None, time_limit=None, mip_gap=None, verbosity=None, log_to_console=None, lp_algorithm=None, parameters=None, solver=None)
     )]
     #[allow(clippy::too_many_arguments)]
     fn new(
@@ -453,6 +482,7 @@ impl PyXpress {
         mip_gap: Option<f64>,
         verbosity: Option<u32>,
         log_to_console: Option<bool>,
+        lp_algorithm: Option<PyLpAlgorithm>,
         parameters: Option<SolverParameters>,
         solver: Option<String>,
     ) -> PyResult<PyClassInitializer<Self>> {
@@ -464,6 +494,7 @@ impl PyXpress {
             mip_gap,
             verbosity,
             log_to_console,
+            lp_algorithm,
             merge_solver_parameter(parameters, solver),
         )?;
         validate_backend_settings("xpress", &settings)?;
@@ -497,7 +528,7 @@ pub struct PyScip;
 impl PyScip {
     #[new]
     #[pyo3(
-        signature = (*, presolve=None, threads=None, tolerance=None, time_limit=None, mip_gap=None, verbosity=None, log_to_console=None, parameters=None, solver=None)
+        signature = (*, presolve=None, threads=None, tolerance=None, time_limit=None, mip_gap=None, verbosity=None, log_to_console=None, lp_algorithm=None, parameters=None, solver=None)
     )]
     #[allow(clippy::too_many_arguments)]
     fn new(
@@ -508,6 +539,7 @@ impl PyScip {
         mip_gap: Option<f64>,
         verbosity: Option<u32>,
         log_to_console: Option<bool>,
+        lp_algorithm: Option<PyLpAlgorithm>,
         parameters: Option<SolverParameters>,
         solver: Option<String>,
     ) -> PyResult<PyClassInitializer<Self>> {
@@ -519,6 +551,7 @@ impl PyScip {
             mip_gap,
             verbosity,
             log_to_console,
+            lp_algorithm,
             merge_solver_parameter(parameters, solver),
         )?;
         Ok(PyClassInitializer::from(PySolver { settings }).add_subclass(PyScip))
@@ -574,6 +607,7 @@ impl PyIpopt {
             mip_gap,
             verbosity,
             log_to_console,
+            None,
             merge_solver_parameter(parameters, solver),
         )?;
         Ok(PyClassInitializer::from(PySolver { settings }).add_subclass(PyIpopt))

--- a/bindings/python/src/solver.rs
+++ b/bindings/python/src/solver.rs
@@ -81,6 +81,10 @@ impl SolverSettings {
         })
     }
 
+    pub fn set_lp_algorithm(&mut self, algorithm: PyLpAlgorithm) {
+        self.lp_algorithm = Some(algorithm);
+    }
+
     pub fn with_overrides(&self, overrides: SolveOverrides) -> PyResult<Self> {
         Self::new(
             self.presolve,

--- a/bindings/python/tests/test_api_contracts.py
+++ b/bindings/python/tests/test_api_contracts.py
@@ -965,6 +965,25 @@ def test_debug_api_contract_exposes_solver_setting_error_codes() -> None:
         raise AssertionError("expected solver setting validation to fail")
 
 
+def test_solver_api_exposes_solver_independent_lp_algorithm() -> None:
+    solver = arco.HiGHS(lp_algorithm=arco.LpAlgorithm.DUAL_SIMPLEX)
+    assert solver.lp_algorithm == arco.LpAlgorithm.DUAL_SIMPLEX
+
+    updated = solver.copy(update={"lp_algorithm": arco.LpAlgorithm.BARRIER})
+    assert updated.lp_algorithm == arco.LpAlgorithm.BARRIER
+    assert solver.lp_algorithm == arco.LpAlgorithm.DUAL_SIMPLEX
+
+    model = arco.Model()
+    x = model.add_variable(bounds=arco.NonNegativeFloat, name="x")
+    model.add_constraint(x >= 1.0)
+    model.minimize(x)
+    result = model.solve(
+        lp_algorithm=arco.LpAlgorithm.PRIMAL_SIMPLEX,
+        log_to_console=False,
+    )
+    assert result.is_optimal()
+
+
 def test_debug_api_contract_rejects_xpress_unsupported_verbosity() -> None:
     codes = arco.diagnostic_codes()
 

--- a/bindings/python/tests/test_xpress.py
+++ b/bindings/python/tests/test_xpress.py
@@ -79,8 +79,8 @@ def test_xpress_solver_selection_family_solves_model() -> None:
 
 
 @pytest.mark.skipif(
-    not HAS_XPRESS_BACKEND,
-    reason="xpress backend not available in this build",
+    (not HAS_XPRESS_RUNTIME) or (not HAS_XPRESS_BACKEND),
+    reason="xpress runtime/backend not available in this build",
 )
 def test_xpress_solves_with_selected_lp_algorithms() -> None:
     runtime_dir = XPRESS_RUNTIME_INFO.get("runtime_dir")

--- a/bindings/python/tests/test_xpress.py
+++ b/bindings/python/tests/test_xpress.py
@@ -78,6 +78,53 @@ def test_xpress_solver_selection_family_solves_model() -> None:
     assert result.objective_value == pytest.approx(2.0)
 
 
+@pytest.mark.skipif(
+    not HAS_XPRESS_BACKEND,
+    reason="xpress backend not available in this build",
+)
+def test_xpress_solves_with_selected_lp_algorithms() -> None:
+    runtime_dir = XPRESS_RUNTIME_INFO.get("runtime_dir")
+    if runtime_dir:
+        os.environ.setdefault("XPRESSDIR", str(runtime_dir))
+
+    for algorithm in ("primal", "dual", "barrier"):
+        solver = arco.Xpress(
+            log_to_console=False,
+            lp_algorithm={
+                "primal": arco.LpAlgorithm.PRIMAL_SIMPLEX,
+                "dual": arco.LpAlgorithm.DUAL_SIMPLEX,
+                "barrier": arco.LpAlgorithm.BARRIER,
+            }[algorithm],
+        )
+        try:
+            result = build_model().solve(solver=solver)
+        except arco.SolverNotAvailableError as exc:  # pragma: no cover
+            message = str(exc)
+            if "Xpress license initialization failed" in message:
+                pytest.skip(message)
+            raise
+
+        assert result.is_optimal()
+        assert result.objective_value == pytest.approx(2.0)
+
+
+@pytest.mark.skipif(
+    not HAS_XPRESS_BACKEND,
+    reason="xpress backend not available in this build",
+)
+def test_xpress_rejects_unsupported_lp_algorithm_before_runtime_setup() -> None:
+    solver = arco.Xpress(
+        log_to_console=False,
+        lp_algorithm=arco.LpAlgorithm.PRIMAL_DUAL_FIRST_ORDER,
+    )
+
+    with pytest.raises(
+        arco.SolverInvalidSettingError,
+        match="primal_dual_first_order.*not supported by the Xpress backend",
+    ):
+        build_model().solve(solver=solver)
+
+
 def test_xpress_constructor_fails_fast_when_backend_disabled() -> None:
     if HAS_XPRESS_BACKEND:
         pytest.skip("xpress backend enabled in this build")

--- a/crates/arco-builtin-solvers/src/lib.rs
+++ b/crates/arco-builtin-solvers/src/lib.rs
@@ -97,6 +97,7 @@ impl OptimizationAdapter for ScipArcoAdapter {
             threads: self.solver_config.threads,
             tolerance: self.solver_config.tolerance,
             verbosity: self.solver_config.verbosity,
+            lp_algorithm: self.solver_config.lp_algorithm,
         };
         let variable_families = problem
             .variables

--- a/crates/arco-highs/src/solver.rs
+++ b/crates/arco-highs/src/solver.rs
@@ -2,7 +2,7 @@
 
 use arco_model::{ConstraintId, ModelFingerprint, ModelView, Sense, VariableId};
 use arco_solver::{
-    ModelViewBackend, ModelViewSolveResult, SolverConfig, SolverStatus,
+    LpAlgorithm, ModelViewBackend, ModelViewSolveResult, SolverConfig, SolverStatus,
     validate_model_view_solve_result,
 };
 use std::collections::BTreeMap;
@@ -509,11 +509,48 @@ fn apply_direct_solver_config(
         highs_model.set_double_option("primal_feasibility_tolerance", tolerance)?;
         highs_model.set_double_option("dual_feasibility_tolerance", tolerance)?;
     }
+    if let Some(algorithm) = config.lp_algorithm {
+        apply_lp_algorithm(highs_model, algorithm)?;
+    }
     for (key, value) in &config.parameters {
         if key.starts_with("arco.") {
             continue;
         }
         highs_model.set_string_option(key.as_str(), value.as_str())?;
+    }
+    Ok(())
+}
+
+fn apply_lp_algorithm(
+    highs_model: &mut DirectHighsModel,
+    algorithm: LpAlgorithm,
+) -> Result<(), SolverError> {
+    match algorithm {
+        LpAlgorithm::Automatic => highs_model.set_string_option("solver", "choose")?,
+        LpAlgorithm::PrimalSimplex => {
+            highs_model.set_string_option("solver", "simplex")?;
+            highs_model.set_int_option("simplex_strategy", 4)?;
+        }
+        LpAlgorithm::DualSimplex => {
+            highs_model.set_string_option("solver", "simplex")?;
+            highs_model.set_int_option("simplex_strategy", 1)?;
+        }
+        LpAlgorithm::Barrier => {
+            highs_model.set_string_option("solver", "ipm")?;
+            highs_model.set_string_option("run_crossover", "off")?;
+        }
+        LpAlgorithm::BarrierWithCrossover => {
+            highs_model.set_string_option("solver", "ipm")?;
+            highs_model.set_string_option("run_crossover", "on")?;
+        }
+        LpAlgorithm::PrimalDualFirstOrder => {
+            highs_model.set_string_option("solver", "pdlp")?;
+        }
+        LpAlgorithm::Concurrent => {
+            return Err(SolverError::InvalidSettings(
+                "lp_algorithm 'concurrent' is not supported by the HiGHS backend".to_string(),
+            ));
+        }
     }
     Ok(())
 }

--- a/crates/arco-highs/tests/lp_algorithm.rs
+++ b/crates/arco-highs/tests/lp_algorithm.rs
@@ -1,0 +1,36 @@
+use arco_highs::{HighsModelViewBackend, solve_model_view};
+use arco_solver::{LpAlgorithm, SolverConfig, SolverError, check_small_lp, small_lp_model};
+
+#[test]
+fn solves_with_supported_lp_algorithms() {
+    let backend = HighsModelViewBackend;
+    for algorithm in [
+        LpAlgorithm::Automatic,
+        LpAlgorithm::PrimalSimplex,
+        LpAlgorithm::DualSimplex,
+        LpAlgorithm::Barrier,
+        LpAlgorithm::BarrierWithCrossover,
+        LpAlgorithm::PrimalDualFirstOrder,
+    ] {
+        let config = SolverConfig::new()
+            .with_log_to_console(false)
+            .with_lp_algorithm(algorithm);
+        let report = check_small_lp(&backend, &config)
+            .unwrap_or_else(|error| panic!("HiGHS should solve with {algorithm:?}: {error}"));
+        assert!((report.objective_value - 2.0).abs() < 1e-9);
+    }
+}
+
+#[test]
+fn rejects_unsupported_concurrent_algorithm() {
+    let model = small_lp_model();
+    let config = SolverConfig::new().with_lp_algorithm(LpAlgorithm::Concurrent);
+
+    let error = solve_model_view(&model, &config)
+        .expect_err("HiGHS should reject unsupported concurrent selection");
+    assert!(matches!(
+        error,
+        SolverError::InvalidSettings(message)
+            if message.contains("concurrent") && message.contains("HiGHS backend")
+    ));
+}

--- a/crates/arco-ops/src/execution_backends.rs
+++ b/crates/arco-ops/src/execution_backends.rs
@@ -309,6 +309,7 @@ impl OptimizationAdapter for ScipArcoAdapter {
             threads: self.solver_config.threads,
             tolerance: self.solver_config.tolerance,
             verbosity: self.solver_config.verbosity,
+            lp_algorithm: self.solver_config.lp_algorithm,
         };
         let variable_families = problem
             .variables

--- a/crates/arco-ops/src/lib.rs
+++ b/crates/arco-ops/src/lib.rs
@@ -103,12 +103,12 @@ pub mod nlp {
 /// Stable solver-facing operations vocabulary exposed through the ops seam.
 pub mod solve {
     pub use arco_solver::{
-        ModelViewBackend, ModelViewBackendRegistry, ModelViewSolveResult, ResolvedSelection,
-        SelectionError, Solution, SolutionView, Solve, SolveRequest, SolverCapabilityModel,
-        SolverConfig, SolverConfigDocument, SolverDiagnostic, SolverError, SolverFamily,
-        SolverModelStats, SolverProfile, SolverRegistry, SolverRequirements, SolverSelection,
-        SolverStatus, SolverTransport, merged_profiles, preflight_model_view, preflight_selection,
-        resolve_selection,
+        LpAlgorithm, ModelViewBackend, ModelViewBackendRegistry, ModelViewSolveResult,
+        ResolvedSelection, SelectionError, Solution, SolutionView, Solve, SolveRequest,
+        SolverCapabilityModel, SolverConfig, SolverConfigDocument, SolverDiagnostic, SolverError,
+        SolverFamily, SolverModelStats, SolverProfile, SolverRegistry, SolverRequirements,
+        SolverSelection, SolverStatus, SolverTransport, merged_profiles, preflight_model_view,
+        preflight_selection, resolve_selection,
     };
 }
 

--- a/crates/arco-scip/src/lib.rs
+++ b/crates/arco-scip/src/lib.rs
@@ -13,6 +13,7 @@ use arco_solver::{
 use russcip::{Model, ProblemOrSolving, Solution, Status, VarType, WithSolutions};
 use std::collections::BTreeMap;
 use std::fmt;
+use std::os::raw::c_char;
 use std::panic::{AssertUnwindSafe, catch_unwind};
 
 const SCIP_INFINITY: f64 = 1.0e20;
@@ -434,13 +435,13 @@ fn solve_problem_native(
     })
 }
 
-fn scip_lp_algorithm(algorithm: LpAlgorithm) -> Result<i8, Error> {
+fn scip_lp_algorithm(algorithm: LpAlgorithm) -> Result<c_char, Error> {
     match algorithm {
-        LpAlgorithm::Automatic => Ok(b's' as i8),
-        LpAlgorithm::PrimalSimplex => Ok(b'p' as i8),
-        LpAlgorithm::DualSimplex => Ok(b'd' as i8),
-        LpAlgorithm::Barrier => Ok(b'b' as i8),
-        LpAlgorithm::BarrierWithCrossover => Ok(b'c' as i8),
+        LpAlgorithm::Automatic => Ok(b's' as c_char),
+        LpAlgorithm::PrimalSimplex => Ok(b'p' as c_char),
+        LpAlgorithm::DualSimplex => Ok(b'd' as c_char),
+        LpAlgorithm::Barrier => Ok(b'b' as c_char),
+        LpAlgorithm::BarrierWithCrossover => Ok(b'c' as c_char),
         LpAlgorithm::PrimalDualFirstOrder => Err(Error::Process {
             message: "lp_algorithm 'primal_dual_first_order' is not supported by the SCIP backend"
                 .to_string(),
@@ -622,11 +623,11 @@ mod tests {
     #[test]
     fn maps_lp_algorithms_to_scip_character_controls() {
         for (algorithm, expected) in [
-            (LpAlgorithm::Automatic, b's' as i8),
-            (LpAlgorithm::PrimalSimplex, b'p' as i8),
-            (LpAlgorithm::DualSimplex, b'd' as i8),
-            (LpAlgorithm::Barrier, b'b' as i8),
-            (LpAlgorithm::BarrierWithCrossover, b'c' as i8),
+            (LpAlgorithm::Automatic, b's' as c_char),
+            (LpAlgorithm::PrimalSimplex, b'p' as c_char),
+            (LpAlgorithm::DualSimplex, b'd' as c_char),
+            (LpAlgorithm::Barrier, b'b' as c_char),
+            (LpAlgorithm::BarrierWithCrossover, b'c' as c_char),
         ] {
             assert_eq!(
                 scip_lp_algorithm(algorithm).expect("algorithm should be supported"),

--- a/crates/arco-scip/src/lib.rs
+++ b/crates/arco-scip/src/lib.rs
@@ -7,8 +7,8 @@ use arco_format::{
 };
 use arco_model::{ModelView, VariableId};
 use arco_solver::{
-    ModelViewBackend, ModelViewSolveResult, SolverCapabilityModel, SolverConfig, SolverError,
-    SolverFamily, SolverRegistry, SolverStatus, validate_model_view_solve_result,
+    LpAlgorithm, ModelViewBackend, ModelViewSolveResult, SolverCapabilityModel, SolverConfig,
+    SolverError, SolverFamily, SolverRegistry, SolverStatus, validate_model_view_solve_result,
 };
 use russcip::{Model, ProblemOrSolving, Solution, Status, VarType, WithSolutions};
 use std::collections::BTreeMap;
@@ -223,6 +223,7 @@ pub struct NativeSolveOptions {
     pub threads: Option<u32>,
     pub tolerance: Option<f64>,
     pub verbosity: Option<u32>,
+    pub lp_algorithm: Option<LpAlgorithm>,
 }
 
 impl NativeSolveOptions {
@@ -245,6 +246,9 @@ impl NativeSolveOptions {
         }
         if config.verbosity.is_some() {
             options.verbosity = config.verbosity;
+        }
+        if config.lp_algorithm.is_some() {
+            options.lp_algorithm = config.lp_algorithm;
         }
         options
     }
@@ -341,6 +345,19 @@ fn solve_problem_native(
                 message: format!("failed to set SCIP verbosity: {source:?}"),
             })?;
     }
+    if let Some(algorithm) = options.lp_algorithm {
+        let native_algorithm = scip_lp_algorithm(algorithm)?;
+        model = model
+            .set_char_param("lp/initalgorithm", native_algorithm)
+            .map_err(|source| Error::Process {
+                message: format!("failed to set SCIP initial LP algorithm: {source:?}"),
+            })?;
+        model = model
+            .set_char_param("lp/resolvealgorithm", native_algorithm)
+            .map_err(|source| Error::Process {
+                message: format!("failed to set SCIP resolve LP algorithm: {source:?}"),
+            })?;
+    }
 
     let mut variables = Vec::with_capacity(problem.portable.variable_instances.len());
     let mut variable_indices = BTreeMap::new();
@@ -415,6 +432,23 @@ fn solve_problem_native(
         report_values,
         variable_values,
     })
+}
+
+fn scip_lp_algorithm(algorithm: LpAlgorithm) -> Result<i8, Error> {
+    match algorithm {
+        LpAlgorithm::Automatic => Ok(b's' as i8),
+        LpAlgorithm::PrimalSimplex => Ok(b'p' as i8),
+        LpAlgorithm::DualSimplex => Ok(b'd' as i8),
+        LpAlgorithm::Barrier => Ok(b'b' as i8),
+        LpAlgorithm::BarrierWithCrossover => Ok(b'c' as i8),
+        LpAlgorithm::PrimalDualFirstOrder => Err(Error::Process {
+            message: "lp_algorithm 'primal_dual_first_order' is not supported by the SCIP backend"
+                .to_string(),
+        }),
+        LpAlgorithm::Concurrent => Err(Error::Process {
+            message: "lp_algorithm 'concurrent' is not supported by the SCIP backend".to_string(),
+        }),
+    }
 }
 
 fn validate_native_options(options: &NativeSolveOptions) -> Result<(), Error> {
@@ -583,6 +617,53 @@ mod tests {
 
         let error = validate_native_options(&options).expect_err("NaN time limit should fail");
         assert!(error.to_string().contains("time_limit"));
+    }
+
+    #[test]
+    fn maps_lp_algorithms_to_scip_character_controls() {
+        for (algorithm, expected) in [
+            (LpAlgorithm::Automatic, b's' as i8),
+            (LpAlgorithm::PrimalSimplex, b'p' as i8),
+            (LpAlgorithm::DualSimplex, b'd' as i8),
+            (LpAlgorithm::Barrier, b'b' as i8),
+            (LpAlgorithm::BarrierWithCrossover, b'c' as i8),
+        ] {
+            assert_eq!(
+                scip_lp_algorithm(algorithm).expect("algorithm should be supported"),
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_unsupported_scip_lp_algorithms() {
+        for algorithm in [LpAlgorithm::PrimalDualFirstOrder, LpAlgorithm::Concurrent] {
+            let error =
+                scip_lp_algorithm(algorithm).expect_err("unsupported algorithm should be rejected");
+            assert!(
+                error
+                    .to_string()
+                    .contains("not supported by the SCIP backend")
+            );
+        }
+    }
+
+    #[test]
+    fn model_view_solves_with_selected_lp_algorithms() {
+        let backend = ScipModelViewBackend;
+        for algorithm in [
+            LpAlgorithm::PrimalSimplex,
+            LpAlgorithm::DualSimplex,
+            LpAlgorithm::Barrier,
+            LpAlgorithm::BarrierWithCrossover,
+        ] {
+            let config = SolverConfig::new()
+                .with_log_to_console(false)
+                .with_lp_algorithm(algorithm);
+            let report = arco_solver::check_small_lp(&backend, &config)
+                .unwrap_or_else(|error| panic!("SCIP should solve with {algorithm:?}: {error}"));
+            assert!((report.objective_value - 2.0).abs() < 1e-9);
+        }
     }
 
     #[test]

--- a/crates/arco-solver/Cargo.toml
+++ b/crates/arco-solver/Cargo.toml
@@ -20,3 +20,6 @@ serde = ["dep:serde", "arco-model/serde"]
 [dependencies]
 arco-model = { workspace = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/crates/arco-solver/src/config.rs
+++ b/crates/arco-solver/src/config.rs
@@ -1,5 +1,31 @@
 use std::collections::BTreeMap;
 
+/// Solver-independent algorithm for linear programs and MIP relaxations.
+///
+/// Backends translate these semantic choices into their native controls. If a
+/// backend cannot represent a selected algorithm, it returns an invalid-setting
+/// error rather than silently choosing something else.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
+pub enum LpAlgorithm {
+    /// Let the backend select its default LP algorithm.
+    #[default]
+    Automatic,
+    /// Primal simplex.
+    PrimalSimplex,
+    /// Dual simplex.
+    DualSimplex,
+    /// Interior-point or barrier algorithm.
+    Barrier,
+    /// Barrier followed by crossover to a basic solution.
+    BarrierWithCrossover,
+    /// First-order primal-dual method.
+    PrimalDualFirstOrder,
+    /// Run multiple supported LP algorithms concurrently.
+    Concurrent,
+}
+
 /// Configuration options for solver behavior.
 #[derive(Debug, Clone, Default, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -18,6 +44,9 @@ pub struct SolverConfig {
     pub tolerance: Option<f64>,
     /// Log solver output to console. `None` uses solver default.
     pub log_to_console: Option<bool>,
+    /// LP algorithm. `None` uses the backend default.
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub lp_algorithm: Option<LpAlgorithm>,
     /// Family-specific passthrough parameters.
     #[cfg_attr(feature = "serde", serde(default))]
     pub parameters: BTreeMap<String, String>,
@@ -63,6 +92,11 @@ impl SolverConfig {
         self
     }
 
+    pub fn with_lp_algorithm(mut self, algorithm: LpAlgorithm) -> Self {
+        self.lp_algorithm = Some(algorithm);
+        self
+    }
+
     pub fn with_parameter(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
         self.parameters.insert(key.into(), value.into());
         self
@@ -91,6 +125,9 @@ impl SolverConfig {
         if overlay.log_to_console.is_some() {
             merged.log_to_console = overlay.log_to_console;
         }
+        if overlay.lp_algorithm.is_some() {
+            merged.lp_algorithm = overlay.lp_algorithm;
+        }
         for (key, value) in &overlay.parameters {
             merged.parameters.insert(key.clone(), value.clone());
         }
@@ -105,6 +142,7 @@ impl SolverConfig {
             && self.threads.is_none()
             && self.tolerance.is_none()
             && self.log_to_console.is_none()
+            && self.lp_algorithm.is_none()
             && self.parameters.is_empty()
     }
 }
@@ -115,19 +153,39 @@ mod tests {
 
     #[test]
     fn config_builder_and_merge_preserve_overlay_precedence() {
-        let base = SolverConfig::new().with_threads(4).with_time_limit(10.0);
+        let base = SolverConfig::new()
+            .with_threads(4)
+            .with_time_limit(10.0)
+            .with_lp_algorithm(LpAlgorithm::DualSimplex);
         let overlay = SolverConfig::new()
             .with_time_limit(20.0)
+            .with_lp_algorithm(LpAlgorithm::Barrier)
             .with_parameter("solver.option", "enabled");
 
         let merged = base.merged_with(&overlay);
 
         assert_eq!(merged.threads, Some(4));
         assert_eq!(merged.time_limit, Some(20.0));
+        assert_eq!(merged.lp_algorithm, Some(LpAlgorithm::Barrier));
         assert_eq!(
             merged.parameters.get("solver.option").map(String::as_str),
             Some("enabled")
         );
         assert!(!merged.is_empty());
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn lp_algorithm_serializes_as_solver_independent_snake_case() {
+        let config = SolverConfig::new().with_lp_algorithm(LpAlgorithm::BarrierWithCrossover);
+        let encoded = serde_json::to_string(&config).expect("config should serialize");
+        assert!(encoded.contains("\"lp_algorithm\":\"barrier_with_crossover\""));
+
+        let decoded: SolverConfig =
+            serde_json::from_str(&encoded).expect("config should deserialize");
+        assert_eq!(
+            decoded.lp_algorithm,
+            Some(LpAlgorithm::BarrierWithCrossover)
+        );
     }
 }

--- a/crates/arco-solver/src/lib.rs
+++ b/crates/arco-solver/src/lib.rs
@@ -16,7 +16,7 @@ mod traits;
 mod types;
 
 pub use backend::SolverBackend as GenericSolverBackend;
-pub use config::SolverConfig;
+pub use config::{LpAlgorithm, SolverConfig};
 pub use conformance::{
     BackendConformanceReport, check_empty_model_rejected, check_no_objective_rejected,
     check_small_lp, check_small_milp, small_lp_model, small_milp_model,

--- a/crates/arco-xpress/src/ffi.rs
+++ b/crates/arco-xpress/src/ffi.rs
@@ -27,6 +27,7 @@ pub(crate) const XPRS_PRESOLVE: c_int = 8011;
 pub(crate) const XPRS_LPLOG: c_int = 8009;
 pub(crate) const XPRS_MIPLOG: c_int = 8028;
 pub(crate) const XPRS_OUTPUTLOG: c_int = 8035;
+pub(crate) const XPRS_CROSSOVER: c_int = 8044;
 
 // Double control indices
 pub(crate) const XPRS_MAXTIME: c_int = 8020;

--- a/crates/arco-xpress/src/solver.rs
+++ b/crates/arco-xpress/src/solver.rs
@@ -5,8 +5,8 @@ use crate::solution::Solution;
 use crate::status;
 use arco_model::{ConstraintId, ModelFingerprint, ModelView, Sense, VariableId};
 use arco_solver::{
-    ModelViewBackend, ModelViewSolveResult, Solve, SolverConfig, SolverDiagnostic, SolverError,
-    SolverModelStats, validate_model_view_solve_result,
+    LpAlgorithm, ModelViewBackend, ModelViewSolveResult, Solve, SolverConfig, SolverDiagnostic,
+    SolverError, SolverModelStats, validate_model_view_solve_result,
 };
 use std::collections::BTreeMap;
 use std::ffi::{CStr, CString, c_char, c_int, c_void};
@@ -393,10 +393,33 @@ fn ensure_non_negative_finite_setting(name: &str, value: Option<f64>) -> Result<
     Ok(())
 }
 
+fn lp_optimizer_flags(config: &SolverConfig) -> Result<Option<&'static CStr>, SolverError> {
+    match config.lp_algorithm {
+        None | Some(LpAlgorithm::Automatic) => Ok(None),
+        Some(LpAlgorithm::PrimalSimplex) => Ok(Some(c"p")),
+        Some(LpAlgorithm::DualSimplex) => Ok(Some(c"d")),
+        Some(LpAlgorithm::Barrier | LpAlgorithm::BarrierWithCrossover) => Ok(Some(c"b")),
+        Some(LpAlgorithm::Concurrent) => Ok(Some(c"pdb")),
+        Some(LpAlgorithm::PrimalDualFirstOrder) => Err(SolverError::InvalidSettings(
+            "lp_algorithm 'primal_dual_first_order' is not supported by the Xpress backend"
+                .to_string(),
+        )),
+    }
+}
+
+fn lp_crossover_setting(config: &SolverConfig) -> Option<c_int> {
+    match config.lp_algorithm {
+        Some(LpAlgorithm::Barrier) => Some(0),
+        Some(LpAlgorithm::BarrierWithCrossover) => Some(1),
+        _ => None,
+    }
+}
+
 fn validate_solver_config(config: &SolverConfig) -> Result<(), SolverError> {
     ensure_non_negative_finite_setting("time_limit", config.time_limit)?;
     ensure_non_negative_finite_setting("mip_gap", config.mip_gap)?;
     ensure_non_negative_finite_setting("tolerance", config.tolerance)?;
+    let _ = lp_optimizer_flags(config)?;
 
     if let Some(0) = config.threads {
         return Err(SolverError::InvalidSettings(
@@ -446,8 +469,6 @@ fn apply_solver_config(
     prob: ffi::XPRSprob,
     config: &SolverConfig,
 ) -> Result<(), SolverError> {
-    validate_solver_config(config)?;
-
     let log_to_console = config.log_to_console.unwrap_or(false);
     if log_to_console {
         enable_console_logging(api, prob)?;
@@ -470,6 +491,9 @@ fn apply_solver_config(
         set_dbl_control(api, prob, ffi::XPRS_FEASTOL, tolerance)?;
         set_dbl_control(api, prob, ffi::XPRS_OPTIMALITYTOL, tolerance)?;
     }
+    if let Some(crossover) = lp_crossover_setting(config) {
+        set_int_control(api, prob, ffi::XPRS_CROSSOVER, crossover)?;
+    }
 
     Ok(())
 }
@@ -487,6 +511,8 @@ fn solve_problem(
     if model.num_variables() == 0 {
         return Err(SolverError::EmptyModel);
     }
+    validate_solver_config(config)?;
+    let optimizer_flags_ptr = lp_optimizer_flags(config)?.map_or(std::ptr::null(), CStr::as_ptr);
 
     let solve_started = Instant::now();
     let ncols = model.num_variables();
@@ -658,10 +684,10 @@ fn solve_problem(
 
     let run_start = Instant::now();
     if has_integer {
-        ffi::check_xprs(unsafe { (api.xprs_mipoptimize)(prob, std::ptr::null()) })
+        ffi::check_xprs(unsafe { (api.xprs_mipoptimize)(prob, optimizer_flags_ptr) })
             .map_err(|rc| xpress_failure_error(api, prob, "XPRSmipoptimize", rc, model))?;
     } else {
-        ffi::check_xprs(unsafe { (api.xprs_lpoptimize)(prob, std::ptr::null()) })
+        ffi::check_xprs(unsafe { (api.xprs_lpoptimize)(prob, optimizer_flags_ptr) })
             .map_err(|rc| xpress_failure_error(api, prob, "XPRSlpoptimize", rc, model))?;
     }
     let run_seconds = run_start.elapsed().as_secs_f64();
@@ -891,6 +917,11 @@ impl<'model> Solver<'model> {
         self.update_config(|config| config.with_tolerance(tolerance));
     }
 
+    /// Select the solver-independent LP algorithm preference.
+    pub fn set_lp_algorithm(&mut self, algorithm: LpAlgorithm) {
+        self.update_config(|config| config.with_lp_algorithm(algorithm));
+    }
+
     pub(crate) fn config(&self) -> &SolverConfig {
         &self.config
     }
@@ -983,10 +1014,12 @@ mod tests {
         solver.set_threads(2);
         solver.set_time_limit(5.0);
         solver.set_log_to_console(false);
+        solver.set_lp_algorithm(LpAlgorithm::Barrier);
 
         assert_eq!(solver.config().threads, Some(2));
         assert_eq!(solver.config().time_limit, Some(5.0));
         assert_eq!(solver.config().log_to_console, Some(false));
+        assert_eq!(solver.config().lp_algorithm, Some(LpAlgorithm::Barrier));
     }
 
     #[test]
@@ -1020,6 +1053,58 @@ mod tests {
         assert!(matches!(
             error,
             SolverError::InvalidSettings(message) if message == "threads must be >= 1"
+        ));
+    }
+
+    #[test]
+    fn maps_lp_algorithms_to_xpress_optimizer_flags() {
+        for (algorithm, expected_flag) in [
+            (LpAlgorithm::Automatic, None),
+            (LpAlgorithm::PrimalSimplex, Some("p")),
+            (LpAlgorithm::DualSimplex, Some("d")),
+            (LpAlgorithm::Barrier, Some("b")),
+            (LpAlgorithm::BarrierWithCrossover, Some("b")),
+            (LpAlgorithm::Concurrent, Some("pdb")),
+        ] {
+            let config = SolverConfig::new().with_lp_algorithm(algorithm);
+            assert_eq!(
+                lp_optimizer_flags(&config)
+                    .expect("supported LP algorithm should be accepted")
+                    .map(CStr::to_str)
+                    .transpose()
+                    .expect("algorithm flags should be UTF-8"),
+                expected_flag,
+                "unexpected optimizer flags for {algorithm:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn maps_barrier_crossover_modes_to_xpress_control_values() {
+        assert_eq!(
+            lp_crossover_setting(&SolverConfig::new().with_lp_algorithm(LpAlgorithm::Barrier)),
+            Some(0)
+        );
+        assert_eq!(
+            lp_crossover_setting(
+                &SolverConfig::new().with_lp_algorithm(LpAlgorithm::BarrierWithCrossover)
+            ),
+            Some(1)
+        );
+        assert_eq!(lp_crossover_setting(&SolverConfig::new()), None);
+    }
+
+    #[test]
+    fn rejects_unsupported_xpress_lp_algorithm() {
+        let config = SolverConfig::new().with_lp_algorithm(LpAlgorithm::PrimalDualFirstOrder);
+        let error = lp_optimizer_flags(&config)
+            .expect_err("unsupported LP algorithm should be rejected before solving");
+
+        assert!(matches!(
+            error,
+            SolverError::InvalidSettings(message)
+                if message.contains("primal_dual_first_order")
+                    && message.contains("Xpress backend")
         ));
     }
 

--- a/crates/arco-xpress/tests/integration.rs
+++ b/crates/arco-xpress/tests/integration.rs
@@ -1,5 +1,5 @@
 use arco_model::{Bounds, Constraint, Model, Objective, Sense, Variable};
-use arco_solver::{SolverConfig, SolverError, check_small_lp, check_small_milp};
+use arco_solver::{LpAlgorithm, SolverConfig, SolverError, check_small_lp, check_small_milp};
 use arco_xpress::{Solver, XpressModelViewBackend, detect_xpress_dir};
 use std::path::PathBuf;
 
@@ -84,6 +84,33 @@ fn model_view_shared_small_milp_conformance_with_local_xpress_install() {
     assert_eq!(report.variables, 1);
     assert_eq!(report.constraints, 1);
     assert_eq!(report.coefficients, 1);
+}
+
+#[test]
+fn model_view_solves_with_selected_lp_algorithms() {
+    let Some(_xpress_dir) = local_xpress_dir() else {
+        return;
+    };
+
+    let backend = XpressModelViewBackend;
+    for algorithm in [
+        LpAlgorithm::PrimalSimplex,
+        LpAlgorithm::DualSimplex,
+        LpAlgorithm::Barrier,
+    ] {
+        let config = SolverConfig::new()
+            .with_log_to_console(false)
+            .with_lp_algorithm(algorithm);
+        match check_small_lp(&backend, &config) {
+            Ok(report) => assert_close(report.objective_value, 2.0),
+            Err(SolverError::SolverSpecific(message))
+                if message.contains("Xpress license initialization failed") =>
+            {
+                return;
+            }
+            Err(error) => panic!("xpress {algorithm:?} LP solve succeeds: {error:?}"),
+        }
+    }
 }
 
 #[test]

--- a/docs/how-to/configure-solver.md
+++ b/docs/how-to/configure-solver.md
@@ -401,16 +401,16 @@ solution = model.solve(solver=selection, log_to_console=False)
 
 ### Settings mapping
 
-| Setting                                | Xpress control    | Notes                                           |
-| -------------------------------------- | ----------------- | ----------------------------------------------- |
-| `time_limit`                           | `XPRS_MAXTIME`    |                                                 |
-| `mip_gap`                              | `XPRS_MIPRELSTOP` |                                                 |
-| `tolerance`                            | `XPRS_FEASTOL`    |                                                 |
-| `presolve`                             | `XPRS_PRESOLVE`   | 1 = on, 0 = off                                 |
-| `threads`                              | `XPRS_THREADS`    |                                                 |
-| `log_to_console`                       | `XPRS_OUTPUTLOG`  | 1 = on, 0 = off                                 |
-| `verbosity`                            | --                | Unsupported; raises `SolverInvalidSettingError` |
-| `lp_algorithm`                         | optimizer flags + `XPRS_CROSSOVER` | Uses the shared mapping documented above.       |
+| Setting          | Xpress control                     | Notes                                           |
+| ---------------- | ---------------------------------- | ----------------------------------------------- |
+| `time_limit`     | `XPRS_MAXTIME`                     |                                                 |
+| `mip_gap`        | `XPRS_MIPRELSTOP`                  |                                                 |
+| `tolerance`      | `XPRS_FEASTOL`                     |                                                 |
+| `presolve`       | `XPRS_PRESOLVE`                    | 1 = on, 0 = off                                 |
+| `threads`        | `XPRS_THREADS`                     |                                                 |
+| `log_to_console` | `XPRS_OUTPUTLOG`                   | 1 = on, 0 = off                                 |
+| `verbosity`      | --                                 | Unsupported; raises `SolverInvalidSettingError` |
+| `lp_algorithm`   | optimizer flags + `XPRS_CROSSOVER` | Uses the shared mapping documented above.       |
 
 ## SCIP (embedded native LP / MIP solver)
 
@@ -461,16 +461,16 @@ solution = model.solve(solver=selection, log_to_console=False)
 
 ### Settings mapping
 
-| Setting          | SCIP handling          | Notes                                               |
-| ---------------- | ---------------------- | --------------------------------------------------- |
-| `time_limit`     | `set limits/time`      | From profile or Python settings                     |
-| `mip_gap`        | `set limits/gap`       | From profile or Python settings                     |
-| `log_to_console` | SCIP output toggle     | `false` keeps logs quiet                            |
-| `presolve`       | `presolving/maxrounds` | `false` disables presolve; `true` uses SCIP default |
-| `threads`        | `parallel/maxnthreads` |                                                     |
-| `tolerance`      | `numerics/feastol`     | Feasibility tolerance                               |
-| `verbosity`      | `display/verblevel`    | SCIP verbosity level                                |
-| `lp_algorithm`   | `lp/initalgorithm` + `lp/resolvealgorithm` | Shared mapping above          |
+| Setting          | SCIP handling                              | Notes                                               |
+| ---------------- | ------------------------------------------ | --------------------------------------------------- |
+| `time_limit`     | `set limits/time`                          | From profile or Python settings                     |
+| `mip_gap`        | `set limits/gap`                           | From profile or Python settings                     |
+| `log_to_console` | SCIP output toggle                         | `false` keeps logs quiet                            |
+| `presolve`       | `presolving/maxrounds`                     | `false` disables presolve; `true` uses SCIP default |
+| `threads`        | `parallel/maxnthreads`                     |                                                     |
+| `tolerance`      | `numerics/feastol`                         | Feasibility tolerance                               |
+| `verbosity`      | `display/verblevel`                        | SCIP verbosity level                                |
+| `lp_algorithm`   | `lp/initalgorithm` + `lp/resolvealgorithm` | Shared mapping above                                |
 
 ## IPOPT (nonlinear / continuous solver)
 

--- a/docs/how-to/configure-solver.md
+++ b/docs/how-to/configure-solver.md
@@ -116,15 +116,16 @@ This is equivalent to constructing an `arco.HiGHS(...)` and passing it via the
 All settings return `None` when not explicitly set, in which case the solver
 backend uses its own default.
 
-| Setting          | Type    | Description                                                       |
-| ---------------- | ------- | ----------------------------------------------------------------- |
-| `presolve`       | `bool`  | Enable or disable the presolve phase.                             |
-| `threads`        | `int`   | Number of threads the solver may use.                             |
-| `tolerance`      | `float` | Feasibility tolerance for primal and dual values.                 |
-| `time_limit`     | `float` | Maximum wall-clock seconds the solver may run.                    |
-| `mip_gap`        | `float` | Relative MIP optimality gap at which the solver stops.            |
-| `verbosity`      | `int`   | Solver output verbosity level (backend-specific scale).           |
-| `log_to_console` | `bool`  | Whether the solver prints progress to the console during a solve. |
+| Setting          | Type          | Description                                                       |
+| ---------------- | ------------- | ----------------------------------------------------------------- |
+| `presolve`       | `bool`        | Enable or disable the presolve phase.                             |
+| `threads`        | `int`         | Number of threads the solver may use.                             |
+| `tolerance`      | `float`       | Feasibility tolerance for primal and dual values.                 |
+| `time_limit`     | `float`       | Maximum wall-clock seconds the solver may run.                    |
+| `mip_gap`        | `float`       | Relative MIP optimality gap at which the solver stops.            |
+| `verbosity`      | `int`         | Solver output verbosity level (backend-specific scale).           |
+| `log_to_console` | `bool`        | Whether the solver prints progress to the console during a solve. |
+| `lp_algorithm`   | `LpAlgorithm` | Solver-independent LP algorithm preference.                       |
 
 > [!NOTE]
 > Not every backend interprets every setting. Arco validates shared settings at
@@ -135,6 +136,40 @@ backend uses its own default.
 > `threads` must be at least `1`. Invalid values raise
 > `SolverInvalidSettingError` with diagnostic code
 > `arco::solver::invalid_setting`.
+
+## Select an LP algorithm
+
+Use `LpAlgorithm` when you want to select an LP algorithm without encoding a
+backend's native option names:
+
+```python
+import arco
+
+solver = arco.HiGHS(
+    lp_algorithm=arco.LpAlgorithm.BARRIER_WITH_CROSSOVER,
+    log_to_console=False,
+)
+solution = model.solve(solver=solver)
+```
+
+The same setting is available on `arco.HiGHS`, `arco.Xpress`, `arco.Scip`, the
+generic `arco.Solver`, and the one-off `model.solve(lp_algorithm=...)` call.
+Each adapter translates the semantic value into its native settings:
+
+| `LpAlgorithm` value       | HiGHS                                  | Xpress            | SCIP              |
+| ------------------------- | -------------------------------------- | ----------------- | ----------------- |
+| `AUTOMATIC`               | `solver=choose`                        | no optimize flags | `lp/*algorithm=s` |
+| `PRIMAL_SIMPLEX`          | `solver=simplex`, `simplex_strategy=4` | `p` flag          | `lp/*algorithm=p` |
+| `DUAL_SIMPLEX`            | `solver=simplex`, `simplex_strategy=1` | `d` flag          | `lp/*algorithm=d` |
+| `BARRIER`                 | `solver=ipm`, `run_crossover=off`      | `b` flag          | `lp/*algorithm=b` |
+| `BARRIER_WITH_CROSSOVER`  | `solver=ipm`, `run_crossover=on`       | `b` flag          | `lp/*algorithm=c` |
+| `PRIMAL_DUAL_FIRST_ORDER` | `solver=pdlp`                          | unsupported       | unsupported       |
+| `CONCURRENT`              | unsupported                            | `pdb` flags       | unsupported       |
+
+A backend that cannot represent a selected algorithm raises
+`SolverInvalidSettingError`; it does not silently substitute another method.
+For MIPs, the setting controls LP relaxations according to each solver's native
+semantics.
 
 ## Xpress (LP / MIP solver)
 
@@ -366,15 +401,16 @@ solution = model.solve(solver=selection, log_to_console=False)
 
 ### Settings mapping
 
-| Setting          | Xpress control    | Notes                                           |
-| ---------------- | ----------------- | ----------------------------------------------- |
-| `time_limit`     | `XPRS_MAXTIME`    |                                                 |
-| `mip_gap`        | `XPRS_MIPRELSTOP` |                                                 |
-| `tolerance`      | `XPRS_FEASTOL`    |                                                 |
-| `presolve`       | `XPRS_PRESOLVE`   | 1 = on, 0 = off                                 |
-| `threads`        | `XPRS_THREADS`    |                                                 |
-| `log_to_console` | `XPRS_OUTPUTLOG`  | 1 = on, 0 = off                                 |
-| `verbosity`      | --                | Unsupported; raises `SolverInvalidSettingError` |
+| Setting                                | Xpress control    | Notes                                           |
+| -------------------------------------- | ----------------- | ----------------------------------------------- |
+| `time_limit`                           | `XPRS_MAXTIME`    |                                                 |
+| `mip_gap`                              | `XPRS_MIPRELSTOP` |                                                 |
+| `tolerance`                            | `XPRS_FEASTOL`    |                                                 |
+| `presolve`                             | `XPRS_PRESOLVE`   | 1 = on, 0 = off                                 |
+| `threads`                              | `XPRS_THREADS`    |                                                 |
+| `log_to_console`                       | `XPRS_OUTPUTLOG`  | 1 = on, 0 = off                                 |
+| `verbosity`                            | --                | Unsupported; raises `SolverInvalidSettingError` |
+| `lp_algorithm`                         | optimizer flags + `XPRS_CROSSOVER` | Uses the shared mapping documented above.       |
 
 ## SCIP (embedded native LP / MIP solver)
 
@@ -434,12 +470,14 @@ solution = model.solve(solver=selection, log_to_console=False)
 | `threads`        | `parallel/maxnthreads` |                                                     |
 | `tolerance`      | `numerics/feastol`     | Feasibility tolerance                               |
 | `verbosity`      | `display/verblevel`    | SCIP verbosity level                                |
+| `lp_algorithm`   | `lp/initalgorithm` + `lp/resolvealgorithm` | Shared mapping above          |
 
 ## IPOPT (nonlinear / continuous solver)
 
 The IPOPT backend is available when Arco is built with the `ipopt` feature flag.
 IPOPT is a continuous-only solver -- it does not support integer or binary
 variables. Passing a model that contains integer variables will raise an error.
+IPOPT does not expose the shared `lp_algorithm` setting.
 
 > [!IMPORTANT]
 > Building with IPOPT requires the IPOPT C library to be installed on the

--- a/third_party/russcip-0.9.1/src/model.rs
+++ b/third_party/russcip-0.9.1/src/model.rs
@@ -1619,6 +1619,13 @@ impl<T> Model<T> {
         Ok(self)
     }
 
+    /// Sets a SCIP character parameter and returns a new `Model` instance with the parameter set.
+    #[allow(unused_mut)]
+    pub fn set_char_param(mut self, param: &str, value: i8) -> Result<Self, Retcode> {
+        self.scip.set_char_param(param, value)?;
+        Ok(self)
+    }
+
     /// Sets a SCIP integer parameter and returns a new `Model` instance with the parameter set.
     #[allow(unused_mut)]
     pub fn set_int_param(mut self, param: &str, value: i32) -> Result<Self, Retcode> {

--- a/third_party/russcip-0.9.1/src/model.rs
+++ b/third_party/russcip-0.9.1/src/model.rs
@@ -1621,7 +1621,11 @@ impl<T> Model<T> {
 
     /// Sets a SCIP character parameter and returns a new `Model` instance with the parameter set.
     #[allow(unused_mut)]
-    pub fn set_char_param(mut self, param: &str, value: i8) -> Result<Self, Retcode> {
+    pub fn set_char_param(
+        mut self,
+        param: &str,
+        value: std::os::raw::c_char,
+    ) -> Result<Self, Retcode> {
         self.scip.set_char_param(param, value)?;
         Ok(self)
     }

--- a/third_party/russcip-0.9.1/src/scip.rs
+++ b/third_party/russcip-0.9.1/src/scip.rs
@@ -16,7 +16,7 @@ use scip_sys::{
     SCIP_SOL, SCIP_Var, Scip,
 };
 use std::collections::BTreeMap;
-use std::ffi::{CStr, CString, c_int};
+use std::ffi::{CStr, CString, c_char, c_int};
 use std::mem::MaybeUninit;
 use std::rc::Rc;
 
@@ -72,6 +72,12 @@ impl ScipPtr {
     pub(crate) fn set_bool_param(&self, param: &str, value: bool) -> Result<(), Retcode> {
         let param = CString::new(param).unwrap();
         scip_call! { ffi::SCIPsetBoolParam(self.raw, param.as_ptr(), if value { 1u32 } else { 0u32 }) };
+        Ok(())
+    }
+
+    pub(crate) fn set_char_param(&self, param: &str, value: c_char) -> Result<(), Retcode> {
+        let param = CString::new(param).map_err(|_| Retcode::InvalidData)?;
+        scip_call! { ffi::SCIPsetCharParam(self.raw, param.as_ptr(), value) };
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- add shared `LpAlgorithm` configuration and Python API
- map semantic choices to HiGHS, Xpress, and SCIP native controls
- reject unsupported algorithms, including Xpress barrier crossover handling
- add regression tests and solver configuration documentation

## Validation
- `cargo test -p arco-solver -p arco-highs -p arco-xpress -p arco-scip`
- repository push hooks: format, clippy, and fast tests
- Python targeted tests and documentation doctests: 115 passed, 1 skipped

Rebased onto latest `main`.