### PR TITLE
fix(python): publish EL8-compatible Linux wheels

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,5 @@
+paths:
+  .github/workflows/v-release.yml:
+    ignore:
+      - "shellcheck reported issue in this script: SC2086:.+"
+      - "shellcheck reported issue in this script: SC2129:.+"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -99,6 +99,9 @@ jobs:
               - 'Cargo.toml'
               - 'Cargo.lock'
               - 'justfile'
+              - 'scripts/build_python_wheel.sh'
+              - 'scripts/test_build_python_wheel.py'
+              - 'scripts/setup_manylinux_native_deps.sh'
               - 'scripts/ci_setup_rust_toolchain.sh'
               - 'scripts/setup_highs_binary_env.sh'
               - 'scripts/setup_scip_binary_env.sh'
@@ -140,6 +143,10 @@ jobs:
               - 'bindings/python/pyproject.toml'
               - 'bindings/python/uv.lock'
               - 'CHANGELOG.md'
+              - 'justfile'
+              - 'scripts/build_python_wheel.sh'
+              - 'scripts/test_build_python_wheel.py'
+              - 'scripts/setup_manylinux_native_deps.sh'
               - 'scripts/check_release_version_metadata.py'
               - 'scripts/ci_cargo_dist_preflight.sh'
               - 'scripts/ci_dist_plan_output.sh'
@@ -757,7 +764,8 @@ jobs:
     needs: [version-consistency, ci-plan]
     if: needs.ci-plan.outputs.release == 'true' || needs.ci-plan.outputs.github_actions == 'true'
     runs-on: ${{ matrix.platform.os }}
-    timeout-minutes: 25
+    container: ${{ matrix.platform.manylinux && 'quay.io/pypa/manylinux_2_28_x86_64@sha256:65140ef21cef92d0c13d001708afd7d304d7a154f7120d039df99dac708f3ffb' || null }} # zizmor: ignore[unpinned-images]
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -770,7 +778,8 @@ jobs:
             wheel_features: "pyo3/extension-module,pyo3/abi3-py311,xpress,scip-from-source"
         platform:
           - label: linux
-            os: ubuntu-latest
+            os: ubuntu-22.04
+            manylinux: true
             wheel_python: python3
           - label: macos-arm64
             os: macos-14
@@ -782,6 +791,16 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+
+      - name: Install Rust in manylinux container
+        if: ${{ matrix.platform.manylinux }}
+        shell: bash
+        run: bash scripts/ci_install_rust_if_missing.sh
+
+      - name: Configure manylinux native dependency builds
+        if: ${{ matrix.platform.manylinux }}
+        shell: bash
+        run: bash scripts/setup_manylinux_native_deps.sh "$GITHUB_ENV"
 
       - name: Set up build environment
         uses: ./.github/actions/setup-build-env
@@ -798,11 +817,27 @@ jobs:
           save-uv-cache: "false"
           save-rust-cache: "false"
 
+      - name: Test wheel build configuration
+        if: ${{ matrix.platform.manylinux && matrix.python.label == 'abi3' }}
+        run: uv run --no-project --with pytest pytest scripts/test_build_python_wheel.py -q
+
       - name: Build wheel and validate import
         env:
+          PYTHON_WHEEL_COMPATIBILITY: ${{ matrix.platform.manylinux && 'manylinux_2_28' || 'pypi' }}
           PYTHON_WHEEL_INTERPRETER: ${{ matrix.platform.wheel_python }}
           PYTHON_WHEEL_FEATURES: ${{ matrix.python.wheel_features }}
         run: just ci-python-release-wheel "dist/*.whl"
+
+      - name: Verify Linux wheel target
+        if: ${{ matrix.platform.manylinux }}
+        shell: bash
+        run: |
+          shopt -s nullglob
+          wheels=(dist/*-manylinux_2_28_x86_64.whl)
+          if [[ "${#wheels[@]}" -ne 1 ]]; then
+            echo "expected one manylinux_2_28_x86_64 wheel, found ${#wheels[@]}" >&2
+            exit 1
+          fi
 
       - name: Build sdist
         if: matrix.platform.label == 'linux' && matrix.python.label == 'abi3'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Python
-        uses: ./.github/actions/setup-build-env
+        uses: $/.github/actions/setup-build-env
         with:
           python-version: ${{ env.PYTHON_LATEST }}
           uv-version: ${{ env.UV_VERSION }}
@@ -280,7 +280,7 @@ jobs:
         run: bash ./scripts/setup_manylinux_native_deps.sh "$GITHUB_ENV"
 
       - name: Set up build environment
-        uses: ./.github/actions/setup-build-env
+        uses: $/.github/actions/setup-build-env
         env:
           ARCO_HIGHS_ENABLE_APPLE_STATIC: "1"
           ARCO_HIGHS_TARGETS: ${{ join(matrix.targets, ',') }}
@@ -363,7 +363,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up build environment
-        uses: ./.github/actions/setup-build-env
+        uses: $/.github/actions/setup-build-env
         with:
           python-version: ${{ env.PYTHON_LATEST }}
           uv-version: ${{ env.UV_VERSION }}
@@ -393,7 +393,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up build environment
-        uses: ./.github/actions/setup-build-env
+        uses: $/.github/actions/setup-build-env
         with:
           python-version: ${{ env.PYTHON_LATEST }}
           uv-version: ${{ env.UV_VERSION }}
@@ -420,7 +420,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up build environment
-        uses: ./.github/actions/setup-build-env
+        uses: $/.github/actions/setup-build-env
         with:
           python-version: ${{ env.PYTHON_LATEST }}
           uv-version: ${{ env.UV_VERSION }}
@@ -461,7 +461,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up build environment
-        uses: ./.github/actions/setup-build-env
+        uses: $/.github/actions/setup-build-env
         with:
           python-version: ${{ env.PYTHON_LATEST }}
           uv-version: ${{ env.UV_VERSION }}
@@ -492,7 +492,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up build environment
-        uses: ./.github/actions/setup-build-env
+        uses: $/.github/actions/setup-build-env
         with:
           python-version: ${{ env.PYTHON_LATEST }}
           uv-version: ${{ env.UV_VERSION }}
@@ -520,7 +520,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up build environment
-        uses: ./.github/actions/setup-build-env
+        uses: $/.github/actions/setup-build-env
         with:
           python-version: ${{ env.PYTHON_LATEST }}
           uv-version: ${{ env.UV_VERSION }}
@@ -580,7 +580,7 @@ jobs:
         run: bash scripts/ci_install_apt_deps.sh
 
       - name: Set up build environment
-        uses: ./.github/actions/setup-build-env
+        uses: $/.github/actions/setup-build-env
         with:
           python-version: ${{ env.PYTHON_LATEST }}
           uv-version: ${{ env.UV_VERSION }}
@@ -641,7 +641,7 @@ jobs:
           key: ${{ runner.os }}-torc-${{ env.TORC_VERSION }}
 
       - name: Set up build environment
-        uses: ./.github/actions/setup-build-env
+        uses: $/.github/actions/setup-build-env
         with:
           python-version: ${{ env.PYTHON_LATEST }}
           uv-version: ${{ env.UV_VERSION }}
@@ -733,7 +733,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up build environment
-        uses: ./.github/actions/setup-build-env
+        uses: $/.github/actions/setup-build-env
         with:
           python-version: ${{ matrix.python-version }}
           uv-version: ${{ env.UV_VERSION }}
@@ -803,7 +803,7 @@ jobs:
         run: bash scripts/setup_manylinux_native_deps.sh "$GITHUB_ENV"
 
       - name: Set up build environment
-        uses: ./.github/actions/setup-build-env
+        uses: $/.github/actions/setup-build-env
         env:
           ARCO_HIGHS_ENABLE_APPLE_STATIC: "1"
         with:
@@ -855,7 +855,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up build environment
-        uses: ./.github/actions/setup-build-env
+        uses: $/.github/actions/setup-build-env
         with:
           python-version: ${{ env.PYTHON_LATEST }}
           uv-version: ${{ env.UV_VERSION }}

--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -27,7 +27,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up build environment
-        uses: ./.github/actions/setup-build-env
+        uses: $/.github/actions/setup-build-env
         with:
           python-version: "3.12"
           uv-version: ${{ env.UV_VERSION }}

--- a/.github/workflows/pypi-manual-release.yaml
+++ b/.github/workflows/pypi-manual-release.yaml
@@ -86,7 +86,7 @@ jobs:
         run: bash scripts/setup_manylinux_native_deps.sh "$GITHUB_ENV"
 
       - name: Set up build environment
-        uses: ./.github/actions/setup-build-env
+        uses: $/.github/actions/setup-build-env
         with:
           python-version: ${{ matrix.python.version }}
           uv-version: ${{ env.UV_VERSION }}

--- a/.github/workflows/pypi-manual-release.yaml
+++ b/.github/workflows/pypi-manual-release.yaml
@@ -42,7 +42,8 @@ jobs:
   py-build:
     name: Build Python distributions (${{ matrix.platform.label }}, ${{ matrix.python.label }})
     runs-on: ${{ matrix.platform.os }}
-    timeout-minutes: 15
+    container: ${{ matrix.platform.manylinux && 'quay.io/pypa/manylinux_2_28_x86_64@sha256:65140ef21cef92d0c13d001708afd7d304d7a154f7120d039df99dac708f3ffb' || null }} # zizmor: ignore[unpinned-images]
+    timeout-minutes: 30
     permissions:
       contents: write # Required when upload_to_release publishes artifacts to a GitHub Release.
     strategy:
@@ -57,7 +58,8 @@ jobs:
             wheel_features: "pyo3/extension-module,pyo3/abi3-py311,xpress,scip-from-source"
         platform:
           - label: linux
-            os: ubuntu-latest
+            os: ubuntu-22.04
+            manylinux: true
             wheel_python: python3
           - label: macos-arm64
             os: macos-14
@@ -73,6 +75,16 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
+      - name: Install Rust in manylinux container
+        if: ${{ matrix.platform.manylinux }}
+        shell: bash
+        run: bash scripts/ci_install_rust_if_missing.sh
+
+      - name: Configure manylinux native dependency builds
+        if: ${{ matrix.platform.manylinux }}
+        shell: bash
+        run: bash scripts/setup_manylinux_native_deps.sh "$GITHUB_ENV"
+
       - name: Set up build environment
         uses: ./.github/actions/setup-build-env
         with:
@@ -87,6 +99,7 @@ jobs:
       - name: Build wheel
         shell: bash
         env:
+          PYTHON_WHEEL_COMPATIBILITY: ${{ matrix.platform.manylinux && 'manylinux_2_28' || 'pypi' }}
           PYTHON_WHEEL_INTERPRETER: ${{ matrix.platform.wheel_python }}
           PYTHON_WHEEL_FEATURES: ${{ matrix.python.wheel_features }}
         run: |
@@ -96,6 +109,17 @@ jobs:
             just --shell "C:/Program Files/Git/bin/bash.exe" --shell-arg "-eu" --shell-arg "-o" --shell-arg "pipefail" --shell-arg "-c" py-build-release-wheel
           else
             just py-build-release-wheel
+          fi
+
+      - name: Verify Linux wheel target
+        if: ${{ matrix.platform.manylinux }}
+        shell: bash
+        run: |
+          shopt -s nullglob
+          wheels=(dist/*-manylinux_2_28_x86_64.whl)
+          if [[ "${#wheels[@]}" -ne 1 ]]; then
+            echo "expected one manylinux_2_28_x86_64 wheel, found ${#wheels[@]}" >&2
+            exit 1
           fi
 
       - name: Build sdist

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -231,7 +231,7 @@ jobs:
         run: bash scripts/setup_manylinux_native_deps.sh "$GITHUB_ENV"
 
       - name: Set up build environment
-        uses: ./.github/actions/setup-build-env
+        uses: $/.github/actions/setup-build-env
         with:
           python-version: ${{ matrix.python.version }}
           uv-version: ${{ env.UV_VERSION }}

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -183,7 +183,7 @@ jobs:
 
   py-build:
     name: Python Build Artifacts (${{ matrix.platform.label }}, ${{ matrix.python.label }})
-    timeout-minutes: 15
+    timeout-minutes: 30
     permissions:
       contents: write # Required to upload Python distribution assets to the GitHub Release.
     needs:
@@ -201,7 +201,8 @@ jobs:
             wheel_features: "pyo3/extension-module,pyo3/abi3-py311,xpress,scip-from-source"
         platform:
           - label: linux
-            os: ubuntu-latest
+            os: ubuntu-22.04
+            manylinux: true
             wheel_python: python3
           - label: macos-arm64
             os: macos-14
@@ -210,6 +211,7 @@ jobs:
             os: windows-latest
             wheel_python: python
     runs-on: ${{ matrix.platform.os }}
+    container: ${{ matrix.platform.manylinux && 'quay.io/pypa/manylinux_2_28_x86_64@sha256:65140ef21cef92d0c13d001708afd7d304d7a154f7120d039df99dac708f3ffb' || null }} # zizmor: ignore[unpinned-images]
     steps:
       - name: Checkout release commit
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -217,6 +219,16 @@ jobs:
           ref: ${{ needs.dispatch-dist-release.outputs.tag }}
           fetch-depth: 1
           persist-credentials: false
+
+      - name: Install Rust in manylinux container
+        if: ${{ matrix.platform.manylinux }}
+        shell: bash
+        run: bash scripts/ci_install_rust_if_missing.sh
+
+      - name: Configure manylinux native dependency builds
+        if: ${{ matrix.platform.manylinux }}
+        shell: bash
+        run: bash scripts/setup_manylinux_native_deps.sh "$GITHUB_ENV"
 
       - name: Set up build environment
         uses: ./.github/actions/setup-build-env
@@ -232,6 +244,7 @@ jobs:
       - name: Build wheel
         shell: bash
         env:
+          PYTHON_WHEEL_COMPATIBILITY: ${{ matrix.platform.manylinux && 'manylinux_2_28' || 'pypi' }}
           PYTHON_WHEEL_INTERPRETER: ${{ matrix.platform.wheel_python }}
           PYTHON_WHEEL_FEATURES: ${{ matrix.python.wheel_features }}
         run: |
@@ -241,6 +254,17 @@ jobs:
             just --shell "C:/Program Files/Git/bin/bash.exe" --shell-arg "-eu" --shell-arg "-o" --shell-arg "pipefail" --shell-arg "-c" py-build-release-wheel
           else
             just py-build-release-wheel
+          fi
+
+      - name: Verify Linux wheel target
+        if: ${{ matrix.platform.manylinux }}
+        shell: bash
+        run: |
+          shopt -s nullglob
+          wheels=(dist/*-manylinux_2_28_x86_64.whl)
+          if [[ "${#wheels[@]}" -ne 1 ]]; then
+            echo "expected one manylinux_2_28_x86_64 wheel, found ${#wheels[@]}" >&2
+            exit 1
           fi
 
       - name: Build sdist

--- a/.github/workflows/workflow-quality.yaml
+++ b/.github/workflows/workflow-quality.yaml
@@ -28,14 +28,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
-        with:
-          version: "0.9.4"
-          enable-cache: false
-
       - name: Run zizmor
-        run: uvx zizmor --pedantic .github/
+        uses: zizmorcore/zizmor-action@70fb788f84895a7701f5643d103d587e460b5c99 # v1.30.0
+        with:
+          persona: pedantic
+          min-severity: low
 
   actionlint:
     name: actionlint
@@ -46,11 +43,5 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
-        with:
-          version: "0.9.4"
-          enable-cache: false
-
       - name: Run actionlint
-        run: uvx --from actionlint-py actionlint .github/workflows/*.yaml
+        uses: kjanat/actionlint@c9565647ad2ff016b50b148a595dfcce50975816 # v1.13.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -141,7 +141,7 @@ repos:
         exclude: ^third_party/
 
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: v1.14.0
+    rev: v1.29.0
     hooks:
       - id: zizmor
         args: [--pedantic, --config, .github/zizmor.yml]

--- a/README.md
+++ b/README.md
@@ -170,8 +170,15 @@ uv add arco
 ```
 
 ```bash
+uv pip install arco
+```
+
+```bash
 pip install arco
 ```
+
+Linux x86_64 Python wheels support glibc 2.28 or newer, including EL8 systems
+such as Kestrel.
 
 ### From Source
 

--- a/docs/how-to/release-python-distributions.md
+++ b/docs/how-to/release-python-distributions.md
@@ -10,7 +10,7 @@ Use this when a release is ready but a Python wheel build or PyPI upload fails.
 4. Let PyPI publish after all Python artifacts build.
 5. Verify the release files on PyPI.
 
-The wheel matrix is intentionally small: `cp310` and `abi3` across Linux, macOS arm64, and Windows. The `abi3` wheels target CPython 3.11 and support Python 3.12, 3.13, and 3.14. VS Code extension upload is separate and does not block PyPI publishing.
+The wheel matrix is intentionally small: `cp310` and `abi3` across Linux, macOS arm64, and Windows. Linux x86_64 wheels build in the pinned `manylinux_2_28` container, supporting glibc 2.28 or newer. The `abi3` wheels target CPython 3.11 and support Python 3.12, 3.13, and 3.14. VS Code extension upload is separate and does not block PyPI publishing.
 
 ## If a wheel job fails
 

--- a/scripts/build_python_wheel.sh
+++ b/scripts/build_python_wheel.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 main() {
 	local interpreter="${PYTHON_WHEEL_INTERPRETER:-python3}"
+	local compatibility="${PYTHON_WHEEL_COMPATIBILITY:-pypi}"
 	local features="${PYTHON_WHEEL_FEATURES:-}"
 	local no_default_features="${PYTHON_WHEEL_NO_DEFAULT_FEATURES:-}"
 	local build_args=(
@@ -10,7 +11,7 @@ main() {
 		--release
 		--manifest-path bindings/python/Cargo.toml
 		-i "$interpreter"
-		--compatibility pypi
+		--compatibility "$compatibility"
 		--out dist
 	)
 

--- a/scripts/test_build_python_wheel.py
+++ b/scripts/test_build_python_wheel.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import stat
+import subprocess
+import sys
+
+import pytest
+
+
+_SCRIPT = Path(__file__).with_name("build_python_wheel.sh")
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="requires Bash")
+@pytest.mark.parametrize(
+    ("compatibility", "expected_compatibility"),
+    [("manylinux_2_28", "manylinux_2_28"), (None, "pypi")],
+)
+def test_build_wheel_passes_compatibility_to_maturin(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    compatibility: str | None,
+    expected_compatibility: str,
+) -> None:
+    args_file = tmp_path / "uv-args"
+    fake_uv = tmp_path / "uv"
+    fake_uv.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        'printf "%s\\0" "$@" > "$UV_ARGS_FILE"\n',
+        encoding="utf-8",
+    )
+    fake_uv.chmod(fake_uv.stat().st_mode | stat.S_IXUSR)
+
+    monkeypatch.setenv("UV_ARGS_FILE", str(args_file))
+    monkeypatch.setenv("PATH", f"{tmp_path}{os.pathsep}{os.environ['PATH']}")
+    if compatibility is None:
+        monkeypatch.delenv("PYTHON_WHEEL_COMPATIBILITY", raising=False)
+    else:
+        monkeypatch.setenv("PYTHON_WHEEL_COMPATIBILITY", compatibility)
+
+    subprocess.run(["bash", str(_SCRIPT)], check=True, cwd=_SCRIPT.parent.parent)
+
+    args = args_file.read_bytes().rstrip(b"\0").decode("utf-8").split("\0")
+    compatibility_index = args.index("--compatibility")
+    assert args[compatibility_index + 1] == expected_compatibility


### PR DESCRIPTION
## Summary

- Build Linux Python wheels in a pinned `manylinux_2_28_x86_64` container instead of the host Ubuntu environment.
- Configure Rust and existing native solver prerequisites in that container, then require a `manylinux_2_28_x86_64` wheel before upload.
- Apply the target to release preflight, normal releases, and Manual PyPI Release so the current release can be backfilled safely.
- Document glibc 2.28 support and cover the wheel-build compatibility argument.

## Acceptance criteria

- [x] Linux x86_64 Python wheels target glibc 2.28 and can be selected on EL8/Kestrel.
- [x] Release builds reject a Linux wheel without the required `manylinux_2_28_x86_64` tag.
- [x] Normal and manual PyPI release paths use the same Linux baseline.

## Deviations from the original plan

- None.

## Testing Strategy

- `uv run --no-project --with pytest pytest scripts/test_build_python_wheel.py -q`
- `uv run --no-project --with 'ruff==0.15.6' ruff check scripts/test_build_python_wheel.py`
- `uv run --no-project --with 'ruff==0.15.6' ruff format --check scripts/test_build_python_wheel.py`
- `bash -n scripts/build_python_wheel.sh`
- `shellcheck scripts/build_python_wheel.sh`
- `actionlint .github/workflows/ci.yaml .github/workflows/release-please.yaml .github/workflows/pypi-manual-release.yaml`
- `RUSTUP_TOOLCHAIN=1.85 just rust-clippy`
- Git pre-push hooks: cargo fmt, clippy, and fast cargo tests
- Kestrel: built the v0.11.0 ABI3 `manylinux_2_28_x86_64` wheel and imported it with Python 3.12.

## References

- Files: `.github/workflows/ci.yaml`, `.github/workflows/release-please.yaml`, `.github/workflows/pypi-manual-release.yaml`
- Files: `scripts/build_python_wheel.sh`, `scripts/test_build_python_wheel.py`
