### PR TITLE
fix(ci): upload Python release assets outside manylinux

### DIFF
--- a/.github/workflows/pypi-manual-release.yaml
+++ b/.github/workflows/pypi-manual-release.yaml
@@ -44,8 +44,6 @@ jobs:
     runs-on: ${{ matrix.platform.os }}
     container: ${{ matrix.platform.manylinux && 'quay.io/pypa/manylinux_2_28_x86_64@sha256:65140ef21cef92d0c13d001708afd7d304d7a154f7120d039df99dac708f3ffb' || null }} # zizmor: ignore[unpinned-images]
     timeout-minutes: 30
-    permissions:
-      contents: write # Required when upload_to_release publishes artifacts to a GitHub Release.
     strategy:
       fail-fast: false
       matrix:
@@ -134,6 +132,23 @@ jobs:
           path: dist/
           retention-days: 3
 
+  upload-python-distributions:
+    name: Upload Python distributions to release
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: py-build
+    permissions:
+      actions: read # Required to download matrix artifacts from this workflow run.
+      contents: write # Required when upload_to_release publishes artifacts to a GitHub Release.
+    steps:
+      - name: Download Python distributions
+        if: inputs.upload_to_release
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: python-package-distributions-*
+          path: dist/
+          merge-multiple: true
+
       - name: Upload Python distributions to release
         if: inputs.upload_to_release
         shell: bash
@@ -152,7 +167,7 @@ jobs:
     name: Publish to PyPI
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: py-build
+    needs: upload-python-distributions
     permissions:
       id-token: write # Required for PyPI trusted publishing via OIDC.
     environment:

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -184,8 +184,6 @@ jobs:
   py-build:
     name: Python Build Artifacts (${{ matrix.platform.label }}, ${{ matrix.python.label }})
     timeout-minutes: 30
-    permissions:
-      contents: write # Required to upload Python distribution assets to the GitHub Release.
     needs:
       - dispatch-dist-release
     if: needs.dispatch-dist-release.result == 'success'
@@ -279,6 +277,25 @@ jobs:
           path: dist/
           retention-days: 3
 
+  upload-python-distributions:
+    name: Upload Python distributions to release
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs:
+      - dispatch-dist-release
+      - py-build
+    if: needs.dispatch-dist-release.result == 'success' && needs.py-build.result == 'success'
+    permissions:
+      actions: read # Required to download matrix artifacts from this workflow run.
+      contents: write # Required to upload Python distribution assets to the GitHub Release.
+    steps:
+      - name: Download Python distributions
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: python-package-distributions-*
+          path: dist/
+          merge-multiple: true
+
       - name: Upload Python distributions to release
         shell: bash
         env:
@@ -293,7 +310,7 @@ jobs:
       id-token: write # Required for PyPI trusted publishing via OIDC.
     needs:
       - dispatch-dist-release
-      - py-build
+      - upload-python-distributions
     if: needs.dispatch-dist-release.result == 'success'
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/workflow-quality.yaml
+++ b/.github/workflows/workflow-quality.yaml
@@ -23,6 +23,9 @@ jobs:
     name: zizmor
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
+      security-events: write # Required by zizmor's SARIF upload.
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/RELEASE_POLICY.md
+++ b/RELEASE_POLICY.md
@@ -77,10 +77,10 @@ still perform the same setup and validation work.
 The `py-build`, `upload-vscode-extension`, `upload-python-distributions`, and
 `publish-pypi` jobs in `release-please.yaml` depend on the
 `dispatch-dist-release` job. That job does not finish until the cargo-dist
-workflow has published the GitHub Release. PyPI publishing also waits for the VS
-Code extension upload and the Python distribution asset upload. If cargo-dist
-fails, times out, or either release-asset upload fails, PyPI publishing does not
-start.
+workflow has published the GitHub Release. PyPI publishing waits for the Python
+distribution asset upload. The VS Code extension upload runs separately and does
+not block PyPI publishing. If cargo-dist fails, times out, or the Python
+release-asset upload fails, PyPI publishing does not start.
 
 ## Release Notes
 

--- a/docs/how-to/release-python-distributions.md
+++ b/docs/how-to/release-python-distributions.md
@@ -6,7 +6,8 @@ Use this when a release is ready but a Python wheel build or PyPI upload fails.
 
 1. Merge the release-please PR.
 2. Let `release-please` dispatch the cargo-dist release.
-3. Let each Python wheel job upload its artifact to the GitHub Release.
+3. Let the Python wheel matrix store its artifacts, then let the dedicated upload
+   job publish the complete set to the GitHub Release.
 4. Let PyPI publish after all Python artifacts build.
 5. Verify the release files on PyPI.
 


### PR DESCRIPTION
## Summary

- Moves Python GitHub Release uploads out of the containerized manylinux matrix and into a dedicated Ubuntu artifact-upload job.
- Uses the same host-side upload path for Manual PyPI Release, so `v0.11.1` can be rebuilt and recovered after this merges.
- Grants only the zizmor job the SARIF permission it requires, and updates the release documentation.

## Acceptance criteria

- [x] Linux wheel jobs no longer invoke `gh` inside the manylinux container.
- [x] Python assets upload before PyPI publishing.
- [x] Manual recovery can rebuild all Python artifacts from the release tag.
- [x] Workflow-quality SARIF upload has its required permission.

## Deviations from the original plan

- None.

## Testing Strategy

- `uvx --from actionlint-py actionlint -ignore 'specifying action "\$/.github/actions/setup-build-env" in invalid format because ref is missing' .github/workflows/release-please.yaml .github/workflows/pypi-manual-release.yaml .github/workflows/workflow-quality.yaml`
- `uvx zizmor --pedantic .github/workflows/release-please.yaml .github/workflows/pypi-manual-release.yaml .github/workflows/workflow-quality.yaml`
- `npx --no-install prettier --check .github/workflows/release-please.yaml .github/workflows/pypi-manual-release.yaml .github/workflows/workflow-quality.yaml docs/how-to/release-python-distributions.md RELEASE_POLICY.md`
- `PATH="$HOME/.rustup/toolchains/1.85-aarch64-apple-darwin/bin:$PATH" RUSTUP_TOOLCHAIN=1.85 just rust-clippy`
- Pre-push hooks: fmt, clippy, and fast library tests.

## Release recovery

After merge, dispatch **Manual PyPI Release** from `main` with `ref=v0.11.1`, `release_tag=v0.11.1`, `upload_to_release=true`, and `skip_existing=true`.

## References

- Failed release job: https://github.com/NatLabRockies/arco/actions/runs/33585556857/job/100111837664
- Files: `.github/workflows/release-please.yaml`, `.github/workflows/pypi-manual-release.yaml`, `.github/workflows/workflow-quality.yaml`
